### PR TITLE
test: add bats smoke tests for dalcenter CLI

### DIFF
--- a/tests/smoke.bats
+++ b/tests/smoke.bats
@@ -13,6 +13,11 @@ setup_file() {
     rm -rf ~/.dalcenter 2>/dev/null || true
 }
 
+teardown_file() {
+    # 테스트 후 남은 프로세스 정리
+    $DALCENTER stop agent-coach 2>/dev/null || true
+}
+
 # --- CLI 기본 ---
 
 @test "help 출력" {
@@ -40,6 +45,12 @@ setup_file() {
     run $DALCENTER catalog search agent-coach
     [ "$status" -eq 0 ]
     [[ "$output" == *"agent-coach"* ]]
+}
+
+# --- 전제조건 ---
+
+@test "dal.spec.cue 존재" {
+    [ -f /root/dalforge-dalcenter/dal.spec.cue ] || skip "dal.spec.cue 없음 — join 테스트 실패 예상"
 }
 
 # --- JOIN / LIST / STATUS ---


### PR DESCRIPTION
## Summary
- dalcenter 전체 서브커맨드 스모크 테스트 추가 (bats)
- proxmox-host-setup, dalsoop-tmux-tools와 동일한 테스트 패턴
- LXC 200에서 21/21 통과 확인

## Test plan
- [x] `bats tests/smoke.bats` — LXC 내에서 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)