### PR TITLE
fix: HTTP 서버 graceful shutdown (#34)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dalsoop/dalcenter/internal/localdal"
 	"github.com/dalsoop/dalcenter/internal/talk"
@@ -101,7 +102,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
-		srv.Close()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := srv.Shutdown(shutdownCtx); err != nil {
+			log.Printf("[daemon] shutdown error: %v", err)
+		}
 	}()
 
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {


### PR DESCRIPTION
## Summary
- `srv.Close()` → `srv.Shutdown(ctx)` 변경
- 30초 timeout으로 진행 중인 요청 완료 후 종료

Closes #34

## Test plan
- [x] `go build ./...` passes
- [ ] SIGTERM 시 진행 중인 요청이 완료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)