### PR TITLE
feat: dal self-repair + escalation system

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -114,11 +114,28 @@ func runAgentLoop(dalName string) error {
 		output, err := executeTask(prompt)
 		if err != nil {
 			log.Printf("[agent] failed: %v", err)
-			mm.Send(bridge.Message{
-				Content: fmt.Sprintf("❌ 실패: %v\n```\n%s\n```", err, truncate(output, 500)),
-				ReplyTo: threadID,
-			})
-			continue
+
+			// Self-repair: try to fix and retry once
+			if shouldRetry, fix := selfRepair(prompt, output, err); shouldRetry {
+				log.Printf("[agent] self-repair applied: %s, retrying", fix)
+				mm.Send(bridge.Message{
+					Content: fmt.Sprintf("🔧 자가 수리: %s — 재시도 중...", fix),
+					ReplyTo: threadID,
+				})
+				output, err = executeTask(prompt)
+			}
+
+			if err != nil {
+				class := classifyTaskError(output)
+				// Post failure to thread
+				mm.Send(bridge.Message{
+					Content: fmt.Sprintf("❌ 실패 (%s): %v\n```\n%s\n```", class, err, truncate(output, 500)),
+					ReplyTo: threadID,
+				})
+				// Escalate to daemon
+				escalateToHost(dalName, prompt, output, string(class))
+				continue
+			}
 		}
 
 		log.Printf("[agent] done (%d bytes)", len(output))

--- a/cmd/dalcli/self_repair.go
+++ b/cmd/dalcli/self_repair.go
@@ -1,0 +1,191 @@
+package main
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrorClass categorizes task failures for self-repair decisions.
+type ErrorClass string
+
+const (
+	ErrClassEnv          ErrorClass = "env"          // missing binary, wrong dir, permission
+	ErrClassDeps         ErrorClass = "deps"         // go mod, npm, cargo dependency issues
+	ErrClassGit          ErrorClass = "git"          // merge conflict, detached HEAD
+	ErrClassInstructions ErrorClass = "instructions" // stale/wrong instructions
+	ErrClassUnknown      ErrorClass = "unknown"
+)
+
+// classifyTaskError analyzes combined output to determine error category.
+func classifyTaskError(output string) ErrorClass {
+	lower := strings.ToLower(output)
+
+	// Environment issues
+	envPatterns := []string{
+		"command not found", "no such file or directory",
+		"permission denied", "not a directory",
+		"exec format error", "is not recognized",
+	}
+	for _, p := range envPatterns {
+		if strings.Contains(lower, p) {
+			return ErrClassEnv
+		}
+	}
+
+	// Dependency issues
+	depPatterns := []string{
+		"go: module", "go mod tidy", "cannot find module",
+		"npm err", "module not found", "package not found",
+		"cargo build", "unresolved import", "could not compile",
+	}
+	for _, p := range depPatterns {
+		if strings.Contains(lower, p) {
+			return ErrClassDeps
+		}
+	}
+
+	// Git issues
+	gitPatterns := []string{
+		"merge conflict", "detached head", "head detached", "not a git repository",
+		"your branch is behind", "unmerged files",
+		"fatal: refusing to merge unrelated",
+	}
+	for _, p := range gitPatterns {
+		if strings.Contains(lower, p) {
+			return ErrClassGit
+		}
+	}
+
+	// Stale instructions
+	instrPatterns := []string{
+		"instructions.md", "stale instruction",
+		"task.md", "issue #",
+	}
+	matchCount := 0
+	for _, p := range instrPatterns {
+		if strings.Contains(lower, p) {
+			matchCount++
+		}
+	}
+	// Only classify as instructions if multiple indicators present
+	if matchCount >= 2 && strings.Contains(lower, "error") {
+		return ErrClassInstructions
+	}
+
+	return ErrClassUnknown
+}
+
+// repairCooldown prevents repeated repair attempts for the same task.
+var repairCooldown = struct {
+	mu    sync.Mutex
+	tasks map[string]time.Time
+}{tasks: make(map[string]time.Time)}
+
+const repairCooldownDuration = 5 * time.Minute
+
+func taskHash(task string) string {
+	h := sha256.Sum256([]byte(task))
+	return fmt.Sprintf("%x", h[:8])
+}
+
+func isRepairCoolingDown(task string) bool {
+	repairCooldown.mu.Lock()
+	defer repairCooldown.mu.Unlock()
+	hash := taskHash(task)
+	if t, ok := repairCooldown.tasks[hash]; ok {
+		if time.Since(t) < repairCooldownDuration {
+			return true
+		}
+	}
+	return false
+}
+
+func markRepairAttempted(task string) {
+	repairCooldown.mu.Lock()
+	defer repairCooldown.mu.Unlock()
+	repairCooldown.tasks[taskHash(task)] = time.Now()
+}
+
+// selfRepair attempts to fix a classified error. Returns whether to retry.
+func selfRepair(task, output string, taskErr error) (shouldRetry bool, fix string) {
+	if isRepairCoolingDown(task) {
+		return false, ""
+	}
+	markRepairAttempted(task)
+
+	class := classifyTaskError(output)
+	log.Printf("[repair] classified as %s", class)
+
+	switch class {
+	case ErrClassEnv:
+		// Try to fix workspace directory
+		if _, err := os.Stat("/workspace"); err == nil {
+			fix = "cd /workspace"
+			if err := os.Chdir("/workspace"); err == nil {
+				return true, fix
+			}
+		}
+		return false, ""
+
+	case ErrClassDeps:
+		// Try go mod tidy
+		if _, err := os.Stat("/workspace/go.mod"); err == nil {
+			cmd := exec.Command("go", "mod", "tidy")
+			cmd.Dir = "/workspace"
+			if err := cmd.Run(); err == nil {
+				return true, "go mod tidy"
+			}
+		}
+		// Try npm install
+		if _, err := os.Stat("/workspace/package.json"); err == nil {
+			cmd := exec.Command("npm", "install")
+			cmd.Dir = "/workspace"
+			if err := cmd.Run(); err == nil {
+				return true, "npm install"
+			}
+		}
+		return false, ""
+
+	case ErrClassGit:
+		cmd := exec.Command("git", "checkout", "main")
+		cmd.Dir = "/workspace"
+		if err := cmd.Run(); err == nil {
+			pull := exec.Command("git", "pull")
+			pull.Dir = "/workspace"
+			if err := pull.Run(); err == nil {
+				return true, "git checkout main && git pull"
+			}
+		}
+		return false, ""
+
+	case ErrClassInstructions, ErrClassUnknown:
+		// Cannot self-repair — escalate
+		return false, ""
+	}
+
+	return false, ""
+}
+
+// escalateToHost reports a task failure to the dalcenter daemon for tracking.
+func escalateToHost(dalName, task, output, errorClass string) {
+	dcURL := os.Getenv("DALCENTER_URL")
+	if dcURL == "" {
+		dcURL = "http://host.docker.internal:11190"
+	}
+	body := fmt.Sprintf(`{"dal":%q,"task":%q,"output":%q,"error_class":%q}`,
+		dalName, truncate(task, 500), truncate(output, 1000), errorClass)
+	resp, err := http.Post(dcURL+"/api/escalate", "application/json", strings.NewReader(body))
+	if err != nil {
+		log.Printf("[escalate] failed to reach daemon: %v", err)
+		return
+	}
+	resp.Body.Close()
+	log.Printf("[escalate] reported to daemon: dal=%s class=%s", dalName, errorClass)
+}

--- a/cmd/dalcli/self_repair_test.go
+++ b/cmd/dalcli/self_repair_test.go
@@ -1,0 +1,91 @@
+package main
+
+import "testing"
+
+func TestClassifyTaskError_Env(t *testing.T) {
+	cases := []string{
+		"bash: claude: command not found",
+		"/bin/sh: go: No such file or directory",
+		"Error: permission denied while trying to connect",
+	}
+	for _, c := range cases {
+		if got := classifyTaskError(c); got != ErrClassEnv {
+			t.Errorf("classifyTaskError(%q) = %s, want env", c, got)
+		}
+	}
+}
+
+func TestClassifyTaskError_Deps(t *testing.T) {
+	cases := []string{
+		"go: module github.com/foo/bar: not found",
+		"npm ERR! missing: react@^18.0.0",
+		"error: could not compile `veil-cli`",
+	}
+	for _, c := range cases {
+		if got := classifyTaskError(c); got != ErrClassDeps {
+			t.Errorf("classifyTaskError(%q) = %s, want deps", c, got)
+		}
+	}
+}
+
+func TestClassifyTaskError_Git(t *testing.T) {
+	cases := []string{
+		"error: merge conflict in main.go",
+		"HEAD detached at abc1234",
+		"fatal: not a git repository",
+	}
+	for _, c := range cases {
+		if got := classifyTaskError(c); got != ErrClassGit {
+			t.Errorf("classifyTaskError(%q) = %s, want git", c, got)
+		}
+	}
+}
+
+func TestClassifyTaskError_Unknown(t *testing.T) {
+	cases := []string{
+		"something went wrong",
+		"exit status 1",
+		"",
+	}
+	for _, c := range cases {
+		if got := classifyTaskError(c); got != ErrClassUnknown {
+			t.Errorf("classifyTaskError(%q) = %s, want unknown", c, got)
+		}
+	}
+}
+
+func TestSelfRepair_UnknownReturnsNoRetry(t *testing.T) {
+	retry, fix := selfRepair("test task", "unknown error", nil)
+	if retry {
+		t.Error("unknown error should not retry")
+	}
+	if fix != "" {
+		t.Errorf("fix should be empty, got %q", fix)
+	}
+}
+
+func TestSelfRepair_Cooldown(t *testing.T) {
+	task := "cooldown-test-task-unique"
+	// First attempt marks cooldown
+	selfRepair(task, "unknown error", nil)
+	// Second attempt should be cooled down
+	if !isRepairCoolingDown(task) {
+		t.Error("should be cooling down after first attempt")
+	}
+}
+
+func TestClassifyTaskError_Instructions(t *testing.T) {
+	// Needs multiple indicators to classify as instructions
+	output := "error: instructions.md references issue #398 which is stale, task.md conflict"
+	if got := classifyTaskError(output); got != ErrClassInstructions {
+		t.Errorf("got %s, want instructions", got)
+	}
+}
+
+func TestClassifyTaskError_InstructionsSingleIndicator(t *testing.T) {
+	// Single indicator should NOT be classified as instructions
+	output := "reading instructions.md"
+	if got := classifyTaskError(output); got == ErrClassInstructions {
+		t.Error("single indicator should not classify as instructions")
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -34,6 +34,7 @@ type Daemon struct {
 	channelID    string // channel for this project
 	containers   map[string]*Container // dal name -> container
 	mu           sync.RWMutex
+	escalations  *escalationStore
 }
 
 // Container tracks a running dal Docker container.
@@ -61,6 +62,7 @@ func New(addr, localdalRoot, serviceRepo string, mm *MattermostConfig) *Daemon {
 		mm:           mm,
 		apiToken:     token,
 		containers:   make(map[string]*Container),
+		escalations:  newEscalationStore(),
 	}
 }
 
@@ -130,6 +132,10 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/sync", d.requireAuth(d.handleSync))
 	mux.HandleFunc("POST /api/message", d.requireAuth(d.handleMessage))
 	mux.HandleFunc("GET /api/agent-config/{name}", d.handleAgentConfig)
+	// Escalation endpoints
+	mux.HandleFunc("POST /api/escalate", d.requireAuth(d.handleEscalate))
+	mux.HandleFunc("GET /api/escalations", d.handleEscalations)
+	mux.HandleFunc("POST /api/escalations/{id}/resolve", d.requireAuth(d.handleResolveEscalation))
 
 	srv := &http.Server{Addr: d.addr, Handler: mux}
 	log.Printf("[daemon] listening on %s", d.addr)

--- a/internal/daemon/escalation.go
+++ b/internal/daemon/escalation.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Escalation represents a dal task failure that needs human intervention.
+type Escalation struct {
+	ID           string    `json:"id"`
+	Dal          string    `json:"dal"`
+	Task         string    `json:"task"`
+	ErrorClass   string    `json:"error_class"`
+	Output       string    `json:"output"`
+	Timestamp    time.Time `json:"timestamp"`
+	Resolved     bool      `json:"resolved"`
+	ResolvedAt   *time.Time `json:"resolved_at,omitempty"`
+}
+
+// escalationStore is an in-memory store for escalations.
+type escalationStore struct {
+	mu    sync.RWMutex
+	items []Escalation
+	seq   int
+}
+
+const maxEscalations = 100
+
+func newEscalationStore() *escalationStore {
+	return &escalationStore{items: make([]Escalation, 0)}
+}
+
+func (s *escalationStore) Add(dal, task, errorClass, output string) Escalation {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seq++
+
+	// Truncate output
+	if len(output) > 1024 {
+		output = output[:1024]
+	}
+	// Truncate task
+	if len(task) > 500 {
+		task = task[:500]
+	}
+
+	esc := Escalation{
+		ID:         fmt.Sprintf("esc-%04d", s.seq),
+		Dal:        dal,
+		Task:       task,
+		ErrorClass: errorClass,
+		Output:     output,
+		Timestamp:  time.Now().UTC(),
+	}
+	s.items = append(s.items, esc)
+
+	// FIFO eviction
+	if len(s.items) > maxEscalations {
+		s.items = s.items[len(s.items)-maxEscalations:]
+	}
+	return esc
+}
+
+func (s *escalationStore) Unresolved() []Escalation {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []Escalation
+	for _, e := range s.items {
+		if !e.Resolved {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+func (s *escalationStore) Resolve(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.items {
+		if s.items[i].ID == id && !s.items[i].Resolved {
+			s.items[i].Resolved = true
+			now := time.Now().UTC()
+			s.items[i].ResolvedAt = &now
+			return true
+		}
+	}
+	return false
+}
+
+func respondJSON(w http.ResponseWriter, status int, data any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+// HTTP handlers
+
+func (d *Daemon) handleEscalate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Dal        string `json:"dal"`
+		Task       string `json:"task"`
+		ErrorClass string `json:"error_class"`
+		Output     string `json:"output"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	esc := d.escalations.Add(req.Dal, req.Task, req.ErrorClass, req.Output)
+	respondJSON(w, http.StatusOK, esc)
+}
+
+func (d *Daemon) handleEscalations(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	items := d.escalations.Unresolved()
+	if items == nil {
+		items = []Escalation{}
+	}
+	respondJSON(w, http.StatusOK, map[string]any{
+		"escalations": items,
+		"count":       len(items),
+	})
+}
+
+func (d *Daemon) handleResolveEscalation(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "id is required", http.StatusBadRequest)
+		return
+	}
+	if d.escalations.Resolve(id) {
+		respondJSON(w, http.StatusOK, map[string]any{"resolved": id})
+	} else {
+		http.Error(w, "escalation not found or already resolved", http.StatusNotFound)
+	}
+}


### PR DESCRIPTION
## Summary
dal 작업 실패 시 자가수리 + 에스컬레이션 시스템 추가.

### 자가수리
- 에러 출력을 분류 (env/deps/git/instructions/unknown)
- env: workspace 디렉토리 복구
- deps: go mod tidy / npm install
- git: checkout main + pull
- 1회 수리 → 재시도 → 실패 시 에스컬레이션
- 5분 쿨다운으로 무한루프 방지

### 에스컬레이션
- `POST /api/escalate` — dal이 실패 보고
- `GET /api/escalations` — 미해결 목록 조회
- `POST /api/escalations/{id}/resolve` — 해결 처리
- Claude Code에서 `curl dalcenter/api/escalations`로 확인

### 테스트
- classifyTaskError 8개 패턴 테스트
- selfRepair 쿨다운/unknown 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)