### PR TITLE
fix: gemini_api_key dal.cue 설정 지원

### DIFF
--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -132,8 +132,25 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 			log.Printf("WARNING: Codex credential not found at %s", credPath)
 		}
 	case "gemini":
-		// Gemini uses API key via environment variable
-		if key := os.Getenv("GEMINI_API_KEY"); key != "" {
+		// Gemini uses API key — resolve from dal.cue (VK:/env:), fallback to host env
+		key := dal.GeminiAPIKey
+		if key != "" {
+			if strings.HasPrefix(key, "VK:") {
+				resolved, err := resolveVeilKey(key)
+				if err != nil {
+					log.Printf("[docker] warning: failed to resolve %s: %v", key, err)
+					key = ""
+				} else {
+					key = resolved
+				}
+			} else if strings.HasPrefix(key, "env:") {
+				key = os.Getenv(strings.TrimPrefix(key, "env:"))
+			}
+		}
+		if key == "" {
+			key = os.Getenv("GEMINI_API_KEY")
+		}
+		if key != "" {
 			args = append(args, "-e", fmt.Sprintf("GEMINI_API_KEY=%s", key))
 		} else {
 			log.Printf("WARNING: GEMINI_API_KEY not set for gemini dal")

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -28,6 +28,7 @@ type DalProfile struct {
 	GitUser        string
 	GitEmail       string
 	GitHubToken    string // VeilKey ref or raw token
+	GeminiAPIKey   string // VeilKey ref, env: ref, or raw key
 }
 
 // Init initializes a localdal repository at the given path.
@@ -194,6 +195,9 @@ func ReadDalCue(path, folderName string) (*DalProfile, error) {
 	}
 	if v := val.LookupPath(cue.ParsePath("git.github_token")); v.Exists() {
 		p.GitHubToken, _ = v.String()
+	}
+	if v := val.LookupPath(cue.ParsePath("gemini_api_key")); v.Exists() {
+		p.GeminiAPIKey, _ = v.String()
 	}
 	return p, nil
 }


### PR DESCRIPTION
## Summary
- `DalProfile`에 `GeminiAPIKey` 필드 추가
- `dal.cue`에서 `gemini_api_key` 읽기 지원 (`VK:`, `env:`, raw 값)
- dal.cue 미설정 시 기존 `GEMINI_API_KEY` 환경변수 fallback 유지

## 사용 예시

```cue
// dal.cue
uuid:    "..."
name:    "gemini-dev"
player:  "gemini"

// VeilKey 참조
gemini_api_key: "VK:secrets/gemini-api-key"

// 또는 환경변수 참조
gemini_api_key: "env:GEMINI_API_KEY"

// 또는 직접 값 (비추천)
gemini_api_key: "AIzaSy..."
```

## Test plan
- [x] `go build ./...` passes
- [ ] gemini dal with `gemini_api_key: "env:GEMINI_API_KEY"` in dal.cue
- [ ] gemini dal without `gemini_api_key` (fallback to host env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)