### PR TITLE
fix: isDalBot() 구현 — dal 봇 메시지 필터링 (#28)

### DIFF
--- a/internal/bridge/mattermost.go
+++ b/internal/bridge/mattermost.go
@@ -217,6 +217,19 @@ func (m *MattermostBridge) apiPost(path, jsonBody string) ([]byte, error) {
 	return body, nil
 }
 
+// GetUserIDByUsername resolves a Mattermost username to a user ID.
+func (m *MattermostBridge) GetUserIDByUsername(username string) (string, error) {
+	data, err := m.apiGet("/api/v4/users/username/" + username)
+	if err != nil {
+		return "", fmt.Errorf("get user %q: %w", username, err)
+	}
+	id := jsonString(data, "id")
+	if id == "" {
+		return "", fmt.Errorf("get user %q: no id in response", username)
+	}
+	return id, nil
+}
+
 func jsonString(data []byte, key string) string {
 	var m map[string]interface{}
 	if json.Unmarshal(data, &m) != nil {

--- a/internal/talk/conductor.go
+++ b/internal/talk/conductor.go
@@ -41,10 +41,11 @@ type Conductor struct {
 	br        bridge.Bridge
 	executor  *Executor
 	sanitizer *Sanitizer
-	seen      map[string]bool
-	threads   map[string]*threadState // rootID → state
-	mu        sync.Mutex
-	botUserID string
+	seen       map[string]bool
+	threads    map[string]*threadState // rootID → state
+	dalBotIDs  map[string]bool         // known dal bot user IDs
+	mu         sync.Mutex
+	botUserID  string
 }
 
 func NewConductor(cfg ConductorConfig) (*Conductor, error) {
@@ -56,6 +57,7 @@ func NewConductor(cfg ConductorConfig) (*Conductor, error) {
 		sanitizer: NewSanitizer(),
 		seen:      make(map[string]bool),
 		threads:   make(map[string]*threadState),
+		dalBotIDs: make(map[string]bool),
 	}, nil
 }
 
@@ -67,6 +69,15 @@ func (c *Conductor) Run(ctx context.Context) error {
 
 	if mm, ok := c.br.(*bridge.MattermostBridge); ok {
 		c.botUserID = mm.BotUserID
+		for _, d := range c.cfg.Dals {
+			uid, err := mm.GetUserIDByUsername(d.Username)
+			if err != nil {
+				log.Printf("[conductor] warning: could not resolve dal bot %q: %v", d.Username, err)
+				continue
+			}
+			c.dalBotIDs[uid] = true
+			log.Printf("[conductor] registered dal bot: @%s → %s", d.Username, uid)
+		}
 	}
 
 	dalList := c.buildDalList()
@@ -218,12 +229,7 @@ func (c *Conductor) buildDalList() string {
 }
 
 func (c *Conductor) isDalBot(userID string) bool {
-	// Known bot user IDs from bridge
-	// In production, this would query the serve registry
-	if mm, ok := c.br.(*bridge.MattermostBridge); ok {
-		_ = mm // future: check against registered bot IDs
-	}
-	return false
+	return c.dalBotIDs[userID]
 }
 
 func (c *Conductor) isDuplicate(id string) bool {


### PR DESCRIPTION
## Summary
- `MattermostBridge`에 `GetUserIDByUsername()` 메서드 추가
- `Conductor` 시작 시 등록된 dal의 username → userID 해석하여 봇 목록 구성
- `isDalBot()`이 실제로 봇 메시지를 필터링

Closes #28

## Test plan
- [x] `go build ./...` passes
- [ ] Mattermost에서 dal 봇 메시지가 conductor에 의해 무시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)