### PR TITLE
test: round 2 — 19 tests, daemon +10%, talk +10%

### DIFF
--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -1,0 +1,165 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+func TestNewClient_NoURL(t *testing.T) {
+	os.Unsetenv("DALCENTER_URL")
+	_, err := NewClient()
+	if err == nil {
+		t.Fatal("expected error when DALCENTER_URL not set")
+	}
+}
+
+func TestNewClient_WithURL(t *testing.T) {
+	os.Setenv("DALCENTER_URL", "http://localhost:11190")
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, err := NewClient()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c == nil {
+		t.Fatal("client should not be nil")
+	}
+}
+
+func TestClient_Ps(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/ps" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		containers := []Container{
+			{DalName: "dev", Player: "claude", Role: "member", Status: "running", ContainerID: "abc123def456"},
+			{DalName: "leader", Player: "claude", Role: "leader", Status: "running", ContainerID: "def456abc789"},
+		}
+		json.NewEncoder(w).Encode(containers)
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	containers, err := c.Ps()
+	if err != nil {
+		t.Fatalf("Ps: %v", err)
+	}
+	if len(containers) != 2 {
+		t.Fatalf("got %d containers, want 2", len(containers))
+	}
+	if containers[0].DalName != "dev" {
+		t.Errorf("first dal = %q, want dev", containers[0].DalName)
+	}
+	if containers[1].Role != "leader" {
+		t.Errorf("second role = %q, want leader", containers[1].Role)
+	}
+}
+
+func TestClient_Ps_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte("internal error"))
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	_, err := c.Ps()
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestClient_Wake(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/wake/dev" {
+			t.Errorf("path = %s, want /api/wake/dev", r.URL.Path)
+		}
+		w.Write([]byte(`{"status":"awake","container_id":"abc123"}`))
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	_, err := c.Wake("dev")
+	if err != nil {
+		t.Fatalf("Wake: %v", err)
+	}
+}
+
+func TestClient_Sleep(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/sleep/dev" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"status":"sleeping"}`))
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	_, err := c.Sleep("dev")
+	if err != nil {
+		t.Fatalf("Sleep: %v", err)
+	}
+}
+
+func TestClient_Message(t *testing.T) {
+	var received string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/message" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body)
+		received = body["message"]
+		w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	_, err := c.Message("dev", "hello from test")
+	if err != nil {
+		t.Fatalf("Message: %v", err)
+	}
+	if received != "hello from test" {
+		t.Errorf("received = %q, want 'hello from test'", received)
+	}
+}
+
+func TestClient_Logs(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/logs/dev" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]string{"logs": "line1\nline2"})
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	_, err := c.Logs("dev")
+	if err != nil {
+		t.Fatalf("Logs: %v", err)
+	}
+}

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleAgentConfig_Found(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"story-checker": {
+				DalName:  "story-checker",
+				BotToken: "bot-tok-123",
+			},
+		},
+		channelID: "ch-abc",
+		mm:        &MattermostConfig{URL: "http://mm:8065"},
+	}
+
+	req := httptest.NewRequest("GET", "/api/agent-config/story-checker", nil)
+	req.SetPathValue("name", "story-checker")
+	w := httptest.NewRecorder()
+
+	d.handleAgentConfig(w, req)
+
+	if w.Code != 200 {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["dal_name"] != "story-checker" {
+		t.Errorf("dal_name = %q", resp["dal_name"])
+	}
+	if resp["bot_token"] != "bot-tok-123" {
+		t.Errorf("bot_token = %q", resp["bot_token"])
+	}
+	if resp["channel_id"] != "ch-abc" {
+		t.Errorf("channel_id = %q", resp["channel_id"])
+	}
+	if resp["mm_url"] != "http://mm:8065" {
+		t.Errorf("mm_url = %q", resp["mm_url"])
+	}
+}
+
+func TestHandleAgentConfig_NotFound(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{},
+	}
+
+	req := httptest.NewRequest("GET", "/api/agent-config/nonexistent", nil)
+	req.SetPathValue("name", "nonexistent")
+	w := httptest.NewRecorder()
+
+	d.handleAgentConfig(w, req)
+
+	if w.Code != 404 {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleAgentConfig_NoMM(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"dev": {DalName: "dev", BotToken: "tok"},
+		},
+		channelID: "ch-1",
+		mm:        nil,
+	}
+
+	req := httptest.NewRequest("GET", "/api/agent-config/dev", nil)
+	req.SetPathValue("name", "dev")
+	w := httptest.NewRecorder()
+
+	d.handleAgentConfig(w, req)
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["mm_url"] != "" {
+		t.Errorf("mm_url should be empty when mm is nil, got %q", resp["mm_url"])
+	}
+}

--- a/internal/talk/bot_extra_test.go
+++ b/internal/talk/bot_extra_test.go
@@ -1,0 +1,151 @@
+package talk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestTeardownBot_Found(t *testing.T) {
+	var disabled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v4/bots" && r.Method == "GET":
+			w.Write([]byte(`[{"user_id":"u1","username":"dal-dev"}]`))
+		case r.URL.Path == "/api/v4/users/u1/tokens" && r.Method == "GET":
+			w.Write([]byte(`[{"id":"tok1"},{"id":"tok2"}]`))
+		case r.URL.Path == "/api/v4/users/u1/tokens/revoke":
+			w.Write([]byte(`{}`))
+		case r.URL.Path == "/api/v4/bots/u1/disable":
+			disabled = true
+			w.Write([]byte(`{}`))
+		default:
+			w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	err := TeardownBot(srv.URL, "token", "dal-dev")
+	if err != nil {
+		t.Fatalf("TeardownBot: %v", err)
+	}
+	if !disabled {
+		t.Fatal("bot should have been disabled")
+	}
+}
+
+func TestTeardownBot_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[]`))
+	}))
+	defer srv.Close()
+
+	err := TeardownBot(srv.URL, "token", "dal-nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent bot")
+	}
+}
+
+func TestGetAdminToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v4/users/login" {
+			t.Errorf("path = %s", r.URL.Path)
+		}
+		w.Header().Set("Token", "session-tok-abc")
+		w.Write([]byte(`{"id":"user1"}`))
+	}))
+	defer srv.Close()
+
+	tok, err := GetAdminToken(srv.URL, "admin", "password")
+	if err != nil {
+		t.Fatalf("GetAdminToken: %v", err)
+	}
+	if tok != "session-tok-abc" {
+		t.Errorf("token = %q, want session-tok-abc", tok)
+	}
+}
+
+func TestGetAdminToken_Failure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(401)
+		w.Write([]byte(`{"message":"invalid credentials"}`))
+	}))
+	defer srv.Close()
+
+	_, err := GetAdminToken(srv.URL, "admin", "wrong")
+	if err == nil {
+		t.Fatal("expected error for wrong password")
+	}
+}
+
+func TestCreateChannel_New(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v4/channels" && r.Method == "POST" {
+			w.Write([]byte(`{"id":"ch-new"}`))
+		}
+	}))
+	defer srv.Close()
+
+	id, err := CreateChannel(srv.URL, "token", "team1", "mychannel")
+	if err != nil {
+		t.Fatalf("CreateChannel: %v", err)
+	}
+	if id != "ch-new" {
+		t.Errorf("id = %q, want ch-new", id)
+	}
+}
+
+func TestCreateChannel_RestoreArchived(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v4/channels" && r.Method == "POST":
+			w.WriteHeader(400)
+			w.Write([]byte(`{"message":"exists"}`))
+		case r.URL.Path == "/api/v4/channels/search":
+			w.Write([]byte(`[{"id":"ch-archived","name":"mychannel","delete_at":12345}]`))
+		case r.URL.Path == "/api/v4/channels/ch-archived/restore":
+			w.Write([]byte(`{"id":"ch-archived"}`))
+		}
+	}))
+	defer srv.Close()
+
+	id, err := CreateChannel(srv.URL, "token", "team1", "mychannel")
+	if err != nil {
+		t.Fatalf("CreateChannel restore: %v", err)
+	}
+	if id != "ch-archived" {
+		t.Errorf("id = %q, want ch-archived", id)
+	}
+}
+
+func TestDeleteChannel(t *testing.T) {
+	var deleted bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" && r.URL.Path == "/api/v4/channels/ch1" {
+			deleted = true
+			w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	err := DeleteChannel(srv.URL, "token", "ch1")
+	if err != nil {
+		t.Fatalf("DeleteChannel: %v", err)
+	}
+	if !deleted {
+		t.Fatal("channel should have been deleted")
+	}
+}
+
+func TestMmAPI_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(500)
+		w.Write([]byte(`server error`))
+	}))
+	defer srv.Close()
+
+	_, err := mmAPI("GET", srv.URL+"/api/v4/test", "token", "")
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+}


### PR DESCRIPTION
agent-config(3), client(8), bot/channel(8)