### PR TITLE
fix: dockerSync() 구현 — 구조 변경 감지 + 컨테이너 재생성 (#26)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -302,23 +302,64 @@ func (d *Daemon) handleSync(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var synced []string
+	var restarted []string
 	for name, c := range running {
 		dal, err := localdal.ReadDalCue(d.dalCuePath(name), name)
 		if err != nil {
 			log.Printf("[daemon] sync skip %s: %v", name, err)
 			continue
 		}
-		if err := dockerSync(d.localdalRoot, c.ContainerID, dal); err != nil {
+		needsRestart, reason, err := dockerSync(d.localdalRoot, c.ContainerID, dal)
+		if err != nil {
 			log.Printf("[daemon] sync error %s: %v", name, err)
 			continue
+		}
+		if needsRestart {
+			log.Printf("[daemon] sync restart %s: %s", name, reason)
+			// Stop old container
+			oldID := c.ContainerID
+			if err := dockerStop(oldID); err != nil {
+				log.Printf("[daemon] sync restart stop %s: %v", name, err)
+				continue
+			}
+			// Start new container
+			newID, _, err := dockerRun(d.localdalRoot, d.serviceRepo, name, d.addr, dal)
+			if err != nil {
+				log.Printf("[daemon] sync restart run %s: %v", name, err)
+				// Remove from containers map since old one is stopped
+				d.mu.Lock()
+				delete(d.containers, name)
+				d.mu.Unlock()
+				continue
+			}
+			// Update containers map
+			d.mu.Lock()
+			d.containers[name] = &Container{
+				DalName:     name,
+				UUID:        dal.UUID,
+				Player:      dal.Player,
+				Role:        dal.Role,
+				ContainerID: newID,
+				Status:      "running",
+				Skills:      len(dal.Skills),
+				BotToken:    c.BotToken, // preserve bot token
+			}
+			d.mu.Unlock()
+			restarted = append(restarted, name)
+			cid := newID
+			if len(cid) > 12 {
+				cid = cid[:12]
+			}
+			log.Printf("[daemon] sync restarted %s: %s (new container=%s)", name, reason, cid)
 		}
 		synced = append(synced, name)
 	}
 
-	log.Printf("[daemon] sync: %v", synced)
+	log.Printf("[daemon] sync: synced=%v restarted=%v", synced, restarted)
 	json.NewEncoder(w).Encode(map[string]any{
-		"status": "synced",
-		"dals":   synced,
+		"status":    "synced",
+		"dals":      synced,
+		"restarted": restarted,
 	})
 }
 

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -317,15 +317,73 @@ func dockerStop(containerID string) error {
 	return nil
 }
 
+// dockerNeedsRestart checks if a container needs to be recreated based on dal.cue changes.
+// Returns a reason string if restart is needed, empty string if not.
+func dockerNeedsRestart(containerID string, dal *localdal.DalProfile) (string, error) {
+	// 1. Check image: compare current container image with expected
+	imgCmd := exec.Command("docker", "inspect", containerID, "--format", "{{.Config.Image}}")
+	imgOut, err := imgCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("docker inspect image: %w", err)
+	}
+	currentImage := strings.TrimSpace(string(imgOut))
+
+	tag := "latest"
+	if dal.PlayerVersion != "" {
+		tag = dal.PlayerVersion
+	}
+	expectedImage := fmt.Sprintf("dalcenter/%s:%s", dal.Player, tag)
+
+	if currentImage != expectedImage {
+		return fmt.Sprintf("image changed: %s -> %s", currentImage, expectedImage), nil
+	}
+
+	// 2. Check skill mounts: compare mount count with dal.Skills length
+	mountsCmd := exec.Command("docker", "inspect", containerID, "--format", "{{json .Mounts}}")
+	mountsOut, err := mountsCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("docker inspect mounts: %w", err)
+	}
+
+	var mounts []struct {
+		Type        string `json:"Type"`
+		Source      string `json:"Source"`
+		Destination string `json:"Destination"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(mountsOut))), &mounts); err != nil {
+		return "", fmt.Errorf("parse mounts: %w", err)
+	}
+
+	// Count skill mounts: those targeting <playerHome>/skills/*
+	home := playerHome(dal.Player)
+	skillMountPrefix := home + "/skills/"
+	var skillMountCount int
+	for _, m := range mounts {
+		if strings.HasPrefix(m.Destination, skillMountPrefix) {
+			skillMountCount++
+		}
+	}
+
+	if skillMountCount != len(dal.Skills) {
+		return fmt.Sprintf("skills changed: container has %d mounts, dal.cue has %d skills", skillMountCount, len(dal.Skills)), nil
+	}
+
+	return "", nil
+}
+
 // dockerSync verifies a running container matches its dal profile.
-// Since instructions and skills are bind-mounted, file changes are automatic.
-// Sync handles structural changes (new skills added/removed in dal.cue).
-func dockerSync(localdalRoot, containerID string, dal *localdal.DalProfile) error {
-	// Bind mounts auto-reflect file changes.
-	// If dal.cue changed (e.g., new skill added), container needs restart.
-	// For now, log what would change.
-	log.Printf("[sync] %s: player=%s, skills=%d — bind mounts are live", dal.Name, dal.Player, len(dal.Skills))
-	return nil
+// Since instructions and skills are bind-mounted, file content changes are automatic.
+// Sync detects structural changes (image tag, skills added/removed) that require container recreation.
+func dockerSync(localdalRoot, containerID string, dal *localdal.DalProfile) (needsRestart bool, reason string, err error) {
+	reason, err = dockerNeedsRestart(containerID, dal)
+	if err != nil {
+		return false, "", err
+	}
+	if reason != "" {
+		return true, reason, nil
+	}
+	log.Printf("[sync] %s: no structural changes — bind mounts are live", dal.Name)
+	return false, "", nil
 }
 
 // dockerLogs returns logs from a Docker container.


### PR DESCRIPTION
## Summary
- `docker inspect`로 현재 이미지/마운트 vs dal.cue 비교
- 스킬 추가/제거, player_version 변경 시 컨테이너 자동 재생성
- 파일 내용 변경은 bind mount로 자동 반영 (기존 동작 유지)
- sync 응답에 `restarted` 필드 추가

Closes #26

## Test plan
- [x] `go build ./...` passes
- [ ] dal.cue에서 skill 추가 후 `dalcenter sync` → 컨테이너 재생성 확인
- [ ] player_version 변경 후 sync → 이미지 태그 변경되어 재생성 확인
- [ ] 변경 없으면 skip 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)