### PR TITLE
feat: daemon API Bearer 토큰 인증 (#29)

### DIFF
--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -14,19 +14,22 @@ var errNoURL = fmt.Errorf("DALCENTER_URL is not set")
 
 // Client talks to the dalcenter daemon over HTTP.
 type Client struct {
-	baseURL string
-	http    *http.Client
+	baseURL  string
+	apiToken string
+	http     *http.Client
 }
 
 // NewClient creates a daemon client. Requires DALCENTER_URL.
+// Reads DALCENTER_TOKEN for authenticated write requests.
 func NewClient() (*Client, error) {
 	url := os.Getenv("DALCENTER_URL")
 	if url == "" {
 		return nil, errNoURL
 	}
 	return &Client{
-		baseURL: strings.TrimRight(url, "/"),
-		http:    &http.Client{Timeout: 120 * time.Second},
+		baseURL:  strings.TrimRight(url, "/"),
+		apiToken: os.Getenv("DALCENTER_TOKEN"),
+		http:     &http.Client{Timeout: 120 * time.Second},
 	}, nil
 }
 
@@ -59,7 +62,15 @@ func (c *Client) Message(from, message string) (*MessageResult, error) {
 // MessageThread posts a message as a thread reply.
 func (c *Client) MessageThread(from, message, threadID string) (*MessageResult, error) {
 	body := fmt.Sprintf(`{"from":%q,"message":%q,"thread_id":%q}`, from, message, threadID)
-	resp, err := c.http.Post(c.baseURL+"/api/message", "application/json", strings.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/message", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("daemon unreachable: %w", err)
 	}
@@ -107,8 +118,16 @@ func (c *Client) Logs(name string) (string, error) {
 	return string(body), nil
 }
 
-func (c *Client) postJSON(path string) (map[string]string, error) {
-	resp, err := c.http.Post(c.baseURL+path, "application/json", nil)
+func (c *Client) doPost(path string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("daemon unreachable: %w", err)
 	}
@@ -116,6 +135,14 @@ func (c *Client) postJSON(path string) (map[string]string, error) {
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("daemon error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func (c *Client) postJSON(path string) (map[string]string, error) {
+	body, err := c.doPost(path)
+	if err != nil {
+		return nil, err
 	}
 	var result map[string]string
 	if err := json.Unmarshal(body, &result); err != nil {
@@ -125,14 +152,9 @@ func (c *Client) postJSON(path string) (map[string]string, error) {
 }
 
 func (c *Client) postAny(path string) (map[string]any, error) {
-	resp, err := c.http.Post(c.baseURL+path, "application/json", nil)
+	body, err := c.doPost(path)
 	if err != nil {
-		return nil, fmt.Errorf("daemon unreachable: %w", err)
-	}
-	defer resp.Body.Close()
-	body, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("daemon error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		return nil, err
 	}
 	var result map[string]any
 	if err := json.Unmarshal(body, &result); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ type Daemon struct {
 	localdalRoot string
 	serviceRepo  string // service repo path to mount as /workspace
 	mm           *MattermostConfig
+	apiToken     string // Bearer token for write endpoints (empty = no auth)
 	channelID    string // channel for this project
 	containers   map[string]*Container // dal name -> container
 	mu           sync.RWMutex
@@ -48,12 +50,35 @@ type Container struct {
 
 // New creates a daemon.
 func New(addr, localdalRoot, serviceRepo string, mm *MattermostConfig) *Daemon {
+	token := os.Getenv("DALCENTER_TOKEN")
+	if token != "" {
+		log.Println("[daemon] API token auth enabled for write endpoints")
+	}
 	return &Daemon{
 		addr:         addr,
 		localdalRoot: localdalRoot,
 		serviceRepo:  serviceRepo,
 		mm:           mm,
+		apiToken:     token,
 		containers:   make(map[string]*Container),
+	}
+}
+
+// requireAuth is middleware that checks Bearer token for write endpoints.
+// If DALCENTER_TOKEN is not set, all requests are allowed.
+func (d *Daemon) requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if d.apiToken == "" {
+			next(w, r)
+			return
+		}
+		auth := r.Header.Get("Authorization")
+		token := strings.TrimPrefix(auth, "Bearer ")
+		if auth == "" || token == auth || token != d.apiToken {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
 	}
 }
 
@@ -90,15 +115,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 
+	// Read-only endpoints — no auth required
 	mux.HandleFunc("GET /api/ps", d.handlePs)
 	mux.HandleFunc("GET /api/status", d.handleStatus)
 	mux.HandleFunc("GET /api/status/{name}", d.handleStatusOne)
-	mux.HandleFunc("POST /api/wake/{name}", d.handleWake)
-	mux.HandleFunc("POST /api/sleep/{name}", d.handleSleep)
-	mux.HandleFunc("POST /api/sync", d.handleSync)
-	mux.HandleFunc("POST /api/message", d.handleMessage)
 	mux.HandleFunc("POST /api/validate", d.handleValidate)
 	mux.HandleFunc("GET /api/logs/{name}", d.handleLogs)
+	// Write endpoints — require auth when DALCENTER_TOKEN is set
+	mux.HandleFunc("POST /api/wake/{name}", d.requireAuth(d.handleWake))
+	mux.HandleFunc("POST /api/sleep/{name}", d.requireAuth(d.handleSleep))
+	mux.HandleFunc("POST /api/sync", d.requireAuth(d.handleSync))
+	mux.HandleFunc("POST /api/message", d.requireAuth(d.handleMessage))
 
 	srv := &http.Server{Addr: d.addr, Handler: mux}
 	log.Printf("[daemon] listening on %s", d.addr)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -215,3 +215,73 @@ func TestRunServer(t *testing.T) {
 		t.Fatalf("Run error: %v", err)
 	}
 }
+
+// ── API Auth Tests ──────────────────────────────────────────────
+
+func TestRequireAuth_NoToken_AllowAll(t *testing.T) {
+	d, _ := setupTestDaemon(t)
+	// No apiToken set — all requests allowed
+
+	req := httptest.NewRequest("POST", "/api/sync", nil)
+	w := httptest.NewRecorder()
+	d.requireAuth(d.handleSync)(w, req)
+
+	if w.Code == 401 {
+		t.Fatal("expected no auth required when DALCENTER_TOKEN is empty")
+	}
+}
+
+func TestRequireAuth_WithToken_Rejects(t *testing.T) {
+	d, _ := setupTestDaemon(t)
+	d.apiToken = "secret-token"
+
+	req := httptest.NewRequest("POST", "/api/sync", nil)
+	w := httptest.NewRecorder()
+	d.requireAuth(d.handleSync)(w, req)
+
+	if w.Code != 401 {
+		t.Fatalf("expected 401 without token, got %d", w.Code)
+	}
+}
+
+func TestRequireAuth_WithToken_WrongToken(t *testing.T) {
+	d, _ := setupTestDaemon(t)
+	d.apiToken = "secret-token"
+
+	req := httptest.NewRequest("POST", "/api/sync", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	d.requireAuth(d.handleSync)(w, req)
+
+	if w.Code != 401 {
+		t.Fatalf("expected 401 with wrong token, got %d", w.Code)
+	}
+}
+
+func TestRequireAuth_WithToken_CorrectToken(t *testing.T) {
+	d, _ := setupTestDaemon(t)
+	d.apiToken = "secret-token"
+
+	req := httptest.NewRequest("POST", "/api/sync", nil)
+	req.Header.Set("Authorization", "Bearer secret-token")
+	w := httptest.NewRecorder()
+	d.requireAuth(d.handleSync)(w, req)
+
+	if w.Code == 401 {
+		t.Fatal("expected auth to pass with correct token")
+	}
+}
+
+func TestRequireAuth_ReadEndpoints_NoAuth(t *testing.T) {
+	d, _ := setupTestDaemon(t)
+	d.apiToken = "secret-token"
+
+	// Read endpoint should work without token (not wrapped with requireAuth)
+	req := httptest.NewRequest("GET", "/api/status", nil)
+	w := httptest.NewRecorder()
+	d.handleStatus(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("expected 200 for read endpoint without token, got %d", w.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- `DALCENTER_TOKEN` 환경변수로 API 토큰 설정 (미설정 시 기존 동작 — 인증 없음)
- 쓰기 엔드포인트에 `requireAuth` 미들웨어: wake, sleep, sync, message
- 읽기 엔드포인트는 인증 없이 허용: ps, status, logs, validate
- Client가 `DALCENTER_TOKEN` 자동으로 Bearer 헤더에 포함
- 인증 테스트 5개 추가

## 사용법

```bash
# 데몬: 토큰 설정
export DALCENTER_TOKEN="my-secret-token"
dalcenter daemon

# 클라이언트: 같은 토큰 설정
export DALCENTER_TOKEN="my-secret-token"
dalcenter wake dev  # 인증됨
```

미설정 시 기존과 동일하게 인증 없이 동작 → 하위 호환 보장.

Closes #29

## Test plan
- [x] `go build ./...` passes
- [x] auth 테스트 5개 pass
- [ ] DALCENTER_TOKEN 설정 후 wake/sleep 동작 확인
- [ ] DALCENTER_TOKEN 미설정 시 기존 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)