### PR TITLE
feat(daemon): task git diff 자동 검증 + decisions.md 공유 메모리

### DIFF
--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -213,6 +213,12 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 	instrDst := filepath.Join(home, instructionsFileName(dal.Player))
 	args = append(args, "-v", fmt.Sprintf("%s:%s:ro", instrSrc, instrDst))
 
+	// Mount decisions.md as shared team memory (read-write)
+	decisionsPath := filepath.Join(localdalRoot, "decisions.md")
+	if _, err := os.Stat(decisionsPath); err == nil {
+		args = append(args, "-v", fmt.Sprintf("%s:%s", decisionsPath, filepath.Join(containerWorkDir, "decisions.md")))
+	}
+
 	// Inject Claude Code settings.json for autoApprove (dal runs unattended)
 	if dal.Player == "claude" {
 		settingsJSON := `{"permissions":{"allow":["Bash(*)","Edit(*)","Write(*)","Read(*)","Glob(*)","Grep(*)","WebFetch(*)","WebSearch","Agent(*)"],"defaultMode":"autoApprove"}}`

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -21,6 +21,10 @@ type taskResult struct {
 	Status    string    `json:"status"` // "running", "done", "failed"
 	StartedAt time.Time `json:"started_at"`
 	DoneAt    *time.Time `json:"done_at,omitempty"`
+	// Post-task verification
+	GitDiff    string `json:"git_diff,omitempty"`    // workspace git diff after task
+	GitChanges int    `json:"git_changes,omitempty"` // number of files changed
+	Verified   string `json:"verified,omitempty"`    // "yes", "no_changes", "skipped"
 }
 
 // taskStore manages running and completed direct tasks.
@@ -218,7 +222,11 @@ func (d *Daemon) execTaskInContainer(c *Container, tr *taskResult) {
 	} else {
 		tr.Status = "done"
 		tr.Output = stdout.String()
-		log.Printf("[task] %s done (%d bytes)", tr.ID, len(tr.Output))
+
+		// Post-task verification: check git diff in workspace
+		verifyTaskChanges(c.ContainerID, tr)
+
+		log.Printf("[task] %s done (%d bytes, verified=%s, changes=%d)", tr.ID, len(tr.Output), tr.Verified, tr.GitChanges)
 
 		dispatchWebhook(WebhookEvent{
 			Event:      "task_complete",
@@ -227,6 +235,34 @@ func (d *Daemon) execTaskInContainer(c *Container, tr *taskResult) {
 			OutputSize: len(tr.Output),
 			Timestamp:  now.Format(time.RFC3339),
 		})
+	}
+}
+
+// verifyTaskChanges runs git diff inside the container to verify actual file changes.
+func verifyTaskChanges(containerID string, tr *taskResult) {
+	diffCmd := exec.Command("docker", "exec", containerID,
+		"bash", "-c", fmt.Sprintf("cd %s && git diff --stat HEAD 2>/dev/null; git diff --stat --cached HEAD 2>/dev/null; git status --porcelain 2>/dev/null", containerWorkDir))
+	diffOut, err := diffCmd.Output()
+	if err != nil {
+		tr.Verified = "skipped"
+		return
+	}
+
+	diff := strings.TrimSpace(string(diffOut))
+	if diff == "" {
+		tr.Verified = "no_changes"
+		tr.GitDiff = ""
+		tr.GitChanges = 0
+	} else {
+		tr.Verified = "yes"
+		tr.GitDiff = truncateStr(diff, 2000)
+		// Count changed files from porcelain output
+		for _, line := range strings.Split(diff, "\n") {
+			line = strings.TrimSpace(line)
+			if len(line) >= 2 && (line[0] == 'M' || line[0] == 'A' || line[0] == 'D' || line[0] == '?' || line[0] == 'R') {
+				tr.GitChanges++
+			}
+		}
 	}
 }
 

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -119,6 +119,53 @@ func TestTruncateStr(t *testing.T) {
 	}
 }
 
+func TestVerifyTaskChanges_NoContainer(t *testing.T) {
+	tr := &taskResult{ID: "test-001", Status: "done"}
+	verifyTaskChanges("nonexistent-container-id", tr)
+	if tr.Verified != "skipped" {
+		t.Errorf("expected skipped for invalid container, got %q", tr.Verified)
+	}
+}
+
+func TestTaskResult_VerifiedFields(t *testing.T) {
+	tr := &taskResult{
+		ID:         "test-002",
+		Verified:   "no_changes",
+		GitChanges: 0,
+	}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify JSON serialization includes verified field
+	if !strings.Contains(string(data), `"verified":"no_changes"`) {
+		t.Errorf("JSON should contain verified field: %s", data)
+	}
+	// git_diff should be omitted when empty
+	if strings.Contains(string(data), `"git_diff"`) {
+		t.Errorf("git_diff should be omitted when empty: %s", data)
+	}
+}
+
+func TestTaskResult_WithChanges(t *testing.T) {
+	tr := &taskResult{
+		ID:         "test-003",
+		Verified:   "yes",
+		GitDiff:    "M  README.md\nA  new-file.go",
+		GitChanges: 2,
+	}
+	data, err := json.Marshal(tr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"git_changes":2`) {
+		t.Errorf("expected git_changes:2 in JSON: %s", data)
+	}
+	if !strings.Contains(string(data), `"verified":"yes"`) {
+		t.Errorf("expected verified:yes in JSON: %s", data)
+	}
+}
+
 func TestMessageFallback_NoMM(t *testing.T) {
 	d := New(":0", "/tmp/test", t.TempDir(), nil)
 	// No MM configured, no running dals → should return 503

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -53,8 +53,28 @@ func Init(root string) error {
 			return fmt.Errorf("write dal.spec.cue: %w", err)
 		}
 	}
+
+	decisionsPath := filepath.Join(root, "decisions.md")
+	if _, err := os.Stat(decisionsPath); err != nil {
+		if err := os.WriteFile(decisionsPath, []byte(defaultDecisions), 0644); err != nil {
+			return fmt.Errorf("write decisions.md: %w", err)
+		}
+	}
 	return nil
 }
+
+const defaultDecisions = `# Decisions
+
+Architectural decisions and team agreements. All dals read this file.
+Leader appends new entries. Format:
+
+` + "```" + `
+## YYYY-MM-DD — Title
+- Decision: ...
+- Reason: ...
+- Affected: ...
+` + "```" + `
+`
 
 // CreateDal creates a new dal folder with dal.cue and instructions.md.
 func CreateDal(root, name, player string) (*DalProfile, error) {

--- a/internal/localdal/localdal_test.go
+++ b/internal/localdal/localdal_test.go
@@ -3,6 +3,7 @@ package localdal
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +17,37 @@ func TestInitCreatesStructure(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(root, "dal.spec.cue")); err != nil {
 		t.Fatal("dal.spec.cue missing")
+	}
+}
+
+func TestInitCreatesDecisionsMd(t *testing.T) {
+	root := t.TempDir()
+	if err := Init(root); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "decisions.md")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatal("decisions.md missing after init")
+	}
+	content, _ := os.ReadFile(path)
+	if !strings.Contains(string(content), "Architectural decisions") {
+		t.Error("decisions.md should contain template content")
+	}
+}
+
+func TestInitDecisionsMdIdempotent(t *testing.T) {
+	root := t.TempDir()
+	Init(root)
+
+	// Write custom content
+	path := filepath.Join(root, "decisions.md")
+	os.WriteFile(path, []byte("# Custom decisions\n"), 0644)
+
+	// Re-init should not overwrite
+	Init(root)
+	content, _ := os.ReadFile(path)
+	if string(content) != "# Custom decisions\n" {
+		t.Error("decisions.md should not be overwritten on re-init")
 	}
 }
 


### PR DESCRIPTION
## Summary
- task 완료 후 `verifyTaskChanges()`로 컨테이너 내 git diff 자동 수집
- `taskResult`에 `verified`, `git_diff`, `git_changes` 필드 추가
- `dalcenter init` 시 `.dal/decisions.md` 템플릿 생성
- wake 시 decisions.md를 workspace에 bind mount (모든 dal 공유)

## 해결하는 문제
- dal이 "수정 완료"라고 보고하지만 실제 파일 변경이 없는 환각 케이스 감지
- 팀 아키텍처 결정을 파일로 공유하여 dal 간 일관성 유지

## Test plan
- [x] `go build ./...` 빌드 성공
- [x] `go test ./internal/daemon/ ./internal/localdal/` 통과
- [x] verifyTaskChanges: 존재하지 않는 컨테이너 → skipped
- [x] taskResult JSON 직렬화: verified, git_changes 포함 확인
- [x] decisions.md: init 시 생성, 재실행 시 덮어쓰지 않음 (idempotent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)