### PR TITLE
feat: dal claims system

### DIFF
--- a/cmd/dalcenter/cmd_claims.go
+++ b/cmd/dalcenter/cmd_claims.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/dalsoop/dalcenter/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func newClaimsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "claims",
+		Short: "Manage dal claims and improvement requests",
+	}
+	cmd.AddCommand(
+		newClaimsListCmd(),
+		newClaimsRespondCmd(),
+	)
+	return cmd
+}
+
+func newClaimsListCmd() *cobra.Command {
+	var status string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List claims from dals",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			claims, err := client.Claims(status)
+			if err != nil {
+				return err
+			}
+			if len(claims) == 0 {
+				if status != "" {
+					fmt.Printf("No %s claims\n", status)
+				} else {
+					fmt.Println("No claims")
+				}
+				return nil
+			}
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(w, "ID\tDAL\tTYPE\tSTATUS\tTITLE")
+			fmt.Fprintln(w, strings.Repeat("-", 80))
+			for _, c := range claims {
+				title := c.Title
+				if len(title) > 40 {
+					title = title[:40] + "..."
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", c.ID, c.Dal, c.Type, c.Status, title)
+			}
+			w.Flush()
+			fmt.Printf("\nTotal: %d claim(s)\n", len(claims))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&status, "status", "", "Filter by status: open|acknowledged|resolved|rejected")
+	return cmd
+}
+
+func newClaimsRespondCmd() *cobra.Command {
+	var status, response string
+	cmd := &cobra.Command{
+		Use:   "respond <claim-id>",
+		Short: "Respond to a dal claim",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			if err := client.ClaimRespond(args[0], status, response); err != nil {
+				return err
+			}
+			fmt.Printf("[claims] %s → %s\n", args[0], status)
+			if response != "" {
+				fmt.Printf("[claims] response: %s\n", response)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&status, "status", "acknowledged", "Response status: acknowledged|resolved|rejected")
+	cmd.Flags().StringVar(&response, "response", "", "Response message to dal")
+	return cmd
+}

--- a/cmd/dalcenter/main.go
+++ b/cmd/dalcenter/main.go
@@ -27,6 +27,7 @@ func main() {
 		newTaskCmd(),
 		newTaskStatusCmd(),
 		newTaskListCmd(),
+		newClaimsCmd(),
 		newImageCmd(),
 	)
 

--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -192,6 +192,10 @@ func runAgentLoop(dalName string) error {
 				})
 				escalateToHost(dalName, prompt, output, string(class))
 				daemon.DispatchTaskFailed(dalName, truncate(prompt, 200), err.Error(), len(output))
+				// Auto-claim for environment/blocked issues
+				if class == ErrClassEnv || class == ErrClassDeps {
+					autoFileClaim(dalName, class, prompt, output)
+				}
 				continue
 			}
 		}

--- a/cmd/dalcli/main.go
+++ b/cmd/dalcli/main.go
@@ -17,7 +17,7 @@ func main() {
 		Short: fmt.Sprintf("Dal CLI for member dal (%s)", dalName),
 	}
 
-	root.AddCommand(statusCmd(dalName), psCmd(), reportCmd(dalName), runCmd(dalName))
+	root.AddCommand(statusCmd(dalName), psCmd(), reportCmd(dalName), claimCmd(dalName), runCmd(dalName))
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -82,6 +82,45 @@ func psCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func claimCmd(dalName string) *cobra.Command {
+	var claimType, detail, context string
+	cmd := &cobra.Command{
+		Use:   "claim <title>",
+		Short: "Submit a claim/improvement request to the host",
+		Long: `Submit feedback to the host operator.
+
+Types:
+  bug          — something broken
+  improvement  — suggestion for better tooling
+  blocked      — can't proceed without host action
+  env          — environment issue (missing tool, auth, disk)
+
+Examples:
+  dalcli claim --type bug "cargo not installed in container"
+  dalcli claim --type improvement "need --timeout flag for task execution"
+  dalcli claim --type blocked --detail "GH_TOKEN not set, can't push" "GitHub auth missing"
+  dalcli claim --type env "disk full, can't build Rust image"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := daemon.NewClient()
+			if err != nil {
+				return err
+			}
+			title := args[0]
+			result, err := client.Claim(dalName, claimType, title, detail, context)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("[claim] submitted: %s (%s) — %s\n", result.ID, claimType, title)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&claimType, "type", "improvement", "Claim type: bug|improvement|blocked|env")
+	cmd.Flags().StringVar(&detail, "detail", "", "Detailed description")
+	cmd.Flags().StringVar(&context, "context", "", "Task or repo context")
+	return cmd
 }
 
 func reportCmd(dalName string) *cobra.Command {

--- a/cmd/dalcli/self_repair.go
+++ b/cmd/dalcli/self_repair.go
@@ -173,6 +173,49 @@ func selfRepair(task, output string, taskErr error) (shouldRetry bool, fix strin
 	return false, ""
 }
 
+// autoFileClaim creates a claim when environment/dependency issues are detected.
+func autoFileClaim(dalName string, class ErrorClass, task, output string) {
+	dcURL := os.Getenv("DALCENTER_URL")
+	if dcURL == "" {
+		dcURL = "http://host.docker.internal:11190"
+	}
+
+	claimType := "env"
+	title := "환경 문제 감지"
+	if class == ErrClassDeps {
+		claimType = "env"
+		title = "의존성 문제 감지"
+	}
+
+	// Extract key error line from output
+	detail := extractErrorSummary(output)
+	body := fmt.Sprintf(`{"dal":%q,"type":%q,"title":%q,"detail":%q,"context":%q}`,
+		dalName, claimType, title, detail, truncate(task, 200))
+	resp, err := http.Post(dcURL+"/api/claim", "application/json", strings.NewReader(body))
+	if err != nil {
+		log.Printf("[claim] failed to file: %v", err)
+		return
+	}
+	resp.Body.Close()
+	log.Printf("[claim] auto-filed: dal=%s type=%s", dalName, claimType)
+}
+
+// extractErrorSummary picks the most useful line from error output.
+func extractErrorSummary(output string) string {
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "error") || strings.Contains(lower, "not found") ||
+			strings.Contains(lower, "permission denied") || strings.Contains(lower, "cannot") {
+			return strings.TrimSpace(line)
+		}
+	}
+	if len(output) > 200 {
+		return output[:200]
+	}
+	return output
+}
+
 // escalateToHost reports a task failure to the dalcenter daemon for tracking.
 func escalateToHost(dalName, task, output, errorClass string) {
 	dcURL := os.Getenv("DALCENTER_URL")

--- a/internal/daemon/claim.go
+++ b/internal/daemon/claim.go
@@ -1,0 +1,211 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// ClaimType categorizes what kind of feedback a dal is providing.
+type ClaimType string
+
+const (
+	ClaimBug         ClaimType = "bug"         // something broken
+	ClaimImprovement ClaimType = "improvement" // suggestion for better tooling
+	ClaimBlocked     ClaimType = "blocked"     // can't proceed without host action
+	ClaimEnv         ClaimType = "env"         // environment issue (missing tool, auth, disk)
+)
+
+// Claim represents feedback from a dal to the host.
+type Claim struct {
+	ID        string    `json:"id"`
+	Dal       string    `json:"dal"`
+	Type      ClaimType `json:"type"`
+	Title     string    `json:"title"`
+	Detail    string    `json:"detail"`
+	Context   string    `json:"context,omitempty"` // task/repo context
+	Timestamp time.Time `json:"timestamp"`
+	Status    string    `json:"status"` // "open", "acknowledged", "resolved", "rejected"
+	Response  string    `json:"response,omitempty"`
+	RespondAt *time.Time `json:"responded_at,omitempty"`
+}
+
+type claimStore struct {
+	mu    sync.RWMutex
+	items []Claim
+	seq   int
+}
+
+const maxClaims = 200
+
+func newClaimStore() *claimStore {
+	return &claimStore{items: make([]Claim, 0)}
+}
+
+func (s *claimStore) Add(dal string, claimType ClaimType, title, detail, context string) Claim {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.seq++
+
+	if len(detail) > 2048 {
+		detail = detail[:2048]
+	}
+	if len(title) > 200 {
+		title = title[:200]
+	}
+
+	c := Claim{
+		ID:        fmt.Sprintf("claim-%04d", s.seq),
+		Dal:       dal,
+		Type:      claimType,
+		Title:     title,
+		Detail:    detail,
+		Context:   context,
+		Timestamp: time.Now().UTC(),
+		Status:    "open",
+	}
+	s.items = append(s.items, c)
+
+	if len(s.items) > maxClaims {
+		s.items = s.items[len(s.items)-maxClaims:]
+	}
+	return c
+}
+
+func (s *claimStore) List(status string) []Claim {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []Claim
+	for _, c := range s.items {
+		if status == "" || c.Status == status {
+			result = append(result, c)
+		}
+	}
+	return result
+}
+
+func (s *claimStore) Respond(id, status, response string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := range s.items {
+		if s.items[i].ID == id {
+			s.items[i].Status = status
+			s.items[i].Response = response
+			now := time.Now().UTC()
+			s.items[i].RespondAt = &now
+			return true
+		}
+	}
+	return false
+}
+
+func (s *claimStore) Get(id string) *Claim {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, c := range s.items {
+		if c.ID == id {
+			return &c
+		}
+	}
+	return nil
+}
+
+// --- HTTP handlers ---
+
+// POST /api/claim — dal submits a claim
+func (d *Daemon) handleClaim(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		Dal     string `json:"dal"`
+		Type    string `json:"type"`
+		Title   string `json:"title"`
+		Detail  string `json:"detail"`
+		Context string `json:"context"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Dal == "" || req.Title == "" {
+		http.Error(w, "dal and title are required", http.StatusBadRequest)
+		return
+	}
+
+	claimType := ClaimType(req.Type)
+	switch claimType {
+	case ClaimBug, ClaimImprovement, ClaimBlocked, ClaimEnv:
+	default:
+		claimType = ClaimImprovement
+	}
+
+	claim := d.claims.Add(req.Dal, claimType, req.Title, req.Detail, req.Context)
+
+	// Webhook notification
+	dispatchWebhook(WebhookEvent{
+		Event:     "claim",
+		Dal:       req.Dal,
+		Task:      req.Title,
+		Error:     string(claimType) + ": " + req.Detail,
+		Timestamp: claim.Timestamp.Format(time.RFC3339),
+	})
+
+	respondJSON(w, http.StatusOK, claim)
+}
+
+// GET /api/claims?status=open — list claims
+func (d *Daemon) handleClaims(w http.ResponseWriter, r *http.Request) {
+	status := r.URL.Query().Get("status")
+	items := d.claims.List(status)
+	if items == nil {
+		items = []Claim{}
+	}
+	respondJSON(w, http.StatusOK, map[string]any{
+		"claims": items,
+		"count":  len(items),
+	})
+}
+
+// GET /api/claims/{id} — get single claim
+func (d *Daemon) handleClaimGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	claim := d.claims.Get(id)
+	if claim == nil {
+		http.Error(w, "claim not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, claim)
+}
+
+// POST /api/claims/{id}/respond — host responds to a claim
+func (d *Daemon) handleClaimRespond(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	id := r.PathValue("id")
+	var req struct {
+		Status   string `json:"status"`   // "acknowledged", "resolved", "rejected"
+		Response string `json:"response"` // human response text
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	switch req.Status {
+	case "acknowledged", "resolved", "rejected":
+	default:
+		http.Error(w, "status must be acknowledged/resolved/rejected", http.StatusBadRequest)
+		return
+	}
+
+	if d.claims.Respond(id, req.Status, req.Response) {
+		respondJSON(w, http.StatusOK, map[string]string{"id": id, "status": req.Status})
+	} else {
+		http.Error(w, "claim not found", http.StatusNotFound)
+	}
+}

--- a/internal/daemon/claim_test.go
+++ b/internal/daemon/claim_test.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestClaimStore_Add(t *testing.T) {
+	s := newClaimStore()
+	c := s.Add("dev", ClaimBug, "cargo not found", "command not found: cargo", "build task")
+	if c.ID != "claim-0001" {
+		t.Errorf("expected claim-0001, got %s", c.ID)
+	}
+	if c.Status != "open" {
+		t.Errorf("expected open, got %s", c.Status)
+	}
+	if c.Type != ClaimBug {
+		t.Errorf("expected bug, got %s", c.Type)
+	}
+}
+
+func TestClaimStore_List(t *testing.T) {
+	s := newClaimStore()
+	s.Add("dev", ClaimBug, "bug1", "", "")
+	s.Add("leader", ClaimImprovement, "idea1", "", "")
+
+	all := s.List("")
+	if len(all) != 2 {
+		t.Errorf("expected 2, got %d", len(all))
+	}
+
+	open := s.List("open")
+	if len(open) != 2 {
+		t.Errorf("expected 2 open, got %d", len(open))
+	}
+}
+
+func TestClaimStore_Respond(t *testing.T) {
+	s := newClaimStore()
+	c := s.Add("dev", ClaimBlocked, "need auth", "", "")
+	if !s.Respond(c.ID, "resolved", "GH_TOKEN added") {
+		t.Error("respond should return true")
+	}
+	got := s.Get(c.ID)
+	if got.Status != "resolved" {
+		t.Errorf("expected resolved, got %s", got.Status)
+	}
+	if got.Response != "GH_TOKEN added" {
+		t.Errorf("expected response text, got %q", got.Response)
+	}
+}
+
+func TestClaimStore_RespondNotFound(t *testing.T) {
+	s := newClaimStore()
+	if s.Respond("claim-9999", "resolved", "") {
+		t.Error("should return false for missing claim")
+	}
+}
+
+func TestClaimStore_FilterByStatus(t *testing.T) {
+	s := newClaimStore()
+	s.Add("dev", ClaimBug, "bug1", "", "")
+	c2 := s.Add("dev", ClaimBug, "bug2", "", "")
+	s.Respond(c2.ID, "resolved", "fixed")
+
+	open := s.List("open")
+	if len(open) != 1 {
+		t.Errorf("expected 1 open, got %d", len(open))
+	}
+	resolved := s.List("resolved")
+	if len(resolved) != 1 {
+		t.Errorf("expected 1 resolved, got %d", len(resolved))
+	}
+}
+
+func TestHandleClaim_Post(t *testing.T) {
+	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	body := `{"dal":"dev","type":"bug","title":"cargo missing","detail":"command not found"}`
+	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	d.handleClaim(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+	var claim Claim
+	json.NewDecoder(w.Body).Decode(&claim)
+	if claim.ID != "claim-0001" {
+		t.Errorf("expected claim-0001, got %s", claim.ID)
+	}
+}
+
+func TestHandleClaims_Empty(t *testing.T) {
+	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	req := httptest.NewRequest("GET", "/api/claims", nil)
+	w := httptest.NewRecorder()
+	d.handleClaims(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestHandleClaim_MissingFields(t *testing.T) {
+	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	body := `{"dal":"","title":""}`
+	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	d.handleClaim(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestClaimStore_Eviction(t *testing.T) {
+	s := newClaimStore()
+	for i := 0; i < 210; i++ {
+		s.Add("dev", ClaimBug, "bug", "", "")
+	}
+	all := s.List("")
+	if len(all) > maxClaims {
+		t.Errorf("expected max %d, got %d", maxClaims, len(all))
+	}
+}

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -163,6 +163,76 @@ func (c *Client) postAny(path string) (map[string]any, error) {
 	return result, nil
 }
 
+// ClaimResult holds the response from submitting a claim.
+type ClaimResult struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+// Claim submits feedback from a dal to the host.
+func (c *Client) Claim(dal, claimType, title, detail, ctx string) (*ClaimResult, error) {
+	body := fmt.Sprintf(`{"dal":%q,"type":%q,"title":%q,"detail":%q,"context":%q}`,
+		dal, claimType, title, detail, ctx)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/claim", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("claim failed: %s", strings.TrimSpace(string(b)))
+	}
+	var result ClaimResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// Claims lists claims with optional status filter.
+func (c *Client) Claims(status string) ([]Claim, error) {
+	url := c.baseURL + "/api/claims"
+	if status != "" {
+		url += "?status=" + status
+	}
+	resp, err := c.http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	var result struct {
+		Claims []Claim `json:"claims"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result.Claims, nil
+}
+
+// ClaimRespond responds to a claim (host action).
+func (c *Client) ClaimRespond(id, status, response string) error {
+	body := fmt.Sprintf(`{"status":%q,"response":%q}`, status, response)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/claims/"+id+"/respond", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("respond failed: %s", strings.TrimSpace(string(b)))
+	}
+	return nil
+}
+
 // TaskResult holds the response from a direct task execution.
 type TaskResult struct {
 	ID     string `json:"task_id,omitempty"`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -35,6 +35,7 @@ type Daemon struct {
 	containers   map[string]*Container // dal name -> container
 	mu           sync.RWMutex
 	escalations  *escalationStore
+	claims       *claimStore
 	tasks        *taskStore
 	registry     *Registry
 }
@@ -65,6 +66,7 @@ func New(addr, localdalRoot, serviceRepo string, mm *MattermostConfig) *Daemon {
 		apiToken:     token,
 		containers:   make(map[string]*Container),
 		escalations:  newEscalationStore(),
+		claims:       newClaimStore(),
 		tasks:        newTaskStore(),
 		registry:     newRegistry(serviceRepo),
 	}
@@ -160,6 +162,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/task", d.requireAuth(d.handleTask))
 	mux.HandleFunc("GET /api/task/{id}", d.handleTaskStatus)
 	mux.HandleFunc("GET /api/tasks", d.handleTaskList)
+	// Claims — dal feedback to host
+	mux.HandleFunc("POST /api/claim", d.handleClaim)
+	mux.HandleFunc("GET /api/claims", d.handleClaims)
+	mux.HandleFunc("GET /api/claims/{id}", d.handleClaimGet)
+	mux.HandleFunc("POST /api/claims/{id}/respond", d.requireAuth(d.handleClaimRespond))
 	// Escalation endpoints
 	mux.HandleFunc("POST /api/escalate", d.requireAuth(d.handleEscalate))
 	mux.HandleFunc("GET /api/escalations", d.handleEscalations)


### PR DESCRIPTION
## Summary
dal ↔ host 양방향 피드백 루프.

### dal이 사용
```bash
dalcli claim --type bug "cargo not installed in container"
dalcli claim --type blocked --detail "GH_TOKEN not set" "GitHub auth missing"
```

### host가 관리
```bash
dalcenter claims list --status open
dalcenter claims respond claim-0001 --status resolved --response "rust 이미지 빌드 완료"
```

### 자동 감지
- task 실패 시 `env`/`deps` 에러 → 자동 claim 생성
- webhook dispatch 연동

## Test plan
- [x] `go test ./...` 전체 통과
- [ ] `dalcli claim` 컨테이너 내 실행 확인
- [ ] `dalcenter claims list` 조회 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)