### PR TITLE
test: credential 만료 체크 + ReadDalCue edge case 테스트 (#35)

### DIFF
--- a/internal/daemon/docker_test.go
+++ b/internal/daemon/docker_test.go
@@ -1,0 +1,206 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ── isCredentialExpired ─────────────────────────────────────────
+
+func TestIsCredentialExpired_ClaudeExpired(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cred.json")
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	data := fmt.Sprintf(`{"claudeAiOauth":{"expiresAt":%d}}`, past)
+	os.WriteFile(f, []byte(data), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !expired {
+		t.Fatal("expected expired for past timestamp")
+	}
+}
+
+func TestIsCredentialExpired_ClaudeValid(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cred.json")
+	future := time.Now().Add(time.Hour).UnixMilli()
+	data := fmt.Sprintf(`{"claudeAiOauth":{"expiresAt":%d}}`, future)
+	os.WriteFile(f, []byte(data), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected not expired for future timestamp")
+	}
+}
+
+func TestIsCredentialExpired_CodexExpired(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "auth.json")
+	past := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	data := fmt.Sprintf(`{"tokens":{"expires_at":"%s"}}`, past)
+	os.WriteFile(f, []byte(data), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !expired {
+		t.Fatal("expected expired for past RFC3339")
+	}
+}
+
+func TestIsCredentialExpired_CodexValid(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "auth.json")
+	future := time.Now().Add(time.Hour).Format(time.RFC3339)
+	data := fmt.Sprintf(`{"tokens":{"expires_at":"%s"}}`, future)
+	os.WriteFile(f, []byte(data), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected not expired for future RFC3339")
+	}
+}
+
+func TestIsCredentialExpired_InvalidJSON(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad.json")
+	os.WriteFile(f, []byte(`not json`), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected false for invalid JSON")
+	}
+}
+
+func TestIsCredentialExpired_MissingFile(t *testing.T) {
+	_, err := isCredentialExpired("/nonexistent/file")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestIsCredentialExpired_EmptyFields(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "empty.json")
+	os.WriteFile(f, []byte(`{"claudeAiOauth":{"expiresAt":0}}`), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected false for zero expiresAt")
+	}
+}
+
+func TestIsCredentialExpired_CodexBadDate(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "bad-date.json")
+	os.WriteFile(f, []byte(`{"tokens":{"expires_at":"not-a-date"}}`), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected false for invalid RFC3339")
+	}
+}
+
+func TestIsCredentialExpired_UnknownFormat(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "unknown.json")
+	os.WriteFile(f, []byte(`{"some_other_provider":{"key":"value"}}`), 0600)
+
+	expired, err := isCredentialExpired(f)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if expired {
+		t.Fatal("expected false for unknown credential format")
+	}
+}
+
+// ── instructionsFileName ────────────────────────────────────────
+
+func TestInstructionsFileName(t *testing.T) {
+	tests := []struct {
+		player string
+		want   string
+	}{
+		{"claude", "CLAUDE.md"},
+		{"codex", "AGENTS.md"},
+		{"gemini", "GEMINI.md"},
+		{"unknown", "AGENTS.md"},
+		{"", "AGENTS.md"},
+	}
+	for _, tt := range tests {
+		if got := instructionsFileName(tt.player); got != tt.want {
+			t.Errorf("instructionsFileName(%q) = %q, want %q", tt.player, got, tt.want)
+		}
+	}
+}
+
+// ── playerHome ──────────────────────────────────────────────────
+
+func TestPlayerHome(t *testing.T) {
+	tests := []struct {
+		player string
+		want   string
+	}{
+		{"claude", "/root/.claude"},
+		{"codex", "/root/.codex"},
+		{"gemini", "/root/.gemini"},
+		{"unknown", "/root/.config"},
+		{"", "/root/.config"},
+	}
+	for _, tt := range tests {
+		if got := playerHome(tt.player); got != tt.want {
+			t.Errorf("playerHome(%q) = %q, want %q", tt.player, got, tt.want)
+		}
+	}
+}
+
+// ── JSON round-trip for credential formats ──────────────────────
+
+func TestCredentialFormats_ClaudeRoundTrip(t *testing.T) {
+	// Verify the struct tags match the actual credential format
+	type claudeCred struct {
+		ClaudeAiOauth struct {
+			ExpiresAt int64 `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	input := `{"claudeAiOauth":{"expiresAt":1711929600000}}`
+	var c claudeCred
+	if err := json.Unmarshal([]byte(input), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.ClaudeAiOauth.ExpiresAt != 1711929600000 {
+		t.Fatalf("got %d, want 1711929600000", c.ClaudeAiOauth.ExpiresAt)
+	}
+}
+
+func TestCredentialFormats_CodexRoundTrip(t *testing.T) {
+	type codexCred struct {
+		Tokens struct {
+			ExpiresAt string `json:"expires_at"`
+		} `json:"tokens"`
+	}
+	input := `{"tokens":{"expires_at":"2026-03-20T12:00:00Z"},"last_refresh":"2026-03-19T12:00:00Z"}`
+	var c codexCred
+	if err := json.Unmarshal([]byte(input), &c); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if c.Tokens.ExpiresAt != "2026-03-20T12:00:00Z" {
+		t.Fatalf("got %q, want 2026-03-20T12:00:00Z", c.Tokens.ExpiresAt)
+	}
+}

--- a/internal/localdal/localdal_test.go
+++ b/internal/localdal/localdal_test.go
@@ -149,3 +149,152 @@ func TestUUIDFormat(t *testing.T) {
 	parts := filepath.SplitList(uuid)
 	_ = parts // basic check
 }
+
+// ── ReadDalCue extended fields ──────────────────────────────────
+
+func TestReadDalCue_GitConfig(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+uuid:    "git-test-001"
+name:    "gitdal"
+version: "1.0.0"
+player:  "claude"
+role:    "member"
+git: {
+	user:         "test-user"
+	email:        "test@example.com"
+	github_token: "VK:secrets/gh-token"
+}
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	p, err := ReadDalCue(f, "gitdal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.GitUser != "test-user" {
+		t.Errorf("GitUser = %q, want test-user", p.GitUser)
+	}
+	if p.GitEmail != "test@example.com" {
+		t.Errorf("GitEmail = %q, want test@example.com", p.GitEmail)
+	}
+	if p.GitHubToken != "VK:secrets/gh-token" {
+		t.Errorf("GitHubToken = %q, want VK:secrets/gh-token", p.GitHubToken)
+	}
+}
+
+func TestReadDalCue_PlayerVersion(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+uuid:           "pv-test-001"
+name:           "pvdal"
+version:        "1.0.0"
+player:         "claude"
+player_version: "2.1.81"
+role:           "member"
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	p, err := ReadDalCue(f, "pvdal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.PlayerVersion != "2.1.81" {
+		t.Errorf("PlayerVersion = %q, want 2.1.81", p.PlayerVersion)
+	}
+}
+
+func TestReadDalCue_MissingUUID(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+name:    "no-uuid"
+version: "1.0.0"
+player:  "claude"
+role:    "member"
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	_, err := ReadDalCue(f, "no-uuid")
+	if err == nil {
+		t.Fatal("expected error for missing uuid")
+	}
+}
+
+func TestReadDalCue_InvalidSyntax(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(`this is not valid cue {{{`), 0644)
+
+	_, err := ReadDalCue(f, "bad")
+	if err == nil {
+		t.Fatal("expected error for invalid cue syntax")
+	}
+}
+
+func TestReadDalCue_DefaultRole(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+uuid:    "role-test-001"
+name:    "norole"
+version: "1.0.0"
+player:  "claude"
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	p, err := ReadDalCue(f, "norole")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Role != "member" {
+		t.Errorf("Role = %q, want member (default)", p.Role)
+	}
+}
+
+func TestReadDalCue_DefaultName(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+uuid:    "name-test-001"
+version: "1.0.0"
+player:  "codex"
+role:    "member"
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	p, err := ReadDalCue(f, "folder-name")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name != "folder-name" {
+		t.Errorf("Name = %q, want folder-name (from folderName param)", p.Name)
+	}
+}
+
+func TestReadDalCue_Hooks(t *testing.T) {
+	dir := t.TempDir()
+	cue := `
+uuid:    "hook-test-001"
+name:    "hookdal"
+version: "1.0.0"
+player:  "claude"
+role:    "member"
+hooks:   ["pre-commit", "post-deploy"]
+`
+	f := filepath.Join(dir, "dal.cue")
+	os.WriteFile(f, []byte(cue), 0644)
+
+	p, err := ReadDalCue(f, "hookdal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(p.Hooks) != 2 {
+		t.Fatalf("Hooks = %v, want 2 items", p.Hooks)
+	}
+	if p.Hooks[0] != "pre-commit" || p.Hooks[1] != "post-deploy" {
+		t.Errorf("Hooks = %v", p.Hooks)
+	}
+}


### PR DESCRIPTION
## Summary
- `isCredentialExpired()` 테스트 9개: Claude/Codex 만료·유효, 잘못된 JSON, 누락 파일, 빈 필드, 잘못된 날짜, 미지원 포맷
- `instructionsFileName()` / `playerHome()` 테스트: 전 player + default
- credential JSON round-trip 테스트 2개
- `ReadDalCue()` edge case 테스트 7개: git config, player_version, missing uuid, invalid syntax, default role/name, hooks

**테스트 수 변화**: daemon 11→24 (+13), localdal 12→19 (+7)

Closes #35 (partial)

## Test plan
- [x] `go test ./...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)