### PR TITLE
fix: 데몬 시작 시 컨테이너 reconciliation + stale 정리 (#27, #33)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -85,6 +85,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
+	// Reconcile existing containers from a previous daemon run
+	d.reconcile()
+
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /api/ps", d.handlePs)
@@ -203,6 +206,12 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	d.mu.Unlock()
+
+	// Clean any stopped container with the same name (best-effort, #33)
+	targetContainerName := fmt.Sprintf("dal-%s", instanceName)
+	if err := cleanStaleContainer(targetContainerName); err != nil {
+		log.Printf("[daemon] clean stale container %s: %v (continuing)", targetContainerName, err)
+	}
 
 	containerID, warnings, err := dockerRun(d.localdalRoot, d.serviceRepo, instanceName, d.addr, dal)
 	if err != nil {
@@ -423,6 +432,66 @@ func mmPost(mmURL, token, path, body string) ([]byte, error) {
 		return nil, fmt.Errorf("%d: %s", resp.StatusCode, string(respBody))
 	}
 	return respBody, nil
+}
+
+// reconcile discovers existing dal-* containers and restores daemon state.
+// This is best-effort: running containers with matching dal.cue are added
+// to d.containers; orphans and stopped containers are logged only.
+func (d *Daemon) reconcile() {
+	containers, err := discoverContainers()
+	if err != nil {
+		log.Printf("[daemon] reconcile: %v", err)
+		return
+	}
+	if len(containers) == 0 {
+		return
+	}
+
+	var running, stopped int
+	for _, c := range containers {
+		if !strings.HasPrefix(c.Name, "dal-") {
+			continue
+		}
+		instanceName := strings.TrimPrefix(c.Name, "dal-")
+
+		if c.Running {
+			// Try to read dal.cue — for multi-instance like "dev-2", derive base name
+			dalName := instanceName
+			dal, err := localdal.ReadDalCue(d.dalCuePath(dalName), dalName)
+			if err != nil {
+				// Try stripping instance suffix: "dev-2" -> "dev"
+				if idx := strings.LastIndex(dalName, "-"); idx > 0 {
+					baseName := dalName[:idx]
+					dal, err = localdal.ReadDalCue(d.dalCuePath(baseName), baseName)
+				}
+			}
+			if err != nil {
+				log.Printf("[daemon] reconcile: orphan running container %s (%s) — no matching dal.cue", c.Name, c.ID[:12])
+				continue
+			}
+
+			d.mu.Lock()
+			d.containers[instanceName] = &Container{
+				DalName:     instanceName,
+				UUID:        dal.UUID,
+				Player:      dal.Player,
+				Role:        dal.Role,
+				ContainerID: c.ID,
+				Status:      "running",
+				Skills:      len(dal.Skills),
+			}
+			d.mu.Unlock()
+			running++
+			log.Printf("[daemon] reconcile: restored %s (container=%s)", instanceName, c.ID[:12])
+		} else {
+			stopped++
+			log.Printf("[daemon] reconcile: stopped container %s (%s) — skipping", c.Name, c.ID[:12])
+		}
+	}
+
+	if running > 0 || stopped > 0 {
+		log.Printf("[daemon] reconcile: found %d running, %d stopped dal containers", running, stopped)
+	}
 }
 
 func (d *Daemon) dalCuePath(name string) string {

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -338,6 +338,53 @@ func dockerLogs(containerID string) (string, error) {
 	return string(out), nil
 }
 
+// discoveredContainer represents a container found via docker ps.
+type discoveredContainer struct {
+	ID      string
+	Name    string // e.g. "dal-dev", "dal-dev-2"
+	Running bool
+}
+
+// discoverContainers finds existing dal-* containers (both running and stopped).
+func discoverContainers() ([]discoveredContainer, error) {
+	cmd := exec.Command("docker", "ps", "-a",
+		"--filter", "name=dal-",
+		"--format", "{{.ID}}\t{{.Names}}\t{{.State}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("docker ps: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+
+	output := strings.TrimSpace(string(out))
+	if output == "" {
+		return nil, nil
+	}
+
+	var containers []discoveredContainer
+	for _, line := range strings.Split(output, "\n") {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		containers = append(containers, discoveredContainer{
+			ID:      parts[0],
+			Name:    parts[1],
+			Running: parts[2] == "running",
+		})
+	}
+	return containers, nil
+}
+
+// cleanStaleContainer force-removes a container by name (best-effort).
+func cleanStaleContainer(name string) error {
+	cmd := exec.Command("docker", "rm", "-f", name)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker rm -f %s: %s: %w", name, strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
 // dockerExec runs a command inside a Docker container (for attach).
 func dockerExec(containerID string) *exec.Cmd {
 	return exec.Command("docker", "exec", "-it", containerID, "/bin/bash")


### PR DESCRIPTION
## Summary
- 데몬 재시작 시 `docker ps`로 기존 `dal-*` 컨테이너 자동 탐색/복원
- wake 시 동일 이름의 stopped 컨테이너 자동 정리 (`docker rm -f`)
- 멀티 인스턴스 이름 (dev-2, dev-3) 처리 포함

Closes #27, Closes #33

## Test plan
- [x] `go build ./...` passes
- [ ] 데몬 재시작 후 기존 실행 중인 컨테이너가 status에 보이는지 확인
- [ ] stopped 컨테이너가 있는 상태에서 wake 시 이름 충돌 없이 시작되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)