### PR TITLE
feat: dalcenter talk factory — auto-setup from .dalfactory

### DIFF
--- a/cmd/dalcenter/main.go
+++ b/cmd/dalcenter/main.go
@@ -997,7 +997,7 @@ func talkCmd() *cobra.Command {
 		Use:   "talk",
 		Short: "Dal communication (daemon, bot management)",
 	}
-	cmd.AddCommand(talkRunCmd(), talkConductorCmd(), talkSetupCmd(), talkTeardownCmd())
+	cmd.AddCommand(talkRunCmd(), talkConductorCmd(), talkSetupCmd(), talkTeardownCmd(), talkFactoryCmd())
 	return cmd
 }
 
@@ -1284,5 +1284,34 @@ func tuiCmd() *cobra.Command {
 	cmd.Flags().StringVar(&mmURL, "mm-url", "", "Mattermost server URL")
 	cmd.Flags().StringVar(&mmToken, "mm-token", "", "Mattermost bot token for reading")
 	cmd.Flags().StringVar(&channelID, "channel-id", "", "Mattermost channel ID")
+	return cmd
+}
+
+func talkFactoryCmd() *cobra.Command {
+	var (
+		dalfactory string
+		url        string
+		login      string
+		password   string
+		team       string
+	)
+	cmd := &cobra.Command{
+		Use:   "factory",
+		Short: "Setup all bots and channels from .dalfactory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if dalfactory == "" {
+				dalfactory = ".dalfactory"
+			}
+			return talk.SetupFromFactory(dalfactory, url, login, password, team)
+		},
+	}
+	cmd.Flags().StringVar(&dalfactory, "dalfactory", ".dalfactory", "path to .dalfactory directory")
+	cmd.Flags().StringVar(&url, "url", "", "Mattermost server URL")
+	cmd.Flags().StringVar(&login, "login", "", "admin login (email)")
+	cmd.Flags().StringVar(&password, "password", "", "admin password")
+	cmd.Flags().StringVar(&team, "team", "", "team name (empty = first)")
+	cmd.MarkFlagRequired("url")
+	cmd.MarkFlagRequired("login")
+	cmd.MarkFlagRequired("password")
 	return cmd
 }

--- a/internal/talk/factory.go
+++ b/internal/talk/factory.go
@@ -1,0 +1,180 @@
+package talk
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FactoryTalk represents the talk block from .dalfactory/dal.cue.
+type FactoryTalk struct {
+	Channel   string   `json:"channel"`
+	Conductor string   `json:"conductor"`
+	Dals      []string `json:"dals"`
+}
+
+// FactoryDal represents a dal definition from .dalfactory/{name}/dal.cue.
+type FactoryDal struct {
+	Name   string `json:"name"`
+	Role   string `json:"role"`
+	Player string `json:"player"` // "claude" or "codex"
+}
+
+// LoadTalkConfig reads the talk block from .dalfactory/dal.cue.
+// Uses a simple key-value parser (not full CUE) for portability.
+func LoadTalkConfig(dalfactoryPath string) (*FactoryTalk, error) {
+	dalCuePath := filepath.Join(dalfactoryPath, "dal.cue")
+	data, err := os.ReadFile(dalCuePath)
+	if err != nil {
+		return nil, fmt.Errorf("read dal.cue: %w", err)
+	}
+
+	content := string(data)
+	talk := &FactoryTalk{}
+
+	// Parse talk block
+	inTalk := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "talk: {" {
+			inTalk = true
+			continue
+		}
+		if inTalk && trimmed == "}" {
+			break
+		}
+		if !inTalk {
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "channel:") {
+			talk.Channel = extractQuotedValue(trimmed)
+		} else if strings.HasPrefix(trimmed, "conductor:") {
+			talk.Conductor = extractQuotedValue(trimmed)
+		} else if strings.HasPrefix(trimmed, "dals:") {
+			talk.Dals = extractStringList(trimmed)
+		}
+	}
+
+	if talk.Channel == "" {
+		return nil, fmt.Errorf("no talk.channel in %s", dalCuePath)
+	}
+	return talk, nil
+}
+
+// LoadFactoryDal reads a dal definition from .dalfactory/{name}/dal.cue.
+func LoadFactoryDal(dalfactoryPath, name string) (*FactoryDal, error) {
+	dalCuePath := filepath.Join(dalfactoryPath, name, "dal.cue")
+	data, err := os.ReadFile(dalCuePath)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", dalCuePath, err)
+	}
+
+	content := string(data)
+	dal := &FactoryDal{Name: name}
+
+	inDal := false
+	for _, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "dal: {" {
+			inDal = true
+			continue
+		}
+		if inDal && trimmed == "}" {
+			break
+		}
+		if !inDal {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "role:") {
+			dal.Role = extractQuotedValue(trimmed)
+		} else if strings.HasPrefix(trimmed, "player:") {
+			dal.Player = extractQuotedValue(trimmed)
+		}
+	}
+
+	return dal, nil
+}
+
+// SetupFromFactory reads .dalfactory and creates all bots + channel.
+func SetupFromFactory(dalfactoryPath, mmURL, adminLogin, adminPassword, team string) error {
+	talkCfg, err := LoadTalkConfig(dalfactoryPath)
+	if err != nil {
+		return err
+	}
+
+	adminToken, err := GetAdminToken(mmURL, adminLogin, adminPassword)
+	if err != nil {
+		return fmt.Errorf("login: %w", err)
+	}
+
+	teamID, channelID, err := GetTeamAndChannel(mmURL, adminToken, team, talkCfg.Channel)
+	if err != nil {
+		return fmt.Errorf("channel: %w", err)
+	}
+
+	fmt.Printf("channel: %s (id: %s)\n", talkCfg.Channel, channelID)
+
+	// Create conductor bot
+	conductorName := "dal-leader"
+	if talkCfg.Conductor != "" {
+		conductorName = talkCfg.Conductor
+	}
+	bot, err := SetupBot(mmURL, adminToken, teamID, channelID, conductorName, "Dal Leader", "dal 오케스트레이터")
+	if err != nil {
+		log.Printf("conductor bot %q: %v (may already exist)", conductorName, err)
+	} else {
+		fmt.Printf("conductor: %s (token: %s)\n", bot.Username, bot.Token)
+	}
+
+	// Create dal bots
+	for _, dalName := range talkCfg.Dals {
+		dalDef, err := LoadFactoryDal(dalfactoryPath, dalName)
+		if err != nil {
+			log.Printf("skip %s: %v", dalName, err)
+			continue
+		}
+
+		botUsername := "dal-" + dalName
+		displayName := dalName
+		description := dalDef.Role
+
+		dalBot, err := SetupBot(mmURL, adminToken, teamID, channelID, botUsername, displayName, description)
+		if err != nil {
+			log.Printf("dal bot %q: %v (may already exist)", botUsername, err)
+			continue
+		}
+		fmt.Printf("dal: %s (token: %s, player: %s)\n", dalBot.Username, dalBot.Token, dalDef.Player)
+	}
+
+	return nil
+}
+
+func extractQuotedValue(line string) string {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	v := strings.TrimSpace(parts[1])
+	v = strings.Trim(v, `"'`)
+	return v
+}
+
+func extractStringList(line string) []string {
+	// Parse: dals: ["marketing", "tech-writer", "ci-worker"]
+	idx := strings.Index(line, "[")
+	if idx < 0 {
+		return nil
+	}
+	end := strings.Index(line, "]")
+	if end < 0 {
+		return nil
+	}
+	inner := line[idx : end+1]
+	var list []string
+	json.Unmarshal([]byte(inner), &list)
+	return list
+}


### PR DESCRIPTION
## Summary
- `.dalfactory/dal.cue`의 talk 블록을 읽고 채널 + 봇 전부 자동 생성
- 각 dal 폴더의 `dal.cue`에서 role, player 정보 파싱

## 테스트 결과
```
$ dalcenter talk factory --dalfactory /path/.dalfactory --url MM --login EMAIL --password PASS

channel: veilkey (id: p7hat8...)
conductor: keycenter
dal: dal-marketing (token: ..., player: claude)
dal: dal-tech-writer (token: ..., player: claude)
dal: dal-ci-worker (token: ..., player: codex)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)