### PR TITLE
feat: pipeline commands (restart, task, image)

### DIFF
--- a/cmd/dalcenter/cmd_pipeline.go
+++ b/cmd/dalcenter/cmd_pipeline.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dalsoop/dalcenter/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+// --- restart ---
+
+func newRestartCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "restart <dal>",
+		Short: "Restart a dal (sleep + wake — applies dal.cue changes)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			name := args[0]
+
+			// Sleep (ignore error if not running)
+			if _, err := client.Sleep(name); err != nil {
+				fmt.Printf("[restart] %s was not running, starting fresh\n", name)
+			} else {
+				fmt.Printf("[restart] %s stopped\n", name)
+			}
+
+			// Brief pause for container cleanup
+			time.Sleep(2 * time.Second)
+
+			// Wake
+			result, err := client.Wake(name)
+			if err != nil {
+				return fmt.Errorf("wake failed: %w", err)
+			}
+			cid := result["container_id"]
+			if len(cid) > 12 {
+				cid = cid[:12]
+			}
+			fmt.Printf("[restart] %s started (container=%s)\n", name, cid)
+			if w, ok := result["warnings"]; ok && w != "" {
+				fmt.Printf("[restart] ⚠️  %s\n", w)
+			}
+			return nil
+		},
+	}
+}
+
+// --- task ---
+
+func newTaskCmd() *cobra.Command {
+	var async bool
+	var poll bool
+	cmd := &cobra.Command{
+		Use:   "task <dal> <prompt>",
+		Short: "Execute a task directly in a dal container",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			dal := args[0]
+			task := strings.Join(args[1:], " ")
+
+			result, err := client.Task(dal, task, async)
+			if err != nil {
+				return err
+			}
+
+			if async {
+				fmt.Printf("[task] dispatched: %s (dal=%s)\n", result.ID, dal)
+				if !poll {
+					return nil
+				}
+				// Poll until done
+				fmt.Print("[task] waiting")
+				for {
+					time.Sleep(5 * time.Second)
+					fmt.Print(".")
+					r, err := client.TaskStatus(result.ID)
+					if err != nil {
+						return err
+					}
+					if r.Status != "running" {
+						fmt.Println()
+						printTaskResult(r)
+						return nil
+					}
+				}
+			}
+
+			// Synchronous result
+			printTaskResult(result)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&async, "async", false, "Run task asynchronously")
+	cmd.Flags().BoolVar(&poll, "poll", false, "Wait for async task to complete (implies --async)")
+	return cmd
+}
+
+func printTaskResult(r *daemon.TaskResult) {
+	if r.Status == "done" {
+		fmt.Println(r.Output)
+	} else if r.Status == "failed" {
+		fmt.Fprintf(os.Stderr, "[task] failed: %s\n", r.Error)
+		if r.Output != "" {
+			fmt.Println(r.Output)
+		}
+		os.Exit(1)
+	} else {
+		fmt.Printf("[task] status: %s\n", r.Status)
+	}
+}
+
+// --- task-status ---
+
+func newTaskStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "task-status <task-id>",
+		Short: "Check status of a direct task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			r, err := client.TaskStatus(args[0])
+			if err != nil {
+				return err
+			}
+			printTaskResult(r)
+			return nil
+		},
+	}
+}
+
+// --- task-list ---
+
+func newTaskListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "task-list",
+		Short: "List all tracked tasks",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			tasks, err := client.TaskList()
+			if err != nil {
+				return err
+			}
+			if len(tasks) == 0 {
+				fmt.Println("No tasks")
+				return nil
+			}
+			fmt.Printf("%-12s %-10s %-10s %s\n", "ID", "DAL", "STATUS", "TASK")
+			fmt.Println(strings.Repeat("-", 70))
+			for _, t := range tasks {
+				task := t.Task
+				if len(task) > 40 {
+					task = task[:40] + "..."
+				}
+				fmt.Printf("%-12s %-10s %-10s %s\n", t.ID, t.Dal, t.Status, task)
+			}
+			return nil
+		},
+	}
+}
+
+// --- image ---
+
+func newImageCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage dal Docker images",
+	}
+	cmd.AddCommand(newImageListCmd(), newImageBuildCmd())
+	return cmd
+}
+
+func newImageListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List available dalcenter Docker images",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := exec.Command("docker", "images", "--filter", "reference=dalcenter/*",
+				"--format", "{{.Repository}}:{{.Tag}}\t{{.Size}}\t{{.CreatedSince}}").CombinedOutput()
+			if err != nil {
+				return fmt.Errorf("docker images: %w", err)
+			}
+			output := strings.TrimSpace(string(out))
+			if output == "" {
+				fmt.Println("No dalcenter images found")
+				return nil
+			}
+			fmt.Printf("%-30s %-10s %s\n", "IMAGE", "SIZE", "CREATED")
+			fmt.Println(strings.Repeat("-", 60))
+			for _, line := range strings.Split(output, "\n") {
+				parts := strings.SplitN(line, "\t", 3)
+				if len(parts) == 3 {
+					fmt.Printf("%-30s %-10s %s\n", parts[0], parts[1], parts[2])
+				}
+			}
+			return nil
+		},
+	}
+}
+
+func newImageBuildCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "build <dockerfile-tag>",
+		Short: "Build a dalcenter Docker image (e.g., 'rust' builds claude-rust.Dockerfile)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			tag := args[0]
+
+			// Find Dockerfile directory
+			root := localdalRoot()
+			// Look for dockerfiles relative to repo root (parent of .dal)
+			repoRoot := filepath.Dir(root)
+			dockerfilesDir := filepath.Join(repoRoot, "dockerfiles")
+			if _, err := os.Stat(dockerfilesDir); err != nil {
+				return fmt.Errorf("dockerfiles directory not found at %s", dockerfilesDir)
+			}
+
+			// Map tag to Dockerfile: "rust" → "claude-rust.Dockerfile"
+			dockerfile := filepath.Join(dockerfilesDir, fmt.Sprintf("claude-%s.Dockerfile", tag))
+			if _, err := os.Stat(dockerfile); err != nil {
+				// Try exact name
+				dockerfile = filepath.Join(dockerfilesDir, fmt.Sprintf("%s.Dockerfile", tag))
+				if _, err := os.Stat(dockerfile); err != nil {
+					return fmt.Errorf("no Dockerfile found for tag %q", tag)
+				}
+			}
+
+			imageName := fmt.Sprintf("dalcenter/claude:%s", tag)
+			fmt.Printf("[image] building %s from %s\n", imageName, filepath.Base(dockerfile))
+
+			c := exec.Command("docker", "build", "-f", dockerfile, "-t", imageName, dockerfilesDir)
+			c.Stdout = os.Stdout
+			c.Stderr = os.Stderr
+			if err := c.Run(); err != nil {
+				return fmt.Errorf("build failed: %w", err)
+			}
+			fmt.Printf("[image] ✓ %s built successfully\n", imageName)
+			return nil
+		},
+	}
+}

--- a/cmd/dalcenter/main.go
+++ b/cmd/dalcenter/main.go
@@ -18,11 +18,16 @@ func main() {
 		newValidateCmd(),
 		newWakeCmd(),
 		newSleepCmd(),
+		newRestartCmd(),
 		newSyncCmd(),
 		newPsCmd(),
 		newStatusCmd(),
 		newLogsCmd(),
 		newAttachCmd(),
+		newTaskCmd(),
+		newTaskStatusCmd(),
+		newTaskListCmd(),
+		newImageCmd(),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -162,3 +162,67 @@ func (c *Client) postAny(path string) (map[string]any, error) {
 	}
 	return result, nil
 }
+
+// TaskResult holds the response from a direct task execution.
+type TaskResult struct {
+	ID     string `json:"task_id,omitempty"`
+	Status string `json:"status"`
+	// Full result fields (when polling)
+	Dal    string `json:"dal,omitempty"`
+	Task   string `json:"task,omitempty"`
+	Output string `json:"output,omitempty"`
+	Error  string `json:"error,omitempty"`
+}
+
+// Task submits a direct task to a dal container. If async=true, returns immediately with a task ID.
+func (c *Client) Task(dal, task string, async bool) (*TaskResult, error) {
+	body := fmt.Sprintf(`{"dal":%q,"task":%q,"async":%t}`, dal, task, async)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task failed: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// TaskStatus polls a task by ID.
+func (c *Client) TaskStatus(id string) (*TaskResult, error) {
+	resp, err := c.http.Get(c.baseURL + "/api/task/" + id)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task not found: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// TaskList returns all tracked tasks.
+func (c *Client) TaskList() ([]TaskResult, error) {
+	resp, err := c.http.Get(c.baseURL + "/api/tasks")
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	var results []TaskResult
+	json.NewDecoder(resp.Body).Decode(&results)
+	return results, nil
+}


### PR DESCRIPTION
## Summary
dal 라이프사이클을 CLI로 관리하는 파이프라인 커맨드 추가:

```bash
# dal 재시작 (dal.cue 변경사항 반영)
dalcenter restart leader

# dal에 직접 task 실행
dalcenter task leader "go test ./... 돌려봐"

# 비동기 + 완료 대기
dalcenter task --async --poll leader "이슈 #481 구현해줘"

# task 상태 확인
dalcenter task-status task-0001
dalcenter task-list

# Docker 이미지 관리
dalcenter image list
dalcenter image build rust
```

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./...` 전체 통과
- [ ] `dalcenter restart leader` 로 leader 재기동 확인
- [ ] `dalcenter task leader "echo hello"` 동기 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)