### PR TITLE
feat: persist claims/escalations to disk

### DIFF
--- a/internal/daemon/claim.go
+++ b/internal/daemon/claim.go
@@ -33,15 +33,50 @@ type Claim struct {
 }
 
 type claimStore struct {
-	mu    sync.RWMutex
-	items []Claim
-	seq   int
+	mu       sync.RWMutex
+	items    []Claim
+	seq      int
+	filePath string
 }
 
 const maxClaims = 200
 
 func newClaimStore() *claimStore {
 	return &claimStore{items: make([]Claim, 0)}
+}
+
+// newClaimStoreWithFile creates a persistent claim store.
+func newClaimStoreWithFile(path string) *claimStore {
+	s := &claimStore{items: make([]Claim, 0), filePath: path}
+	s.load()
+	return s
+}
+
+func (s *claimStore) load() {
+	if s.filePath == "" {
+		return
+	}
+	var items []Claim
+	if err := loadJSON(s.filePath, &items); err != nil {
+		return // first run or corrupt — start fresh
+	}
+	s.items = items
+	// Restore seq from highest ID
+	for _, c := range items {
+		var n int
+		fmt.Sscanf(c.ID, "claim-%d", &n)
+		if n > s.seq {
+			s.seq = n
+		}
+	}
+}
+
+func (s *claimStore) save() {
+	if s.filePath == "" {
+		return
+	}
+	// caller holds lock
+	persistJSON(s.filePath, s.items, nil)
 }
 
 func (s *claimStore) Add(dal string, claimType ClaimType, title, detail, context string) Claim {
@@ -71,6 +106,7 @@ func (s *claimStore) Add(dal string, claimType ClaimType, title, detail, context
 	if len(s.items) > maxClaims {
 		s.items = s.items[len(s.items)-maxClaims:]
 	}
+	s.save()
 	return c
 }
 
@@ -95,6 +131,7 @@ func (s *claimStore) Respond(id, status, response string) bool {
 			s.items[i].Response = response
 			now := time.Now().UTC()
 			s.items[i].RespondAt = &now
+			s.save()
 			return true
 		}
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -65,8 +65,8 @@ func New(addr, localdalRoot, serviceRepo string, mm *MattermostConfig) *Daemon {
 		mm:           mm,
 		apiToken:     token,
 		containers:   make(map[string]*Container),
-		escalations:  newEscalationStore(),
-		claims:       newClaimStore(),
+		escalations:  newEscalationStoreWithFile(filepath.Join(dataDir(serviceRepo), "escalations.json")),
+		claims:       newClaimStoreWithFile(filepath.Join(dataDir(serviceRepo), "claims.json")),
 		tasks:        newTaskStore(),
 		registry:     newRegistry(serviceRepo),
 	}

--- a/internal/daemon/escalation.go
+++ b/internal/daemon/escalation.go
@@ -20,17 +20,41 @@ type Escalation struct {
 	ResolvedAt   *time.Time `json:"resolved_at,omitempty"`
 }
 
-// escalationStore is an in-memory store for escalations.
+// escalationStore is a persistent store for escalations.
 type escalationStore struct {
-	mu    sync.RWMutex
-	items []Escalation
-	seq   int
+	mu       sync.RWMutex
+	items    []Escalation
+	seq      int
+	filePath string
 }
 
 const maxEscalations = 100
 
 func newEscalationStore() *escalationStore {
 	return &escalationStore{items: make([]Escalation, 0)}
+}
+
+func newEscalationStoreWithFile(path string) *escalationStore {
+	s := &escalationStore{items: make([]Escalation, 0), filePath: path}
+	var items []Escalation
+	if err := loadJSON(path, &items); err == nil {
+		s.items = items
+		for _, e := range items {
+			var n int
+			fmt.Sscanf(e.ID, "esc-%d", &n)
+			if n > s.seq {
+				s.seq = n
+			}
+		}
+	}
+	return s
+}
+
+func (s *escalationStore) save() {
+	if s.filePath == "" {
+		return
+	}
+	persistJSON(s.filePath, s.items, nil)
 }
 
 func (s *escalationStore) Add(dal, task, errorClass, output string) Escalation {
@@ -61,6 +85,7 @@ func (s *escalationStore) Add(dal, task, errorClass, output string) Escalation {
 	if len(s.items) > maxEscalations {
 		s.items = s.items[len(s.items)-maxEscalations:]
 	}
+	s.save()
 	return esc
 }
 
@@ -84,6 +109,7 @@ func (s *escalationStore) Resolve(id string) bool {
 			s.items[i].Resolved = true
 			now := time.Now().UTC()
 			s.items[i].ResolvedAt = &now
+			s.save()
 			return true
 		}
 	}

--- a/internal/daemon/persist.go
+++ b/internal/daemon/persist.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// dataDir returns the persistent data directory for a service repo.
+// Creates .dal/data/ if it doesn't exist.
+func dataDir(serviceRepo string) string {
+	dir := filepath.Join(serviceRepo, ".dal", "data")
+	os.MkdirAll(dir, 0o755)
+	return dir
+}
+
+// persistJSON writes data to a JSON file atomically.
+func persistJSON(path string, data any, mu *sync.RWMutex) {
+	if mu != nil {
+		mu.RLock()
+		defer mu.RUnlock()
+	}
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		log.Printf("[persist] marshal error for %s: %v", filepath.Base(path), err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		log.Printf("[persist] write error for %s: %v", filepath.Base(path), err)
+		return
+	}
+	os.Rename(tmp, path)
+}
+
+// loadJSON reads data from a JSON file.
+func loadJSON(path string, target any) error {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, target)
+}


### PR DESCRIPTION
## Summary
claims와 escalations를 `{service-repo}/.dal/data/` 디렉토리에 JSON으로 영속화.

- `claims.json` — dal 클레임/개선요청
- `escalations.json` — task 실패 에스컬레이션

daemon 재시작해도 데이터 유지. atomic write (tmp + rename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)