### PR TITLE
fix: .dal/ 전용 변경 시 PR 스킵 (#128)

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -257,6 +257,33 @@ func runAgentLoop(dalName string) error {
 	}
 }
 
+// isDalOnlyChanges returns true if every changed file in git porcelain output
+// is under the .dal/ directory. These are internal metadata changes that don't
+// need a PR.
+func isDalOnlyChanges(porcelainOutput string) bool {
+	lines := strings.Split(porcelainOutput, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		// git porcelain format: "XY filename" or "XY filename -> renamed"
+		// strip the two-char status prefix + space
+		file := line
+		if len(file) > 3 {
+			file = file[3:]
+		}
+		// handle renames: "old -> new"
+		if idx := strings.Index(file, " -> "); idx >= 0 {
+			file = file[idx+4:]
+		}
+		if !strings.HasPrefix(file, ".dal/") {
+			return false
+		}
+	}
+	return true
+}
+
 // autoGitWorkflow checks for file changes and creates a branch + commit + PR.
 func autoGitWorkflow(dalName string) string {
 	// Check if there are changes
@@ -269,6 +296,11 @@ func autoGitWorkflow(dalName string) string {
 
 	changes := strings.TrimSpace(string(statusOut))
 	log.Printf("[git] changes detected:\n%s", changes)
+
+	dalOnly := isDalOnlyChanges(changes)
+	if dalOnly {
+		log.Printf("[git] .dal/ only changes — will commit+push but skip PR")
+	}
 
 	// Create branch
 	branch := fmt.Sprintf("dal/%s/%d", dalName, time.Now().Unix())
@@ -289,8 +321,12 @@ func autoGitWorkflow(dalName string) string {
 	}
 
 	// Commit
-	commitMsg := fmt.Sprintf("feat: %s dal 자동 반영\n\n변경 파일:\n%s\n\nCo-Authored-By: dal-%s <dal-%s@dalcenter.local>",
-		dalName, changes, dalName, dalName)
+	prefix := "feat"
+	if dalOnly {
+		prefix = "auto"
+	}
+	commitMsg := fmt.Sprintf("%s: %s dal 자동 반영\n\n변경 파일:\n%s\n\nCo-Authored-By: dal-%s <dal-%s@dalcenter.local>",
+		prefix, dalName, changes, dalName, dalName)
 	if _, err := run("git", "commit", "-m", commitMsg); err != nil {
 		return fmt.Sprintf("⚠️ 커밋 실패: %v", err)
 	}
@@ -298,6 +334,12 @@ func autoGitWorkflow(dalName string) string {
 	// Push
 	if _, err := run("git", "push", "-u", "origin", branch); err != nil {
 		return fmt.Sprintf("⚠️ 푸시 실패: %v", err)
+	}
+
+	// Skip PR for .dal/-only changes (internal metadata, context sync, etc.)
+	if dalOnly {
+		run("git", "checkout", "main")
+		return fmt.Sprintf("✅ .dal/ 전용 변경 — 커밋+푸시 완료, PR 스킵\n브랜치: `%s`", branch)
 	}
 
 	// Create PR

--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -405,6 +405,33 @@ func TestMessageRouting_FreeFormFallback(t *testing.T) {
 	}
 }
 
+// ── isDalOnlyChanges ──
+
+func TestIsDalOnlyChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		want   bool
+	}{
+		{"dal only", " M .dal/context/foo.md\n M .dal/data/claims.json", true},
+		{"dal added", "?? .dal/context/new.md", true},
+		{"mixed", " M .dal/context/foo.md\n M cmd/dalcli/cmd_run.go", false},
+		{"no dal", " M README.md", false},
+		{"rename into dal", " R old.txt -> .dal/data/new.txt", true},
+		{"rename out of dal", " R .dal/old.txt -> cmd/new.txt", false},
+		{"empty", "", true},
+		{"single dal file", "A  .dal/spec.cue", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDalOnlyChanges(tt.input)
+			if got != tt.want {
+				t.Errorf("isDalOnlyChanges(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 // ── autoGitWorkflow branch naming ──
 
 func TestAutoGitWorkflow_BranchFormat(t *testing.T) {


### PR DESCRIPTION
## Summary
- `autoGitWorkflow()`에서 변경 파일이 모두 `.dal/` 하위인 경우 PR 생성을 스킵
- context sync, claims 등 내부 메타데이터 변경으로 인한 **PR 스팸 방지**
- `.dal/` 전용 변경은 커밋+푸시만 수행하고 커밋 prefix를 `auto:`로 변경

## Changes
- `isDalOnlyChanges()` 헬퍼 함수 추가 — git porcelain 출력 파싱, rename 처리 포함
- `autoGitWorkflow()` — dalOnly 판별 후 PR 생성 분기
- 테이블 드리븐 테스트 8케이스 추가

## Test plan
- [ ] `go test ./cmd/dalcli/ -run TestIsDalOnlyChanges` 통과 확인
- [ ] `.dal/` 전용 변경 시 PR 미생성 확인
- [ ] 혼합 변경 (`.dal/` + 코드) 시 기존대로 PR 생성 확인

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)