### PR TITLE
feat: resolve instance names in export/unexport

### DIFF
--- a/cmd/dalcenter/main.go
+++ b/cmd/dalcenter/main.go
@@ -485,11 +485,12 @@ func validateCmd() *cobra.Command {
 
 			specPath := specPath()
 			hasError := false
-			for _, path := range paths {
+			for _, arg := range paths {
+				path := resolveRepoPath(arg)
 				manifestPath, err := validate.ResolveManifestPath(path)
 				if err != nil {
 					hasError = true
-					fmt.Fprintf(os.Stderr, "invalid %s: %v\n", path, err)
+					fmt.Fprintf(os.Stderr, "invalid %s: %v\n", arg, err)
 					continue
 				}
 				if _, err := validate.Manifest(specPath, manifestPath); err != nil {


### PR DESCRIPTION
## Summary
- `dalcenter export agent-coach` 처럼 인스턴스 이름으로 export/unexport 가능
- 기존 경로 방식도 그대로 동작 (하위 호환)
- `resolveRepoPath()` 헬퍼: 슬래시 없고 파일시스템에 없으면 레지스트리에서 RepoRoot 조회

## Test plan
- [x] LXC 200에서 `dalcenter export agent-coach` 동작 확인
- [x] LXC 200에서 `dalcenter unexport agent-coach` 동작 확인
- [x] 풀 경로 방식 기존대로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)