### PR TITLE
docs: sync README with actual CLI commands

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>dalcenter</h1>
-  <p><strong>Dal 생명주기 관리자 — AI 에이전트 컨테이너를 깨우고, 재우고, 동기화</strong></p>
+  <p><strong>Dal 생명주기 관리자 — AI 에이전트 인스턴스를 생성, 프로비저닝, 동기화</strong></p>
   <p>
     <a href="https://github.com/dalsoop/dalcenter"><img src="https://img.shields.io/badge/github-dalsoop%2Fdalcenter-181717?logo=github&logoColor=white" alt="GitHub repository"></a>
     <a href="./LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-2563eb.svg" alt="AGPL-3.0 License"></a>
@@ -8,80 +8,91 @@
   <p><a href="./README.md">English</a></p>
 </div>
 
-dalcenter는 dal(AI 인형)을 관리합니다. Claude Code, Codex, Gemini가 설치된 Docker 컨테이너를 각각의 스킬, 지시사항, git 인증으로 구성합니다. 템플릿은 git(localdal)으로 관리하고, dalcenter는 런타임을 담당합니다.
+dalcenter는 dal(AI 에이전트)을 관리합니다. `.dalfactory` 매니페스트로 정의된 인스턴스를 스킬, 시크릿, 헬스체크와 함께 관리합니다. 패키지는 dalforge cloud 또는 로컬 소스에서 가져오고, dalcenter가 생명주기를 담당합니다.
 
 ## 빠른 시작
 
 ```bash
-# 1. 데몬 시작
-dalcenter serve --addr :11190 --repo /path/to/your-project \
-  --mm-url http://mattermost:8065 --mm-token TOKEN --mm-team myteam
+# 1. API 서버 시작
+dalcenter serve --port 10100
 
-# 2. localdal 초기화
-dalcenter init --repo /path/to/your-project
+# 2. dal 패키지 검색 및 참여
+dalcenter catalog search agent-coach
+dalcenter join dalcli-agent-coach
 
-# 3. dal 템플릿 작성 (git으로)
-# .dal/leader/dal.cue + instructions.md
-# .dal/dev/dal.cue + instructions.md
-# .dal/skills/code-review/SKILL.md
-
-# 4. 검증
+# 3. 매니페스트 검증
 dalcenter validate
 
-# 5. dal 소환
-dalcenter wake leader
-dalcenter wake dev
-dalcenter ps
+# 4. 프로비저닝 및 시작
+dalcenter provision <name>
+dalcenter start <name>
+dalcenter list
 
-# 6. 작업 끝
-dalcenter sleep --all
+# 5. 작업 끝
+dalcenter stop <name>
 ```
 
 ## 동작 방식
 
 ```
-.dal/ (git 관리, localdal)
-  leader/dal.cue + instructions.md     ← dal 템플릿
-  dev/dal.cue + instructions.md
-  skills/code-review/SKILL.md          ← 공유 스킬
+.dalfactory/ (매니페스트)
+  dal.cue                            ← dal 정의 + 템플릿
 
-dalcenter serve
-  → soft-serve (git 서버) 시작
-  → HTTP API 시작
+dalcenter join <source>
+  → 패키지 소스 다운로드/클론
+  → ~/.dalcenter/instances/에 인스턴스 생성
 
-dalcenter wake dev
-  → .dal/dev/dal.cue 읽기
-  → Docker 컨테이너 생성 (dalcenter/claude:latest)
-  → instructions.md → CLAUDE.md 변환 주입
-  → 스킬, 인증, 서비스 레포 마운트
-  → dalcli 바이너리 주입
-  → dal이 작업 시작
+dalcenter provision <name>
+  → .dalfactory/dal.cue 읽기
+  → LXC 컨테이너 프로비저닝 (bridge, cores, memory, storage)
+
+dalcenter start <name>
+  → 매니페스트의 build.entry 실행
+  → Claude/Codex에 스킬 export
+  → 헬스체크 시작
+
+dalcenter reconcile
+  → 모든 인스턴스 점검
+  → export 복구 (스킬, 훅, 설정)
 ```
 
 ## 구조
 
 ```
 LXC: dalcenter
-├── dalcenter serve          HTTP API + soft-serve + Docker 관리
-├── soft-serve               localdal git 호스팅 + webhook
-├── Docker: leader (claude)  dalcli-leader 내장
-├── Docker: dev (claude)     dalcli 내장
-└── Docker: dev-2 (claude)   복수 소환 가능
+├── dalcenter serve          API 서버 (포트 10100)
+├── dalcenter watch          지속적 reconcile 루프
+├── instance: leader         dalcli-leader 내장
+├── instance: dev            dalcli 내장
+└── instance: dev-2          복수 인스턴스 지원
 ```
 
 ## CLI
 
 ```
-dalcenter serve                   # 데몬 (HTTP API + soft-serve + Docker)
-dalcenter init --repo <path>      # localdal 초기화 (.dal/ + soft-serve + subtree)
-dalcenter wake <dal> [--all]      # Docker 컨테이너 생성
-dalcenter sleep <dal> [--all]     # Docker 컨테이너 정지
-dalcenter sync                    # 변경사항 → 실행중인 dal에 반영
-dalcenter validate [path]         # CUE 스키마 + 참조 검증
-dalcenter status [dal]            # dal 상태
-dalcenter ps                      # 소환된 dal 목록
-dalcenter logs <dal>              # 컨테이너 로그
-dalcenter attach <dal>            # 컨테이너 접속
+dalcenter serve                          # API 서버 (dal 레지스트리)
+dalcenter join <source>                  # .dalfactory 매니페스트로 인스턴스 생성
+dalcenter provision <name>               # LXC 컨테이너 프로비저닝
+dalcenter start <name>                   # 인스턴스 프로세스 시작
+dalcenter stop <name>                    # 프로세스 정지
+dalcenter restart <name>                 # 프로세스 재시작
+dalcenter destroy <name>                 # 컨테이너 정지 및 삭제
+dalcenter list                           # 모든 인스턴스 목록
+dalcenter status [name]                  # 인스턴스 상태 확인
+dalcenter validate [path...]             # CUE 스키마 검증
+dalcenter reconcile                      # 모든 export 점검 및 복구
+dalcenter watch                          # 지속적 reconcile (기본 60초)
+dalcenter export [path...]               # 매니페스트에서 Claude 스킬 export
+dalcenter unexport [path...]             # export된 스킬 제거
+dalcenter secret set <name>              # 시크릿 저장 (stdin에서 읽기)
+dalcenter secret get <name>              # 시크릿 조회
+dalcenter secret list                    # 시크릿 목록
+dalcenter catalog search [query]         # dalforge cloud 패키지 검색
+dalcenter talk run                       # dal 통신 데몬 (MM 브릿지)
+dalcenter talk conductor                 # 중앙 오케스트레이터 봇
+dalcenter talk setup                     # Mattermost 봇 계정 생성
+dalcenter talk teardown                  # 봇 계정 비활성화
+dalcenter tui                            # 터미널 대시보드
 ```
 
 ### 컨테이너 안에서
@@ -97,53 +108,67 @@ dalcli-leader (팀장 전용)          dalcli (팀원)
   assign <dal> <task>
 ```
 
-## dal.cue
+## .dalfactory/dal.cue
 
 ```cue
-uuid:    "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-name:    "dev"
-version: "1.0.0"
-player:  "claude"
-role:    "member"
-skills:  ["skills/code-review", "skills/testing"]
-hooks:   []
-git: {
-    user:         "dal-dev"
-    email:        "dal-dev@myproject.dev"
-    github_token: "env:GITHUB_TOKEN"
+schema_version: "1.0.0"
+
+dal: {
+    id:       "DAL:CLI:848a4292"
+    name:     "dalcli-agent-coach"
+    version:  "0.1.0"
+    category: "CLI"
 }
-```
 
-## localdal 구조
+description: "AI agent coaching CLI tool"
 
-```
-.dal/
-  dal.spec.cue              스키마 정의
-  leader/
-    dal.cue                 uuid, player, role:leader
-    instructions.md         → wake 시 CLAUDE.md로 변환
-  dev/
-    dal.cue                 uuid, player, role:member
-    instructions.md
-  skills/
-    code-review/SKILL.md    여러 dal이 공유
-    testing/SKILL.md
+templates: default: {
+    schema_version: "1.0.0"
+    name:           "default"
+    description:    "Default runtime"
+    container: {
+        base:     "ubuntu:24.04"
+        packages: ["bash", "python3"]
+        agents: {}
+    }
+    permissions: {
+        filesystem: ["/tmp/dal-*"]
+        network:    false
+    }
+    build: {
+        language: "python"
+        entry:    "bin/app"
+        output:   "bin/app"
+    }
+    health_check: {
+        command: "bin/app status"
+    }
+    exports: claude: {
+        skills: ["skills/my-skill/SKILL.md"]
+    }
+}
 ```
 
 ## 통신
 
-dal 간 통신은 Mattermost. 프로젝트당 채널 1개 (serve 시 자동 생성).
+dal 간 통신은 Mattermost. `dalcenter talk`으로 봇 계정과 메시지 라우팅을 관리합니다.
 
-- `dalcli-leader assign dev "작업"` → `@dal-dev 작업 지시: 작업` 전송
-- `dalcli report "완료"` → `[dev] 보고: 완료` 전송
+```bash
+# dal용 봇 설정
+dalcenter talk setup --url http://mm:8065 --username dal-dev \
+  --login admin@example.com --password pass --channel project
 
-## 파일명 변환
+# 통신 데몬 실행
+dalcenter talk run --url http://mm:8065 --bot-token TOKEN \
+  --bot-username dal-dev --channel-id CHID
 
-| 원본 | player | 컨테이너 내 |
-|---|---|---|
-| instructions.md | claude | CLAUDE.md |
-| instructions.md | codex | AGENTS.md |
-| instructions.md | gemini | GEMINI.md |
+# 중앙 오케스트레이터 실행
+dalcenter talk conductor --url http://mm:8065 --bot-token TOKEN \
+  --channel-id CHID --dal dev:member --dal leader:leader
+```
+
+- `dalcli-leader assign dev "작업"` → `@dal-dev 작업` 전송
+- `dalcli report "완료"` → `[dev] 완료` 전송
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
   <h1>dalcenter</h1>
-  <p><strong>Dal lifecycle manager — wake, sleep, sync AI agent containers</strong></p>
+  <p><strong>Dal lifecycle manager — join, provision, reconcile AI agent instances</strong></p>
   <p>
     <a href="https://github.com/dalsoop/dalcenter"><img src="https://img.shields.io/badge/github-dalsoop%2Fdalcenter-181717?logo=github&logoColor=white" alt="GitHub repository"></a>
     <a href="./LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-2563eb.svg" alt="AGPL-3.0 License"></a>
@@ -8,80 +8,91 @@
   <p><a href="./README.ko.md">한국어</a></p>
 </div>
 
-dalcenter manages dal (AI puppets) — Docker containers with Claude Code, Codex, or Gemini installed, each with their own skills, instructions, and git identity. Templates live in git (localdal), dalcenter handles the runtime.
+dalcenter manages dal (AI agents) — instances provisioned from `.dalfactory` manifests with skills, secrets, and health checks. Packages live in dalforge cloud or local sources, dalcenter handles the lifecycle.
 
 ## Quick Start
 
 ```bash
-# 1. Start the daemon
-dalcenter serve --addr :11190 --repo /path/to/your-project \
-  --mm-url http://mattermost:8065 --mm-token TOKEN --mm-team myteam
+# 1. Start the API server
+dalcenter serve --port 10100
 
-# 2. Initialize localdal in your project
-dalcenter init --repo /path/to/your-project
+# 2. Browse and join a dal package
+dalcenter catalog search agent-coach
+dalcenter join dalcli-agent-coach
 
-# 3. Create dal templates (via git)
-# .dal/leader/dal.cue + instructions.md
-# .dal/dev/dal.cue + instructions.md
-# .dal/skills/code-review/SKILL.md
-
-# 4. Validate
+# 3. Validate manifests
 dalcenter validate
 
-# 5. Wake dals
-dalcenter wake leader
-dalcenter wake dev
-dalcenter ps
+# 4. Provision and start
+dalcenter provision <name>
+dalcenter start <name>
+dalcenter list
 
-# 6. Sleep when done
-dalcenter sleep --all
+# 5. Stop when done
+dalcenter stop <name>
 ```
 
 ## How It Works
 
 ```
-.dal/ (git-managed, localdal)
-  leader/dal.cue + instructions.md     ← dal template
-  dev/dal.cue + instructions.md
-  skills/code-review/SKILL.md          ← shared skills
+.dalfactory/ (manifest)
+  dal.cue                            ← dal definition + templates
 
-dalcenter serve
-  → starts soft-serve (git server)
-  → starts HTTP API
+dalcenter join <source>
+  → downloads/clones package source
+  → creates instance in ~/.dalcenter/instances/
 
-dalcenter wake dev
-  → reads .dal/dev/dal.cue
-  → creates Docker container (dalcenter/claude:latest)
-  → injects instructions.md → CLAUDE.md
-  → mounts skills, credentials, service repo
-  → injects dalcli binary
-  → dal starts working
+dalcenter provision <name>
+  → reads .dalfactory/dal.cue
+  → provisions LXC container (bridge, cores, memory, storage)
+
+dalcenter start <name>
+  → runs build.entry from manifest
+  → exports skills to Claude/Codex
+  → health check begins
+
+dalcenter reconcile
+  → checks all instances
+  → repairs exports (skills, hooks, settings)
 ```
 
 ## Architecture
 
 ```
 LXC: dalcenter
-├── dalcenter serve          HTTP API + soft-serve + Docker
-├── soft-serve               localdal git hosting + webhooks
-├── Docker: leader (claude)  dalcli-leader inside
-├── Docker: dev (claude)     dalcli inside
-└── Docker: dev-2 (claude)   multiple instances supported
+├── dalcenter serve          API server (port 10100)
+├── dalcenter watch          continuous reconcile loop
+├── instance: leader         dalcli-leader inside
+├── instance: dev            dalcli inside
+└── instance: dev-2          multiple instances supported
 ```
 
 ## CLI
 
 ```
-dalcenter serve                   # daemon (HTTP API + soft-serve + Docker)
-dalcenter init --repo <path>      # initialize localdal (.dal/ + soft-serve + subtree)
-dalcenter wake <dal> [--all]      # create Docker container
-dalcenter sleep <dal> [--all]     # stop Docker container
-dalcenter sync                    # propagate changes to running containers
-dalcenter validate [path]         # CUE schema + reference validation
-dalcenter status [dal]            # show dal status
-dalcenter ps                      # list awake dals
-dalcenter logs <dal>              # container logs
-dalcenter attach <dal>            # enter container
+dalcenter serve                          # API server (dal registry)
+dalcenter join <source>                  # create instance from .dalfactory manifest
+dalcenter provision <name>               # provision LXC container
+dalcenter start <name>                   # start process in instance
+dalcenter stop <name>                    # stop process
+dalcenter restart <name>                 # restart process
+dalcenter destroy <name>                 # stop and destroy container
+dalcenter list                           # list all instances
+dalcenter status [name]                  # show instance status
+dalcenter validate [path...]             # CUE schema validation
+dalcenter reconcile                      # check and repair all exports
+dalcenter watch                          # continuous reconcile (default 60s)
+dalcenter export [path...]               # export Claude skills from manifests
+dalcenter unexport [path...]             # remove exported skills
+dalcenter secret set <name>              # store secret (reads from stdin)
+dalcenter secret get <name>              # retrieve secret
+dalcenter secret list                    # list all secrets
+dalcenter catalog search [query]         # browse dalforge cloud packages
+dalcenter talk run                       # dal communication daemon (MM bridge)
+dalcenter talk conductor                 # central orchestrator bot
+dalcenter talk setup                     # create Mattermost bot account
+dalcenter talk teardown                  # disable bot account
+dalcenter tui                            # interactive terminal dashboard
 ```
 
 ### Inside containers
@@ -97,53 +108,67 @@ dalcli-leader (leader only)       dalcli (all members)
   assign <dal> <task>
 ```
 
-## dal.cue
+## .dalfactory/dal.cue
 
 ```cue
-uuid:    "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-name:    "dev"
-version: "1.0.0"
-player:  "claude"
-role:    "member"
-skills:  ["skills/code-review", "skills/testing"]
-hooks:   []
-git: {
-    user:         "dal-dev"
-    email:        "dal-dev@myproject.dev"
-    github_token: "env:GITHUB_TOKEN"
+schema_version: "1.0.0"
+
+dal: {
+    id:       "DAL:CLI:848a4292"
+    name:     "dalcli-agent-coach"
+    version:  "0.1.0"
+    category: "CLI"
 }
-```
 
-## localdal Structure
+description: "AI agent coaching CLI tool"
 
-```
-.dal/
-  dal.spec.cue              schema definition
-  leader/
-    dal.cue                 uuid, player, role:leader
-    instructions.md         → CLAUDE.md at wake
-  dev/
-    dal.cue                 uuid, player, role:member
-    instructions.md
-  skills/
-    code-review/SKILL.md    shared across dals
-    testing/SKILL.md
+templates: default: {
+    schema_version: "1.0.0"
+    name:           "default"
+    description:    "Default runtime"
+    container: {
+        base:     "ubuntu:24.04"
+        packages: ["bash", "python3"]
+        agents: {}
+    }
+    permissions: {
+        filesystem: ["/tmp/dal-*"]
+        network:    false
+    }
+    build: {
+        language: "python"
+        entry:    "bin/app"
+        output:   "bin/app"
+    }
+    health_check: {
+        command: "bin/app status"
+    }
+    exports: claude: {
+        skills: ["skills/my-skill/SKILL.md"]
+    }
+}
 ```
 
 ## Communication
 
-Dals communicate via Mattermost. One channel per project (auto-created on serve).
+Dals communicate via Mattermost. `dalcenter talk` manages bot accounts and message routing.
 
-- `dalcli-leader assign dev "task"` → posts `@dal-dev 작업 지시: task`
-- `dalcli report "done"` → posts `[dev] 보고: done`
+```bash
+# Set up a bot for a dal
+dalcenter talk setup --url http://mm:8065 --username dal-dev \
+  --login admin@example.com --password pass --channel project
 
-## File Name Conversion
+# Run communication daemon
+dalcenter talk run --url http://mm:8065 --bot-token TOKEN \
+  --bot-username dal-dev --channel-id CHID
 
-| Source | Player | In Container |
-|---|---|---|
-| instructions.md | claude | CLAUDE.md |
-| instructions.md | codex | AGENTS.md |
-| instructions.md | gemini | GEMINI.md |
+# Run central orchestrator
+dalcenter talk conductor --url http://mm:8065 --bot-token TOKEN \
+  --channel-id CHID --dal dev:member --dal leader:leader
+```
+
+- `dalcli-leader assign dev "task"` → posts `@dal-dev task`
+- `dalcli report "done"` → posts `[dev] done`
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- README가 v1 명령어(wake/sleep/sync/ps/init/attach/logs)로 작성되어 있었으나 실제 CLI와 불일치
- 실제 CLI에 맞게 전면 업데이트: join/provision/start/stop/restart/destroy/list
- `.dalfactory` 매니페스트 구조, secret/catalog/talk/tui 명령어 반영
- README.md (EN) + README.ko.md (KO) 모두 업데이트

## Test plan
- [ ] `dalcenter --help` 출력과 README CLI 섹션 대조
- [ ] 각 서브커맨드 help와 README 설명 일치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)