### PR TITLE
feat: 나머지 항목 — 작업 루프, 스레드, VeilKey, player 버전

### DIFF
--- a/cmd/dalcli-leader/main.go
+++ b/cmd/dalcli-leader/main.go
@@ -154,10 +154,11 @@ func assignCmd(dalName string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := daemon.NewClient()
 			msg := fmt.Sprintf("@dal-%s 작업 지시: %s", args[0], args[1])
-			if err := client.Message(dalName, msg); err != nil {
+			result, err := client.Message(dalName, msg)
+			if err != nil {
 				return err
 			}
-			fmt.Printf("assigned: %s → %s\n", args[0], args[1])
+			fmt.Printf("assigned: %s → %s (thread: %s)\n", args[0], args[1], result.PostID)
 			return nil
 		},
 	}

--- a/cmd/dalcli/main.go
+++ b/cmd/dalcli/main.go
@@ -86,7 +86,7 @@ func reportCmd(dalName string) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client := daemon.NewClient()
 			msg := fmt.Sprintf("[%s] 보고: %s", dalName, args[0])
-			if err := client.Message(dalName, msg); err != nil {
+			if _, err := client.Message(dalName, msg); err != nil {
 				return err
 			}
 			fmt.Printf("reported: %s\n", args[0])

--- a/examples/dev-instructions.md
+++ b/examples/dev-instructions.md
@@ -1,0 +1,32 @@
+# Dev Dal
+
+You are a developer on this project.
+
+## Your Tools
+
+```bash
+dalcli status     # your status
+dalcli ps         # team members
+dalcli report     # report to leader (posts to Mattermost)
+gh pr create      # create pull request
+git push          # push changes
+```
+
+## Workflow
+
+1. Read the task assigned to you
+2. Create a feature branch: `git checkout -b feat/<task>`
+3. Implement the change
+4. Run tests: verify your changes work
+5. Commit with clear message
+6. Push: `git push origin feat/<task>`
+7. Create PR: `gh pr create --title "feat: <task>" --body "description"`
+8. Report completion: `dalcli report "PR #N created for <task>"`
+
+## Rules
+
+- Never push to main directly
+- Write tests for new functionality
+- Keep commits small and focused
+- Report progress to leader via `dalcli report`
+- Follow existing code patterns

--- a/examples/leader-instructions.md
+++ b/examples/leader-instructions.md
@@ -1,0 +1,49 @@
+# Leader Dal
+
+You are the project leader. You manage a team of dals (AI agents) working on this project.
+
+## Your Tools
+
+```bash
+dalcli-leader ps                    # see team status
+dalcli-leader status <dal>          # check a member
+dalcli-leader wake <dal>            # bring a member online
+dalcli-leader sleep <dal>           # take a member offline
+dalcli-leader logs <dal>            # check member logs
+dalcli-leader assign <dal> <task>   # assign work (posts to Mattermost)
+dalcli-leader sync                  # sync changes to all members
+```
+
+## Workflow
+
+1. Check team status: `dalcli-leader ps`
+2. If a member is needed but not awake, wake them: `dalcli-leader wake dev`
+3. Break the task into subtasks and assign to members:
+   - `dalcli-leader assign dev "implement the API endpoint for /users"`
+   - `dalcli-leader assign reviewer "review PR #5 for security issues"`
+4. Monitor progress: `dalcli-leader logs dev`
+5. When members report back, review their work
+6. If changes need iteration, reassign
+7. When all subtasks are complete, create a summary PR
+
+## Code Review Loop
+
+For each code change:
+1. Assign dev to implement
+2. Assign reviewer to review
+3. Collect findings
+4. If issues found, send back to dev with specific feedback
+5. Repeat until clean
+
+## Branch Strategy
+
+- Each task gets a branch: `feat/<task-name>` or `fix/<task-name>`
+- Members push to their branches
+- Leader reviews and creates the final PR to main
+
+## Rules
+
+- Never push directly to main
+- Always review before merging
+- Keep subtasks small and focused
+- Check member status before assigning

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -44,18 +44,31 @@ func (c *Client) Sync() (map[string]any, error) {
 }
 
 // Message posts a message to the project channel.
-func (c *Client) Message(from, message string) error {
-	body := fmt.Sprintf(`{"from":%q,"message":%q}`, from, message)
+// MessageResult contains the response from posting a message.
+type MessageResult struct {
+	PostID string `json:"post_id"`
+}
+
+// Message posts a message to the project channel.
+func (c *Client) Message(from, message string) (*MessageResult, error) {
+	return c.MessageThread(from, message, "")
+}
+
+// MessageThread posts a message as a thread reply.
+func (c *Client) MessageThread(from, message, threadID string) (*MessageResult, error) {
+	body := fmt.Sprintf(`{"from":%q,"message":%q,"thread_id":%q}`, from, message, threadID)
 	resp, err := c.http.Post(c.baseURL+"/api/message", "application/json", strings.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("daemon unreachable: %w", err)
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		b, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("message failed: %s", strings.TrimSpace(string(b)))
+		return nil, fmt.Errorf("message failed: %s", strings.TrimSpace(string(b)))
 	}
-	return nil
+	var result MessageResult
+	json.NewDecoder(resp.Body).Decode(&result)
+	return &result, nil
 }
 
 // Ps returns running containers.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -349,8 +349,9 @@ func (d *Daemon) handleLogs(w http.ResponseWriter, r *http.Request) {
 
 func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		From    string `json:"from"`
-		Message string `json:"message"`
+		From     string `json:"from"`
+		Message  string `json:"message"`
+		ThreadID string `json:"thread_id,omitempty"` // reply to thread
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", 400)
@@ -371,15 +372,32 @@ func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 		token = c.BotToken
 	}
 
-	// Post message to channel
-	body := fmt.Sprintf(`{"channel_id":%q,"message":%q}`, d.channelID, req.Message)
-	_, err := mmPost(d.mm.URL, token, "/api/v4/posts", body)
+	// Post message (with optional thread)
+	var body string
+	if req.ThreadID != "" {
+		body = fmt.Sprintf(`{"channel_id":%q,"message":%q,"root_id":%q}`, d.channelID, req.Message, req.ThreadID)
+	} else {
+		body = fmt.Sprintf(`{"channel_id":%q,"message":%q}`, d.channelID, req.Message)
+	}
+	respBody, err := mmPost(d.mm.URL, token, "/api/v4/posts", body)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("post failed: %v", err), 500)
 		return
 	}
 
-	json.NewEncoder(w).Encode(map[string]string{"status": "sent", "channel": d.channelID[:8]})
+	// Return post ID so caller can start/continue thread
+	postID := ""
+	var postResp map[string]any
+	if json.Unmarshal(respBody, &postResp) == nil {
+		if id, ok := postResp["id"].(string); ok {
+			postID = id
+		}
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "sent",
+		"post_id": postID,
+	})
 }
 
 func mmPost(mmURL, token, path, body string) ([]byte, error) {

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -44,7 +44,11 @@ func playerHome(player string) string {
 // dockerRun creates and starts a Docker container for a dal.
 func dockerRun(localdalRoot, serviceRepo, instanceName string, dal *localdal.DalProfile) (string, error) {
 	containerName := fmt.Sprintf("dal-%s", instanceName)
-	image := fmt.Sprintf("dalcenter/%s:latest", dal.Player)
+	tag := "latest"
+	if dal.PlayerVersion != "" {
+		tag = dal.PlayerVersion
+	}
+	image := fmt.Sprintf("dalcenter/%s:%s", dal.Player, tag)
 
 	dalDir := filepath.Join(localdalRoot, dal.FolderName)
 	home := playerHome(dal.Player)
@@ -60,6 +64,8 @@ func dockerRun(localdalRoot, serviceRepo, instanceName string, dal *localdal.Dal
 		"-e", fmt.Sprintf("DAL_ROLE=%s", dal.Role),
 		"-e", fmt.Sprintf("DAL_PLAYER=%s", dal.Player),
 		"-e", fmt.Sprintf("DALCENTER_URL=http://host.docker.internal:11190"),
+		// VeilKey — pass through if available
+		"-e", fmt.Sprintf("VEILKEY_LOCALVAULT_URL=%s", os.Getenv("VEILKEY_LOCALVAULT_URL")),
 		// Mount dal directory (read-only)
 		"-v", fmt.Sprintf("%s:%s:ro", dalDir, "/dal"),
 		// Working directory

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -17,8 +17,9 @@ type DalProfile struct {
 	UUID       string
 	Name       string
 	Version    string
-	Player     string
-	Role       string // "leader" or "member"
+	Player        string
+	PlayerVersion string // e.g. "2.1.81" for claude, empty = latest
+	Role          string // "leader" or "member"
 	Skills     []string
 	Hooks      []string
 	FolderName string // directory name
@@ -156,6 +157,9 @@ func ReadDalCue(path, folderName string) (*DalProfile, error) {
 	}
 	if v := val.LookupPath(cue.ParsePath("player")); v.Exists() {
 		p.Player, _ = v.String()
+	}
+	if v := val.LookupPath(cue.ParsePath("player_version")); v.Exists() {
+		p.PlayerVersion, _ = v.String()
 	}
 	if v := val.LookupPath(cue.ParsePath("role")); v.Exists() {
 		p.Role, _ = v.String()


### PR DESCRIPTION
## Summary

- leader 자동 작업 루프 (examples/instructions.md)
- Mattermost 스레드 기반 통신 (thread_id 지원)
- VeilKey localvault 연동 (VEILKEY_LOCALVAULT_URL 전달)
- player 버전 지정 (dal.cue player_version → Docker 이미지 태그)

## Test plan

- [x] `go build ./...` 통과
- [x] `go test ./...` 통과

Refs: #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)