### PR TITLE
feat: isolated workspace mode (clone per dal)

### DIFF
--- a/internal/daemon/claim_test.go
+++ b/internal/daemon/claim_test.go
@@ -77,7 +77,7 @@ func TestClaimStore_FilterByStatus(t *testing.T) {
 }
 
 func TestHandleClaim_Post(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	body := `{"dal":"dev","type":"bug","title":"cargo missing","detail":"command not found"}`
 	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -93,7 +93,7 @@ func TestHandleClaim_Post(t *testing.T) {
 }
 
 func TestHandleClaims_Empty(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	req := httptest.NewRequest("GET", "/api/claims", nil)
 	w := httptest.NewRecorder()
 	d.handleClaims(w, req)
@@ -103,7 +103,7 @@ func TestHandleClaims_Empty(t *testing.T) {
 }
 
 func TestHandleClaim_MissingFields(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	body := `{"dal":"","title":""}`
 	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
 	w := httptest.NewRecorder()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -47,7 +47,8 @@ type Container struct {
 	Player      string `json:"player"`
 	Role        string `json:"role"`
 	ContainerID string `json:"container_id"`
-	Status      string `json:"status"` // "running", "stopped"
+	Status      string `json:"status"`    // "running", "stopped"
+	Workspace   string `json:"workspace"` // "shared" or "clone"
 	Skills      int    `json:"skills"`
 	BotToken    string `json:"-"` // Mattermost bot token
 }
@@ -305,6 +306,10 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	ws := dal.Workspace
+	if ws == "" {
+		ws = "shared"
+	}
 	d.mu.Lock()
 	d.containers[instanceName] = &Container{
 		DalName:     instanceName,
@@ -313,6 +318,7 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		Role:        dal.Role,
 		ContainerID: containerID,
 		Status:      "running",
+		Workspace:   ws,
 		Skills:      len(dal.Skills),
 		BotToken:    botToken,
 	}

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -136,8 +136,9 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 		"-w", containerWorkDir,
 	}
 
-	// Mount service repo as workspace
-	if serviceRepo != "" {
+	// Mount service repo as workspace (shared mode) or leave empty for clone mode
+	isCloneMode := dal.Workspace == "clone"
+	if serviceRepo != "" && !isCloneMode {
 		args = append(args, "-v", fmt.Sprintf("%s:%s", serviceRepo, containerWorkDir))
 	}
 
@@ -274,7 +275,54 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 		log.Printf("[docker] warning: failed to inject dalcli: %v", err)
 	}
 
+	// Clone mode: git clone repo into container workspace
+	if isCloneMode && serviceRepo != "" {
+		repoURL := detectRepoURL(serviceRepo)
+		if repoURL != "" {
+			if err := cloneRepoInContainer(containerID, repoURL); err != nil {
+				w := fmt.Sprintf("workspace clone failed: %v (falling back to empty workspace)", err)
+				log.Printf("[docker] %s", w)
+				warnings = append(warnings, w)
+			} else {
+				log.Printf("[docker] workspace: cloned %s into %s", repoURL, containerName)
+			}
+		} else {
+			w := "clone mode: could not detect repo URL, workspace is empty"
+			log.Printf("[docker] %s", w)
+			warnings = append(warnings, w)
+		}
+	}
+
 	return containerID, warnings, nil
+}
+
+// detectRepoURL gets the git remote URL from a local repo.
+func detectRepoURL(repoPath string) string {
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// cloneRepoInContainer runs git clone inside a running container.
+func cloneRepoInContainer(containerID, repoURL string) error {
+	// Clone into a temp dir, then move contents to /workspace
+	// (container may already have /workspace as WORKDIR)
+	script := fmt.Sprintf(
+		`git clone --depth=50 %s /tmp/_clone && `+
+			`cp -a /tmp/_clone/. /workspace/ && `+
+			`rm -rf /tmp/_clone && `+
+			`cd /workspace && git checkout main 2>/dev/null; true`,
+		repoURL,
+	)
+	cmd := exec.Command("docker", "exec", containerID, "bash", "-c", script)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
 }
 
 // resolveVeilKey resolves a VK: reference via veil CLI or localvault API.

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -65,7 +65,7 @@ func TestTaskStore_Eviction(t *testing.T) {
 }
 
 func TestHandleTask_NoDal(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	body := `{"dal":"nonexistent","task":"hello"}`
 	req := httptest.NewRequest("POST", "/api/task", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -76,7 +76,7 @@ func TestHandleTask_NoDal(t *testing.T) {
 }
 
 func TestHandleTask_MissingFields(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	body := `{"dal":"","task":""}`
 	req := httptest.NewRequest("POST", "/api/task", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -87,7 +87,7 @@ func TestHandleTask_MissingFields(t *testing.T) {
 }
 
 func TestHandleTaskList_Empty(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	req := httptest.NewRequest("GET", "/api/tasks", nil)
 	w := httptest.NewRecorder()
 	d.handleTaskList(w, req)
@@ -100,7 +100,7 @@ func TestHandleTaskList_Empty(t *testing.T) {
 }
 
 func TestHandleTaskStatus_NotFound(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	req := httptest.NewRequest("GET", "/api/task/task-9999", nil)
 	req.SetPathValue("id", "task-9999")
 	w := httptest.NewRecorder()
@@ -120,7 +120,7 @@ func TestTruncateStr(t *testing.T) {
 }
 
 func TestMessageFallback_NoMM(t *testing.T) {
-	d := New(":0", "/tmp/test", "/tmp/repo", nil)
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	// No MM configured, no running dals → should return 503
 	body := `{"from":"host","message":"test"}`
 	req := httptest.NewRequest("POST", "/api/message", strings.NewReader(body))

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -29,6 +29,8 @@ type DalProfile struct {
 	GitEmail       string
 	GitHubToken    string // VeilKey ref or raw token
 	GeminiAPIKey   string // VeilKey ref, env: ref, or raw key
+	// Workspace mode
+	Workspace string // "shared" (default, bind mount) or "clone" (git clone per dal)
 	// Auto task
 	AutoTask     string // periodic task prompt (empty = disabled)
 	AutoInterval string // interval like "1h", "30m" (default: disabled)
@@ -201,6 +203,10 @@ func ReadDalCue(path, folderName string) (*DalProfile, error) {
 	}
 	if v := val.LookupPath(cue.ParsePath("gemini_api_key")); v.Exists() {
 		p.GeminiAPIKey, _ = v.String()
+	}
+	// Workspace mode
+	if v := val.LookupPath(cue.ParsePath("workspace")); v.Exists() {
+		p.Workspace, _ = v.String()
 	}
 	// Auto task
 	if v := val.LookupPath(cue.ParsePath("auto_task")); v.Exists() {


### PR DESCRIPTION
## Summary
dal.cue에 `workspace: "clone"` 설정 시 dal마다 독립 git clone 생성.

### Before (shared)
```
leader  ─┐
dev     ─┤─→ /root/repo (bind mount, 충돌 가능)
verifier─┘
```

### After (clone)
```
leader   → /workspace (자체 clone) → feat/cli-health
dev      → /workspace (자체 clone) → feat/cli-agent
verifier → /workspace (자체 clone) → main (go test)
```

### 사용법
```cue
// dal.cue
workspace: "clone"
player_version: "rust"
```

기본값은 `"shared"` (기존 bind mount 방식 유지).

## Test plan
- [x] `go test ./...` 전체 통과
- [ ] `workspace: "clone"` 설정 후 `dalcenter restart` — 독립 clone 확인
- [ ] 2개 dal이 서로 다른 브랜치에서 동시 작업 가능 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)