### PR TITLE
fix(circuit-breaker): record failure on all provider errors

### DIFF
--- a/cmd/dalcli/circuit_breaker_edge_test.go
+++ b/cmd/dalcli/circuit_breaker_edge_test.go
@@ -1,0 +1,483 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ══════════════════════════════════════════════════════════════
+// Circuit Breaker: timing & boundary edge cases
+// ══════════════════════════════════════════════════════════════
+
+// Zero cooldown: open→half-open 즉시 전환
+func TestCB_ZeroCooldown(t *testing.T) {
+	cb := NewCircuitBreaker(1, 0)
+	cb.RecordFailure()
+	assertState(t, cb, "open", "after failure")
+
+	// cooldown=0 이면 ShouldFallback 호출 시 즉시 half-open
+	if cb.ShouldFallback() {
+		t.Error("zero cooldown should transition to half-open immediately")
+	}
+	assertState(t, cb, "half-open", "zero cooldown → immediate half-open")
+}
+
+// cooldown 정확히 경계에서의 동작
+func TestCB_CooldownBoundary(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.RecordFailure()
+
+	// 40ms: 아직 cooldown 내
+	time.Sleep(40 * time.Millisecond)
+	if !cb.ShouldFallback() {
+		t.Error("should still fallback before cooldown expires")
+	}
+	assertState(t, cb, "open", "before cooldown")
+
+	// 추가 20ms (총 60ms > 50ms cooldown)
+	time.Sleep(20 * time.Millisecond)
+	if cb.ShouldFallback() {
+		t.Error("should NOT fallback after cooldown expires")
+	}
+	assertState(t, cb, "half-open", "after cooldown")
+}
+
+// lastFailure가 half-open 실패 시 갱신되어 cooldown 리셋
+func TestCB_HalfOpenFailureResetsCooldown(t *testing.T) {
+	cb := NewCircuitBreaker(1, 50*time.Millisecond)
+	cb.RecordFailure()
+
+	time.Sleep(60 * time.Millisecond)
+	cb.ShouldFallback() // → half-open
+	cb.RecordFailure()  // → open (lastFailure 갱신됨)
+	assertState(t, cb, "open", "back to open")
+
+	// 즉시 체크: 새 cooldown이 시작되었으므로 fallback
+	if !cb.ShouldFallback() {
+		t.Error("cooldown should restart from half-open failure time")
+	}
+
+	// 새 cooldown 기다림
+	time.Sleep(60 * time.Millisecond)
+	if cb.ShouldFallback() {
+		t.Error("should transition to half-open after new cooldown")
+	}
+	assertState(t, cb, "half-open", "after new cooldown")
+}
+
+// open 상태에서 RecordSuccess → closed (cooldown 무시하고 복구)
+func TestCB_SuccessWhileOpen(t *testing.T) {
+	cb := NewCircuitBreaker(2, time.Hour)
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assertState(t, cb, "open", "opened")
+
+	// open 상태에서 직접 RecordSuccess 호출
+	cb.RecordSuccess()
+	assertState(t, cb, "closed", "success resets even from open")
+	if cb.ShouldFallback() {
+		t.Error("should not fallback after success reset")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// Concurrent stress test: race detector 검증
+// ══════════════════════════════════════════════════════════════
+
+func TestCB_ConcurrentRapidTransitions(t *testing.T) {
+	cb := NewCircuitBreaker(2, 1*time.Millisecond)
+	var wg sync.WaitGroup
+
+	// 100 goroutine이 동시에 상태 전이
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() {
+			defer wg.Done()
+			cb.RecordFailure()
+		}()
+		go func() {
+			defer wg.Done()
+			cb.RecordSuccess()
+		}()
+		go func() {
+			defer wg.Done()
+			_ = cb.ShouldFallback()
+			_ = cb.State()
+		}()
+	}
+	wg.Wait()
+
+	s := cb.State()
+	valid := s == "closed" || s == "open" || s == "half-open"
+	if !valid {
+		t.Errorf("invalid state after stress: %q", s)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// isRetryable / isAuthError: 실제 provider 에러 메시지 패턴
+// ══════════════════════════════════════════════════════════════
+
+func TestIsRetryable_RealWorldMessages(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		// Claude API 실제 에러 형식
+		{"Error: 429 Too Many Requests - Your request was rate limited", true},
+		{"Error: 529 Server Overloaded - The API is temporarily overloaded", true},
+		{"API Error: rate limit exceeded, please retry after 30 seconds", true},
+		{"Error: server at capacity, try again later", true},
+
+		// Claude 사용량 제한 (실제 발생 — 시간은 매번 다름)
+		{"You've hit your limit · resets 6pm (UTC)", true},
+		{"You've hit your limit", true},
+		{"Error: usage limit reached for this billing period", true},
+		{"API quota exceeded, retry after reset", true},
+		{"daily limit exceeded", true},
+
+		// 복합 메시지 (retryable 키워드 포함)
+		{"connection error followed by 429", true},
+		{"npm ERR! 429 Too Many Requests", true},
+
+		// 알려진 false positive (부분문자열 매칭 한계, 정규식 도입 시 개선 가능)
+		{"port 4290 is in use", true},              // 429 부분문자열 매칭
+		{"file at line 529", true},                 // 529 부분문자열 매칭
+		{"user has capacity to handle this", true}, // capacity 포함
+
+		// 빈 문자열 / 공백
+		{"", false},
+		{"   ", false},
+
+		// timeout은 retryable이 아님
+		{"TIMEOUT: task exceeded 5m0s", false},
+		{"context deadline exceeded", false},
+	}
+	for _, tt := range tests {
+		if got := isRetryable(tt.msg); got != tt.want {
+			t.Errorf("isRetryable(%q) = %v, want %v", tt.msg, got, tt.want)
+		}
+	}
+}
+
+func TestIsAuthError_RealWorldMessages(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		// Claude 실제 에러 형식
+		{"Error: 401 Unauthorized - Invalid API key", true},
+		{"authentication_error: Your API key is invalid", true},
+		{"Error: Failed to authenticate with the provided credentials", true},
+		{"OAuth token has expired. Please run 'claude auth login'.", true},
+
+		// Codex 에러 형식
+		{"401 - Invalid authentication token", true},
+		{"Failed to authenticate: token expired", true},
+
+		// false positive 방지
+		{"Status: 200 OK, authenticated successfully", false},
+		// 알려진 false positive (부분문자열 매칭 한계)
+		{"Auth middleware initialized on port 8401", true}, // 8401에 401 포함
+
+		// 빈 문자열
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isAuthError(tt.msg); got != tt.want {
+			t.Errorf("isAuthError(%q) = %v, want %v", tt.msg, got, tt.want)
+		}
+	}
+}
+
+// 긴 출력에서도 키워드 탐지
+func TestIsRetryable_LongOutput(t *testing.T) {
+	padding := strings.Repeat("normal log line\n", 500)
+	msg := padding + "Error: 429 Too Many Requests\n" + padding
+	if !isRetryable(msg) {
+		t.Error("should detect rate limit in long output")
+	}
+}
+
+func TestIsAuthError_LongOutput(t *testing.T) {
+	padding := strings.Repeat("processing step ok\n", 500)
+	msg := padding + "authentication_error: expired token\n" + padding
+	if !isAuthError(msg) {
+		t.Error("should detect auth error in long output")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// classifyTaskError 와 circuit breaker 분류의 직교성
+// ══════════════════════════════════════════════════════════════
+
+// retryable/auth 에러는 classifyTaskError에서 unknown이어야 함
+// (circuit breaker가 처리, self-repair는 개입하지 않음)
+func TestClassify_RetryableIsUnknown(t *testing.T) {
+	retryables := []string{
+		"rate limit exceeded",
+		"429 Too Many Requests",
+		"server overloaded",
+	}
+	for _, msg := range retryables {
+		if class := classifyTaskError(msg); class != ErrClassUnknown {
+			t.Errorf("classifyTaskError(%q) = %q, want unknown (circuit breaker handles this)", msg, class)
+		}
+	}
+}
+
+func TestClassify_AuthIsUnknown(t *testing.T) {
+	auths := []string{
+		"authentication_error: bad key",
+		"OAuth token has expired",
+		"Failed to authenticate",
+	}
+	for _, msg := range auths {
+		if class := classifyTaskError(msg); class != ErrClassUnknown {
+			t.Errorf("classifyTaskError(%q) = %q, want unknown", msg, class)
+		}
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// notifyCredentialRefresh: HTTP 호출 검증
+// ══════════════════════════════════════════════════════════════
+
+func TestNotifyCredentialRefresh_WithServer(t *testing.T) {
+	var received string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		received = string(b)
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	notifyCredentialRefresh("test-dal")
+
+	if !strings.Contains(received, "test-dal") {
+		t.Errorf("request body should contain dal name, got: %s", received)
+	}
+	if !strings.Contains(received, "credential") || !strings.Contains(received, "만료") {
+		t.Errorf("request body should contain credential expiry message, got: %s", received)
+	}
+}
+
+func TestNotifyCredentialRefresh_ServerDown(t *testing.T) {
+	os.Setenv("DALCENTER_URL", "http://127.0.0.1:1") // 연결 불가 포트
+	defer os.Unsetenv("DALCENTER_URL")
+
+	// panic 없이 리턴해야 함
+	notifyCredentialRefresh("test-dal")
+}
+
+// ══════════════════════════════════════════════════════════════
+// detectFallback: player별 분기
+// ══════════════════════════════════════════════════════════════
+
+func TestDetectFallback_AllPlayers(t *testing.T) {
+	players := []string{"claude", "codex", "gemini", "", "unknown-player"}
+	for _, p := range players {
+		fb := detectFallback(p)
+		// gemini, empty, unknown → no fallback
+		if p != "claude" && p != "codex" && fb != "" {
+			t.Errorf("detectFallback(%q) = %q, want empty", p, fb)
+		}
+		// claude/codex → 바이너리 있으면 상대방, 없으면 빈 문자열 (둘 다 valid)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// executeTask: 통합 시나리오 (실제 바이너리 없는 환경)
+// ══════════════════════════════════════════════════════════════
+
+// 모든 provider 에러는 circuit breaker에 기록되어야 함
+func TestExecuteTask_AnyErrorRecordsFailure(t *testing.T) {
+	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
+	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
+
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer os.Unsetenv("DAL_PLAYER")
+	defer os.Unsetenv("DAL_ROLE")
+	defer os.Unsetenv("DAL_MAX_DURATION")
+
+	// claude 바이너리 없으면 에러 → RecordFailure 호출됨
+	_, err := executeTask("test")
+	if err == nil {
+		t.Log("claude available — skip")
+		return
+	}
+
+	// 에러 발생 시 circuit에 failure 기록됨
+	s := providerCircuit.State()
+	if s == "closed" {
+		// threshold=3이므로 1회 실패로는 아직 closed일 수 있지만
+		// 실패가 기록되었는지 간접 확인: 2번 더 실패하면 open
+		_, _ = executeTask("test")
+		_, _ = executeTask("test")
+		if providerCircuit.State() != "open" {
+			t.Errorf("3 failures should open circuit, got %s", providerCircuit.State())
+		}
+	}
+}
+
+// 반복 실패 시 circuit이 열려야 함
+func TestExecuteTask_RepeatedFailuresOpenCircuit(t *testing.T) {
+	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
+	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
+
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer os.Unsetenv("DAL_PLAYER")
+	defer os.Unsetenv("DAL_ROLE")
+	defer os.Unsetenv("DAL_MAX_DURATION")
+
+	for i := 0; i < 5; i++ {
+		_, _ = executeTask("test")
+	}
+
+	_, err := executeTask("test")
+	if err == nil {
+		t.Log("claude available — skip")
+		return
+	}
+
+	if providerCircuit.State() == "closed" {
+		t.Errorf("circuit should be open after repeated failures, got %s", providerCircuit.State())
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// Circuit Breaker: 다중 인스턴스 독립성
+// ══════════════════════════════════════════════════════════════
+
+func TestCB_MultipleInstances_Independent(t *testing.T) {
+	cb1 := NewCircuitBreaker(1, time.Minute)
+	cb2 := NewCircuitBreaker(1, time.Minute)
+
+	cb1.RecordFailure()
+	assertState(t, cb1, "open", "cb1 should be open")
+	assertState(t, cb2, "closed", "cb2 should be independent")
+
+	cb2.RecordFailure()
+	assertState(t, cb2, "open", "cb2 now open")
+
+	cb1.RecordSuccess()
+	assertState(t, cb1, "closed", "cb1 reset")
+	assertState(t, cb2, "open", "cb2 still open")
+}
+
+// ══════════════════════════════════════════════════════════════
+// self-repair과 circuit breaker 우선순위 분리
+// ══════════════════════════════════════════════════════════════
+
+// self-repair의 classifyTaskError와 isRetryable/isAuthError 사이에
+// 잘못된 교차 분류가 없는지 전수 검사
+func TestErrorClassification_Exhaustive(t *testing.T) {
+	cases := []struct {
+		output        string
+		retryable     bool
+		authErr       bool
+		selfRepairEnv bool
+	}{
+		// rate limit 계열 → retryable만
+		{"rate limit exceeded", true, false, false},
+		{"429", true, false, false},
+		{"overloaded", true, false, false},
+		{"You've hit your limit", true, false, false},
+		{"quota exceeded", true, false, false},
+
+		// auth 계열 → authErr만
+		{"authentication_error", false, true, false},
+		{"OAuth token has expired", false, true, false},
+
+		// env 계열 → self-repair만
+		{"command not found", false, false, true},
+		{"no such file or directory", false, false, true},
+		{"permission denied", false, false, true},
+
+		// 순수 에러 → 어디에도 안 걸림
+		{"exit status 1", false, false, false},
+		{"panic: runtime error", false, false, false},
+	}
+
+	for _, tt := range cases {
+		r := isRetryable(tt.output)
+		a := isAuthError(tt.output)
+		e := classifyTaskError(tt.output) == ErrClassEnv
+
+		if r != tt.retryable {
+			t.Errorf("isRetryable(%q) = %v, want %v", tt.output, r, tt.retryable)
+		}
+		if a != tt.authErr {
+			t.Errorf("isAuthError(%q) = %v, want %v", tt.output, a, tt.authErr)
+		}
+		if e != tt.selfRepairEnv {
+			t.Errorf("classifyTaskError(%q)==env: %v, want %v", tt.output, e, tt.selfRepairEnv)
+		}
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// Circuit Breaker: 연속 3회 사이클 (open→recover→open→recover→open)
+// ══════════════════════════════════════════════════════════════
+
+func TestCB_ThreeCycles(t *testing.T) {
+	cb := NewCircuitBreaker(1, 20*time.Millisecond)
+
+	for cycle := 1; cycle <= 3; cycle++ {
+		cb.RecordFailure()
+		assertState(t, cb, "open", fmt.Sprintf("cycle %d: open", cycle))
+
+		time.Sleep(30 * time.Millisecond)
+		cb.ShouldFallback()
+		assertState(t, cb, "half-open", fmt.Sprintf("cycle %d: half-open", cycle))
+
+		cb.RecordSuccess()
+		assertState(t, cb, "closed", fmt.Sprintf("cycle %d: recovered", cycle))
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// 401 false positive: 포트번호 8401 등
+// ══════════════════════════════════════════════════════════════
+
+func TestIsAuthError_FalsePositive_PortNumber(t *testing.T) {
+	// 현재 구현은 "401"을 Contains로 검사하므로 8401도 매칭됨
+	// 이 테스트는 현재 동작을 문서화하고,
+	// 나중에 정규식으로 개선할 때 변경 포인트로 사용
+	msg := "server started on port 8401"
+	got := isAuthError(msg)
+	// 현재 구현: true (부분문자열 매칭)
+	if !got {
+		t.Log("port 8401 no longer false-positive — regex improvement applied?")
+	}
+}
+
+func TestIsRetryable_FalsePositive_PortAndLine(t *testing.T) {
+	// 마찬가지로 "429"가 포트/라인번호에 매칭되는 현재 동작 문서화
+	cases := []struct {
+		msg  string
+		note string
+	}{
+		{"listening on port 4290", "port 4290 contains 429"},
+		{"error at line 529 in main.go", "line 529 contains 529"},
+	}
+	for _, tt := range cases {
+		got := isRetryable(tt.msg)
+		// 현재 동작 기록: false positive 가능성 있음
+		t.Logf("isRetryable(%q) = %v — %s", tt.msg, got, tt.note)
+	}
+}

--- a/cmd/dalcli/circuit_breaker_thorough_test.go
+++ b/cmd/dalcli/circuit_breaker_thorough_test.go
@@ -1,0 +1,365 @@
+package main
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// ── State Transition: full cycle ──
+
+func TestCB_FullCycle_ClosedOpenHalfOpenClosedOpen(t *testing.T) {
+	cb := NewCircuitBreaker(2, 30*time.Millisecond)
+
+	// closed → open
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assertState(t, cb, "open", "after 2 failures")
+
+	// open → half-open (cooldown)
+	time.Sleep(40 * time.Millisecond)
+	if cb.ShouldFallback() {
+		t.Fatal("should not fallback after cooldown")
+	}
+	assertState(t, cb, "half-open", "after cooldown")
+
+	// half-open → closed (success)
+	cb.RecordSuccess()
+	assertState(t, cb, "closed", "after half-open success")
+
+	// closed → open again (failures re-accumulate from 0)
+	cb.RecordFailure()
+	assertState(t, cb, "closed", "1 failure after reset")
+	cb.RecordFailure()
+	assertState(t, cb, "open", "2nd failure after reset")
+}
+
+// ── Threshold edge: threshold=1 ──
+
+func TestCB_ThresholdOne(t *testing.T) {
+	cb := NewCircuitBreaker(1, 30*time.Millisecond)
+	assertState(t, cb, "closed", "initial")
+
+	cb.RecordFailure()
+	assertState(t, cb, "open", "single failure with threshold=1")
+	if !cb.ShouldFallback() {
+		t.Error("should fallback immediately")
+	}
+}
+
+// ── Open: ShouldFallback stays true within cooldown ──
+
+func TestCB_OpenStaysDuringCooldown(t *testing.T) {
+	cb := NewCircuitBreaker(1, 200*time.Millisecond)
+	cb.RecordFailure()
+
+	for i := 0; i < 5; i++ {
+		if !cb.ShouldFallback() {
+			t.Fatalf("call %d: should still fallback within cooldown", i)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assertState(t, cb, "open", "still within cooldown")
+}
+
+// ── Half-open: only 1 probe allowed before re-opening ──
+
+func TestCB_HalfOpenReOpensOnFailure(t *testing.T) {
+	cb := NewCircuitBreaker(2, 30*time.Millisecond)
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	time.Sleep(40 * time.Millisecond)
+	cb.ShouldFallback() // triggers half-open
+
+	// half-open allows 1 probe, fail it
+	cb.RecordFailure()
+	assertState(t, cb, "open", "half-open failed, back to open")
+
+	// must wait cooldown again
+	if !cb.ShouldFallback() {
+		t.Error("should fallback again after half-open→open")
+	}
+}
+
+// ── Half-open → open → half-open → closed (double bounce) ──
+
+func TestCB_DoubleBounce(t *testing.T) {
+	cb := NewCircuitBreaker(1, 30*time.Millisecond)
+
+	// Round 1: closed → open → half-open → fail → open
+	cb.RecordFailure()
+	time.Sleep(40 * time.Millisecond)
+	cb.ShouldFallback()
+	cb.RecordFailure()
+	assertState(t, cb, "open", "bounce 1: back to open")
+
+	// Round 2: open → half-open → success → closed
+	time.Sleep(40 * time.Millisecond)
+	cb.ShouldFallback()
+	assertState(t, cb, "half-open", "bounce 2: half-open")
+	cb.RecordSuccess()
+	assertState(t, cb, "closed", "bounce 2: recovered")
+}
+
+// ── Success during closed resets failure count ──
+
+func TestCB_SuccessResetsFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Minute)
+
+	cb.RecordFailure()
+	cb.RecordFailure() // 2 failures
+	cb.RecordSuccess() // reset
+
+	// need 3 more failures to open, not 1
+	cb.RecordFailure()
+	assertState(t, cb, "closed", "1 failure after reset")
+	cb.RecordFailure()
+	assertState(t, cb, "closed", "2 failures after reset")
+	cb.RecordFailure()
+	assertState(t, cb, "open", "3 failures after reset → open")
+}
+
+// ── RecordSuccess on already-closed is safe ──
+
+func TestCB_SuccessOnClosedIsNoop(t *testing.T) {
+	cb := NewCircuitBreaker(3, time.Minute)
+	cb.RecordSuccess()
+	cb.RecordSuccess()
+	assertState(t, cb, "closed", "multiple success on closed")
+	if cb.ShouldFallback() {
+		t.Error("should not fallback")
+	}
+}
+
+// ── RecordFailure on open keeps it open ──
+
+func TestCB_FailureOnOpenKeepsOpen(t *testing.T) {
+	cb := NewCircuitBreaker(2, time.Minute)
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assertState(t, cb, "open", "just opened")
+
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assertState(t, cb, "open", "extra failures keep it open")
+}
+
+// ── Concurrent access: no race condition ──
+
+func TestCB_ConcurrentSafety(t *testing.T) {
+	cb := NewCircuitBreaker(100, 50*time.Millisecond)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			cb.ShouldFallback()
+			if n%3 == 0 {
+				cb.RecordFailure()
+			} else {
+				cb.RecordSuccess()
+			}
+			_ = cb.State()
+		}(i)
+	}
+	wg.Wait()
+
+	// Just verify no panic/deadlock and state is valid
+	s := cb.State()
+	if s != "closed" && s != "open" && s != "half-open" {
+		t.Errorf("invalid state after concurrent access: %q", s)
+	}
+}
+
+// ── isRetryable: exhaustive keyword coverage ──
+
+func TestIsRetryable_AllKeywords(t *testing.T) {
+	positives := []string{
+		"rate limit exceeded",
+		"Rate Limit Exceeded",
+		"RATE LIMIT",
+		"429",
+		"HTTP 429 Too Many Requests",
+		"529",
+		"Error 529",
+		"overloaded",
+		"server is Overloaded",
+		"too many requests",
+		"Too Many Requests",
+		"at capacity",
+		"server at capacity please retry",
+		"You've hit your limit · resets 6pm (UTC)",
+		"hit your limit",
+		"usage limit reached",
+		"API usage limit exceeded",
+		"limit exceeded",
+		"quota exceeded for today",
+	}
+	for _, s := range positives {
+		if !isRetryable(s) {
+			t.Errorf("isRetryable(%q) = false, want true", s)
+		}
+	}
+
+	negatives := []string{
+		"",
+		"exit status 1",
+		"file not found",
+		"permission denied",
+		"authentication_error",
+		"401 Unauthorized",
+		"timeout",
+		"connection refused",
+		"segfault",
+	}
+	for _, s := range negatives {
+		if isRetryable(s) {
+			t.Errorf("isRetryable(%q) = true, want false", s)
+		}
+	}
+}
+
+// ── isAuthError: exhaustive keyword coverage ──
+
+func TestIsAuthError_AllKeywords(t *testing.T) {
+	positives := []string{
+		"401",
+		"HTTP 401",
+		"401 Unauthorized",
+		"authentication_error",
+		"authentication_error: invalid key",
+		"invalid authentication credentials",
+		"Invalid Authentication",
+		"oauth token has expired",
+		"OAuth Token Has Expired",
+		"failed to authenticate",
+		"Failed to authenticate. Please login again.",
+	}
+	for _, s := range positives {
+		if !isAuthError(s) {
+			t.Errorf("isAuthError(%q) = false, want true", s)
+		}
+	}
+
+	negatives := []string{
+		"",
+		"rate limit exceeded",
+		"429 Too Many Requests",
+		"file not found",
+		"exit status 1",
+		"timeout",
+		"connection refused",
+		"200 OK",
+	}
+	for _, s := range negatives {
+		if isAuthError(s) {
+			t.Errorf("isAuthError(%q) = true, want false", s)
+		}
+	}
+}
+
+// ── isRetryable and isAuthError are mutually exclusive for clear outputs ──
+
+func TestRetryableAndAuthError_NoOverlap(t *testing.T) {
+	// Outputs that should be retryable but NOT auth errors
+	retryOnly := []string{
+		"rate limit exceeded",
+		"429 Too Many Requests",
+		"overloaded",
+	}
+	for _, s := range retryOnly {
+		if isRetryable(s) && isAuthError(s) {
+			t.Errorf("overlap: %q is both retryable and auth error", s)
+		}
+	}
+
+	// Outputs that should be auth errors but NOT retryable
+	authOnly := []string{
+		"authentication_error: bad key",
+		"OAuth token has expired",
+		"failed to authenticate",
+	}
+	for _, s := range authOnly {
+		if isRetryable(s) && isAuthError(s) {
+			t.Errorf("overlap: %q is both retryable and auth error", s)
+		}
+	}
+}
+
+// ── "401" is auth error, not retryable ──
+
+func TestAuthVsRetry_401(t *testing.T) {
+	s := "401 Unauthorized"
+	if !isAuthError(s) {
+		t.Error("401 should be auth error")
+	}
+	if isRetryable(s) {
+		t.Error("401 should NOT be retryable")
+	}
+}
+
+// ── State() returns correct strings ──
+
+func TestCB_StateStrings(t *testing.T) {
+	cb := NewCircuitBreaker(1, 30*time.Millisecond)
+
+	if s := cb.State(); s != "closed" {
+		t.Errorf("initial: got %q", s)
+	}
+
+	cb.RecordFailure()
+	if s := cb.State(); s != "open" {
+		t.Errorf("after failure: got %q", s)
+	}
+
+	time.Sleep(40 * time.Millisecond)
+	cb.ShouldFallback() // triggers half-open
+	if s := cb.State(); s != "half-open" {
+		t.Errorf("after cooldown: got %q", s)
+	}
+}
+
+// ── ShouldFallback is idempotent in half-open ──
+
+func TestCB_HalfOpenMultipleShouldFallback(t *testing.T) {
+	cb := NewCircuitBreaker(1, 30*time.Millisecond)
+	cb.RecordFailure()
+
+	time.Sleep(40 * time.Millisecond)
+
+	// First call transitions open → half-open
+	if cb.ShouldFallback() {
+		t.Fatal("first call should allow probe")
+	}
+	assertState(t, cb, "half-open", "first ShouldFallback")
+
+	// Subsequent calls in half-open still allow probe
+	if cb.ShouldFallback() {
+		t.Fatal("second call in half-open should still allow probe")
+	}
+	assertState(t, cb, "half-open", "second ShouldFallback")
+}
+
+// ── Large threshold ──
+
+func TestCB_LargeThreshold(t *testing.T) {
+	cb := NewCircuitBreaker(100, time.Minute)
+
+	for i := 0; i < 99; i++ {
+		cb.RecordFailure()
+	}
+	assertState(t, cb, "closed", "99 failures with threshold 100")
+
+	cb.RecordFailure()
+	assertState(t, cb, "open", "100th failure triggers open")
+}
+
+// helper
+func assertState(t *testing.T, cb *CircuitBreaker, want, msg string) {
+	t.Helper()
+	if got := cb.State(); got != want {
+		t.Errorf("%s: state = %q, want %q", msg, got, want)
+	}
+}

--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -483,7 +483,7 @@ func executeTask(task string) (string, error) {
 		lastOut = out
 		lastErr = err
 
-		// Auth error → wait for credential sync (cron every 5min on host)
+		// Auth error → credential 문제이므로 circuit breaker 대상 아님
 		if isAuthError(out) {
 			wait := 60 * time.Second
 			name := os.Getenv("DAL_NAME")
@@ -493,25 +493,28 @@ func executeTask(task string) (string, error) {
 			continue
 		}
 
-		if isRetryable(out) {
-			providerCircuit.RecordFailure()
+		// 모든 provider 에러 → circuit breaker에 기록
+		providerCircuit.RecordFailure()
 
-			if providerCircuit.ShouldFallback() && fallbackPlayer != "" {
-				log.Printf("[circuit] switching to fallback %s (attempt %d/%d)", fallbackPlayer, attempt, maxRetries)
-				fbOut, fbErr := runProvider(fallbackPlayer, task)
-				if fbErr == nil {
-					return fbOut, nil
-				}
-				log.Printf("[circuit] fallback %s failed: %v", fallbackPlayer, fbErr)
+		// circuit open → fallback 시도
+		if providerCircuit.ShouldFallback() && fallbackPlayer != "" {
+			log.Printf("[circuit] switching to fallback %s (attempt %d/%d)", fallbackPlayer, attempt, maxRetries)
+			fbOut, fbErr := runProvider(fallbackPlayer, task)
+			if fbErr == nil {
+				return fbOut, nil
 			}
+			log.Printf("[circuit] fallback %s failed: %v", fallbackPlayer, fbErr)
+		}
 
+		// retryable → 대기 후 재시도
+		if isRetryable(out) {
 			wait := time.Duration(attempt*30) * time.Second
 			log.Printf("[agent] retrying primary in %s (attempt %d/%d)", wait, attempt, maxRetries)
 			time.Sleep(wait)
 			continue
 		}
 
-		// Non-retryable error
+		// non-retryable → 즉시 종료 (circuit에는 이미 기록됨)
 		return out, err
 	}
 
@@ -609,7 +612,11 @@ func isRetryable(output string) bool {
 		strings.Contains(lower, "429") ||
 		strings.Contains(lower, "529") ||
 		strings.Contains(lower, "too many requests") ||
-		strings.Contains(lower, "capacity")
+		strings.Contains(lower, "capacity") ||
+		strings.Contains(lower, "hit your limit") ||
+		strings.Contains(lower, "usage limit") ||
+		strings.Contains(lower, "limit exceeded") ||
+		strings.Contains(lower, "quota exceeded")
 }
 
 // isAuthError checks if the error is an authentication failure (401, expired token, etc).

--- a/cmd/dalcli/cmd_run_thorough_test.go
+++ b/cmd/dalcli/cmd_run_thorough_test.go
@@ -1,0 +1,340 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ══════════════════════════════════════════════════════════════
+// parseInterval: edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestParseInterval_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  time.Duration
+	}{
+		{"1s", time.Second},
+		{"5m", 5 * time.Minute},
+		{"2h", 2 * time.Hour},
+		{"500ms", 500 * time.Millisecond},
+		{"1h30m", 90 * time.Minute},
+	}
+	for _, tt := range tests {
+		if got := parseInterval(tt.input, time.Hour); got != tt.want {
+			t.Errorf("parseInterval(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseInterval_Empty(t *testing.T) {
+	fallback := 42 * time.Second
+	if got := parseInterval("", fallback); got != fallback {
+		t.Errorf("empty → %v, want fallback %v", got, fallback)
+	}
+}
+
+func TestParseInterval_InvalidInputs(t *testing.T) {
+	fallback := 10 * time.Minute
+	invalids := []string{"abc", "5", "minutes", "-", "1x2y"}
+	for _, s := range invalids {
+		if got := parseInterval(s, fallback); got != fallback {
+			t.Errorf("parseInterval(%q) = %v, want fallback %v", s, got, fallback)
+		}
+	}
+}
+
+func TestParseInterval_ZeroDuration(t *testing.T) {
+	if got := parseInterval("0s", time.Hour); got != 0 {
+		t.Errorf("parseInterval('0s') = %v, want 0", got)
+	}
+}
+
+func TestParseInterval_NegativeDuration(t *testing.T) {
+	// Go's time.ParseDuration accepts negative values
+	got := parseInterval("-5s", time.Hour)
+	if got != -5*time.Second {
+		t.Errorf("parseInterval('-5s') = %v, want -5s", got)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// truncate: edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestTruncate_ExactLength(t *testing.T) {
+	if got := truncate("hello", 5); got != "hello" {
+		t.Errorf("exact length: got %q", got)
+	}
+}
+
+func TestTruncate_ZeroN(t *testing.T) {
+	got := truncate("hello", 0)
+	if got != "..." {
+		t.Errorf("n=0: got %q, want '...'", got)
+	}
+}
+
+func TestTruncate_EmptyString(t *testing.T) {
+	if got := truncate("", 10); got != "" {
+		t.Errorf("empty: got %q", got)
+	}
+}
+
+func TestTruncate_Unicode(t *testing.T) {
+	// truncate works on bytes, not runes — document this behavior
+	s := "한글테스트" // 15 bytes in UTF-8
+	got := truncate(s, 3)
+	// First 3 bytes of "한" (3-byte UTF-8 char) = "한"
+	if len(got) < 3 {
+		t.Errorf("got %q (len=%d)", got, len(got))
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// formatReport: boundary cases
+// ══════════════════════════════════════════════════════════════
+
+func TestFormatReport_ExactlyAtLimit(t *testing.T) {
+	output := strings.Repeat("a", 3000) // exactly 3000
+	report := formatReport(output)
+	if strings.Contains(report, "truncated") {
+		t.Error("exactly 3000 chars should NOT be truncated")
+	}
+}
+
+func TestFormatReport_JustOverLimit(t *testing.T) {
+	output := strings.Repeat("a", 3001) // 3001 > 3000
+	report := formatReport(output)
+	if !strings.Contains(report, "truncated") {
+		t.Error("3001 chars should be truncated")
+	}
+}
+
+func TestFormatReport_PreservesCodeBlock(t *testing.T) {
+	report := formatReport("test output")
+	if !strings.Contains(report, "```") {
+		t.Error("should wrap in code block")
+	}
+}
+
+func TestFormatReport_TruncatedPreservesEnds(t *testing.T) {
+	// Build output with distinctive start and end
+	start := "START_MARKER_"
+	end := "_END_MARKER"
+	middle := strings.Repeat("x", 4000)
+	output := start + middle + end
+
+	report := formatReport(output)
+	if !strings.Contains(report, "START_MARKER") {
+		t.Error("truncated report should preserve start")
+	}
+	if !strings.Contains(report, "END_MARKER") {
+		t.Error("truncated report should preserve end")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// extractTask: edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestExtractTask_MultipleOccurrences(t *testing.T) {
+	// extractTask uses first occurrence
+	content := "작업 지시: first task\n더 많은 내용\n작업 지시: second task"
+	got := extractTask(content, "작업 지시:")
+	if !strings.HasPrefix(got, "first task") {
+		t.Errorf("should use first occurrence, got %q", got)
+	}
+}
+
+func TestExtractTask_PrefixAtEnd(t *testing.T) {
+	got := extractTask("some text 작업 지시:", "작업 지시:")
+	if got != "" {
+		t.Errorf("prefix at end with nothing after should be empty, got %q", got)
+	}
+}
+
+func TestExtractTask_UnicodeContent(t *testing.T) {
+	got := extractTask("@dal 작업 지시: 가야 스크립트 수정해줘", "작업 지시:")
+	if got != "가야 스크립트 수정해줘" {
+		t.Errorf("unicode: got %q", got)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// runClaude: DAL_EXTRA_BASH 변형
+// ══════════════════════════════════════════════════════════════
+
+func TestRunClaude_ExtraBashWildcard(t *testing.T) {
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_EXTRA_BASH", "*")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_EXTRA_BASH")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	// Should not panic; claude not available is fine
+	_, _ = runClaude("claude", "test")
+}
+
+func TestRunClaude_ExtraBashSpecific(t *testing.T) {
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_EXTRA_BASH", "go,npm")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_EXTRA_BASH")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	_, _ = runClaude("claude", "test")
+}
+
+func TestRunClaude_LeaderRole(t *testing.T) {
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "leader")
+	os.Setenv("DAL_EXTRA_BASH", "")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_EXTRA_BASH")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	_, _ = runClaude("claude", "test")
+}
+
+func TestRunClaude_MaxDurationEnv(t *testing.T) {
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "500ms")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	start := time.Now()
+	_, _ = runClaude("claude", "test")
+	elapsed := time.Since(start)
+
+	// If claude exists it might run longer, but with 500ms timeout
+	// it should be capped. Just verify no panic.
+	_ = elapsed
+}
+
+func TestRunClaude_InvalidMaxDuration(t *testing.T) {
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "not-a-duration")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	// Invalid duration should fall back to default (5min), not panic
+	_, _ = runClaude("claude", "test")
+}
+
+// ══════════════════════════════════════════════════════════════
+// executeTask: 글로벌 circuit 상태와 통합
+// ══════════════════════════════════════════════════════════════
+
+func TestExecuteTask_SuccessKeepsCircuitClosed(t *testing.T) {
+	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
+	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
+
+	os.Setenv("DAL_PLAYER", "claude")
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer func() {
+		os.Unsetenv("DAL_PLAYER")
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	_, err := executeTask("echo hi")
+	if err == nil {
+		// claude 성공 → circuit closed 유지
+		if providerCircuit.State() != "closed" {
+			t.Error("circuit should be closed after success")
+		}
+	}
+	// claude 없으면 에러 → failure 기록됨 (이건 정상)
+}
+
+// ══════════════════════════════════════════════════════════════
+// isDalOnlyChanges: 추가 edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestIsDalOnlyChanges_MultipleDALFiles(t *testing.T) {
+	input := " M .dal/leader/dal.cue\n M .dal/dev/dal.cue\nA  .dal/skills/new/SKILL.md"
+	if !isDalOnlyChanges(input) {
+		t.Error("multiple .dal/ files should be dal-only")
+	}
+}
+
+func TestIsDalOnlyChanges_MixedWithSrc(t *testing.T) {
+	input := " M .dal/leader/dal.cue\n M src/main.go"
+	if isDalOnlyChanges(input) {
+		t.Error("mixed .dal/ + src/ should NOT be dal-only")
+	}
+}
+
+func TestIsDalOnlyChanges_WhitespaceLines(t *testing.T) {
+	input := " M .dal/config.cue\n\n  \n M .dal/spec.cue"
+	if !isDalOnlyChanges(input) {
+		t.Error("whitespace lines should be ignored")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// isActiveThread: edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestIsActiveThread_EmptyID(t *testing.T) {
+	var threads sync.Map
+	threads.Store("t1", true)
+	if isActiveThread(&threads, "") {
+		t.Error("empty thread ID should not be active")
+	}
+}
+
+func TestIsActiveThread_EmptyMap(t *testing.T) {
+	var threads sync.Map
+	if isActiveThread(&threads, "t1") {
+		t.Error("should return false for empty map")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// runProvider: player dispatch
+// ══════════════════════════════════════════════════════════════
+
+func TestRunProvider_DispatchesToRunClaude(t *testing.T) {
+	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
+	defer func() {
+		os.Unsetenv("DAL_ROLE")
+		os.Unsetenv("DAL_MAX_DURATION")
+	}()
+
+	// All players go through runProvider → runClaude
+	players := []string{"claude", "codex", "gemini", "unknown"}
+	for _, p := range players {
+		_, err := runProvider(p, "test")
+		// Should not panic regardless of player
+		_ = err
+	}
+}

--- a/cmd/dalcli/self_repair_thorough_test.go
+++ b/cmd/dalcli/self_repair_thorough_test.go
@@ -1,0 +1,394 @@
+package main
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ══════════════════════════════════════════════════════════════
+// classifyTaskError: 모든 패턴 키워드 개별 검증
+// ══════════════════════════════════════════════════════════════
+
+func TestClassify_EnvPatterns_All(t *testing.T) {
+	cases := []struct {
+		output string
+		note   string
+	}{
+		{"bash: npm: command not found", "command not found"},
+		{"/bin/sh: 1: go: not found — command not found", "command not found variant"},
+		{"Error: No such file or directory: /workspace/main.go", "no such file or directory"},
+		{"Permission denied (publickey).", "permission denied"},
+		{"error: not a directory: /workspace/file.txt/sub", "not a directory"},
+		{"exec format error: ./binary", "exec format error"},
+		{"'go' is not recognized as an internal or external command", "is not recognized"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.note, func(t *testing.T) {
+			if got := classifyTaskError(tt.output); got != ErrClassEnv {
+				t.Errorf("classifyTaskError(%q) = %s, want env [%s]", tt.output, got, tt.note)
+			}
+		})
+	}
+}
+
+func TestClassify_DepsPatterns_All(t *testing.T) {
+	cases := []struct {
+		output string
+		note   string
+	}{
+		{"go: module github.com/foo/bar: reading github.com/foo/bar: 404", "go: module"},
+		{"go mod tidy to fix missing modules", "go mod tidy"},
+		{"cannot find module providing package github.com/x/y", "cannot find module"},
+		{"npm ERR! code ERESOLVE", "npm err"},
+		{"Error: Module not found: Error: Can't resolve 'react'", "module not found"},
+		{"error[E0432]: unresolved import `crate::foo`", "unresolved import"},
+		{"error: could not compile `my-crate` due to previous error", "could not compile"},
+		{"Error: package not found: @types/node", "package not found"},
+		{"cargo build failed with exit code 101", "cargo build"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.note, func(t *testing.T) {
+			if got := classifyTaskError(tt.output); got != ErrClassDeps {
+				t.Errorf("classifyTaskError(%q) = %s, want deps [%s]", tt.output, got, tt.note)
+			}
+		})
+	}
+}
+
+func TestClassify_GitPatterns_All(t *testing.T) {
+	cases := []struct {
+		output string
+		note   string
+	}{
+		{"CONFLICT (content): Merge conflict in main.go", "merge conflict"},
+		{"HEAD detached at 4f2a3bc", "detached head"},
+		{"You are in 'head detached' state", "head detached"},
+		{"fatal: not a git repository (or any parent up to mount point /)", "not a git repository"},
+		{"Your branch is behind 'origin/main' by 3 commits", "your branch is behind"},
+		{"error: you need to resolve your current index first\nUnmerged files:", "unmerged files"},
+		{"fatal: refusing to merge unrelated histories", "refusing to merge unrelated"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.note, func(t *testing.T) {
+			if got := classifyTaskError(tt.output); got != ErrClassGit {
+				t.Errorf("classifyTaskError(%q) = %s, want git [%s]", tt.output, got, tt.note)
+			}
+		})
+	}
+}
+
+func TestClassify_Instructions_NeedsMultipleIndicators(t *testing.T) {
+	tests := []struct {
+		output string
+		want   ErrorClass
+		note   string
+	}{
+		// 2+ indicators + "error" → instructions
+		{"error: instructions.md references stale instruction from issue #100", ErrClassInstructions, "3 indicators + error"},
+		{"error in task.md: issue #200 is closed", ErrClassInstructions, "task.md + issue # + error"},
+
+		// single indicator → NOT instructions
+		{"reading instructions.md for setup", ErrClassUnknown, "single: instructions.md only"},
+		{"fixed issue #42 in PR", ErrClassUnknown, "single: issue # only"},
+		{"stale instruction detected", ErrClassUnknown, "single: stale instruction only"},
+		{"updated task.md", ErrClassUnknown, "single: task.md only"},
+
+		// 2 indicators but no "error" → NOT instructions
+		{"instructions.md mentions issue #50", ErrClassUnknown, "2 indicators but no error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.note, func(t *testing.T) {
+			if got := classifyTaskError(tt.output); got != tt.want {
+				t.Errorf("classifyTaskError(%q) = %s, want %s [%s]", tt.output, got, tt.want, tt.note)
+			}
+		})
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// classifyTaskError: 우선순위 (env > deps > git > instructions)
+// ══════════════════════════════════════════════════════════════
+
+func TestClassify_Priority_EnvBeforeDeps(t *testing.T) {
+	// 'command not found' (env) + 'npm err' (deps) → env wins (checked first)
+	output := "npm ERR! command not found: webpack"
+	got := classifyTaskError(output)
+	if got != ErrClassEnv {
+		t.Errorf("env should take priority over deps, got %s", got)
+	}
+}
+
+func TestClassify_Priority_EnvBeforeGit(t *testing.T) {
+	output := "permission denied: fatal: not a git repository"
+	got := classifyTaskError(output)
+	if got != ErrClassEnv {
+		t.Errorf("env should take priority over git, got %s", got)
+	}
+}
+
+func TestClassify_Priority_DepsBeforeGit(t *testing.T) {
+	output := "go: module not found, your branch is behind"
+	got := classifyTaskError(output)
+	if got != ErrClassDeps {
+		t.Errorf("deps should take priority over git, got %s", got)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// classifyTaskError: edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestClassify_EmptyString(t *testing.T) {
+	if got := classifyTaskError(""); got != ErrClassUnknown {
+		t.Errorf("empty → %s, want unknown", got)
+	}
+}
+
+func TestClassify_CaseInsensitive(t *testing.T) {
+	cases := []struct {
+		output string
+		want   ErrorClass
+	}{
+		{"COMMAND NOT FOUND", ErrClassEnv},
+		{"NPM ERR! code E404", ErrClassDeps},
+		{"MERGE CONFLICT in file.go", ErrClassGit},
+	}
+	for _, tt := range cases {
+		if got := classifyTaskError(tt.output); got != tt.want {
+			t.Errorf("classifyTaskError(%q) = %s, want %s", tt.output, got, tt.want)
+		}
+	}
+}
+
+func TestClassify_LongOutput(t *testing.T) {
+	padding := strings.Repeat("ok step completed\n", 1000)
+	output := padding + "fatal: not a git repository\n" + padding
+	if got := classifyTaskError(output); got != ErrClassGit {
+		t.Errorf("should find git error in long output, got %s", got)
+	}
+}
+
+func TestClassify_MultilineErrors(t *testing.T) {
+	output := `Building project...
+Step 1/10: ok
+Step 2/10: ok
+error: could not compile 'mycrate'
+aborting due to previous error`
+	if got := classifyTaskError(output); got != ErrClassDeps {
+		t.Errorf("multiline: got %s, want deps", got)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// extractErrorSummary: 다양한 출력 패턴
+// ══════════════════════════════════════════════════════════════
+
+func TestExtractErrorSummary_ErrorLine(t *testing.T) {
+	output := "Starting build...\nCompiling main.go\nerror: undefined variable x\nDone."
+	got := extractErrorSummary(output)
+	if got != "error: undefined variable x" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestExtractErrorSummary_NotFoundLine(t *testing.T) {
+	output := "Looking for config...\nConfig file not found in /etc/app\nUsing defaults"
+	got := extractErrorSummary(output)
+	if !strings.Contains(got, "not found") {
+		t.Errorf("should pick 'not found' line, got %q", got)
+	}
+}
+
+func TestExtractErrorSummary_PermissionLine(t *testing.T) {
+	output := "Opening /var/log/app.log\npermission denied while opening file\nFailed"
+	got := extractErrorSummary(output)
+	if !strings.Contains(got, "permission denied") {
+		t.Errorf("should pick 'permission denied' line, got %q", got)
+	}
+}
+
+func TestExtractErrorSummary_CannotLine(t *testing.T) {
+	output := "Resolving deps...\ncannot find module providing package foo\nAborted"
+	got := extractErrorSummary(output)
+	if !strings.Contains(got, "cannot") {
+		t.Errorf("should pick 'cannot' line, got %q", got)
+	}
+}
+
+func TestExtractErrorSummary_NoKeywordLine(t *testing.T) {
+	// No recognizable keyword → returns full output (or truncated)
+	output := "step 1 ok\nstep 2 ok\nstep 3 failed\nexit 1"
+	got := extractErrorSummary(output)
+	// Should return full output since no keyword match
+	if got != output {
+		t.Errorf("should return full output when no keyword, got %q", got)
+	}
+}
+
+func TestExtractErrorSummary_TruncatesLongOutput(t *testing.T) {
+	output := strings.Repeat("x", 300)
+	got := extractErrorSummary(output)
+	if len(got) > 201 { // 200 + possible trailing
+		t.Errorf("should truncate to ~200, got len=%d", len(got))
+	}
+}
+
+func TestExtractErrorSummary_Empty(t *testing.T) {
+	if got := extractErrorSummary(""); got != "" {
+		t.Errorf("empty → %q, want empty", got)
+	}
+}
+
+func TestExtractErrorSummary_TrimsWhitespace(t *testing.T) {
+	output := "  \n  error: something broke   \n  "
+	got := extractErrorSummary(output)
+	if got != "error: something broke" {
+		t.Errorf("should trim, got %q", got)
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// taskHash: 결정론적, 충돌 없음, edge cases
+// ══════════════════════════════════════════════════════════════
+
+func TestTaskHash_Deterministic_Thorough(t *testing.T) {
+	h1 := taskHash("hello world")
+	h2 := taskHash("hello world")
+	if h1 != h2 {
+		t.Errorf("same input, different hashes: %s vs %s", h1, h2)
+	}
+}
+
+func TestTaskHash_DifferentInputs(t *testing.T) {
+	h1 := taskHash("task A")
+	h2 := taskHash("task B")
+	if h1 == h2 {
+		t.Error("different inputs should produce different hashes")
+	}
+}
+
+func TestTaskHash_EmptyString(t *testing.T) {
+	h := taskHash("")
+	if h == "" {
+		t.Error("empty string should still produce a hash")
+	}
+	if len(h) != 16 { // sha256[:8] → 16 hex chars
+		t.Errorf("hash len = %d, want 16", len(h))
+	}
+}
+
+func TestTaskHash_LongInput(t *testing.T) {
+	long := strings.Repeat("a", 10000)
+	h := taskHash(long)
+	if len(h) != 16 {
+		t.Errorf("hash len = %d, want 16", len(h))
+	}
+}
+
+func TestTaskHash_Unicode(t *testing.T) {
+	h1 := taskHash("한국어 작업")
+	h2 := taskHash("한국어 작업")
+	if h1 != h2 {
+		t.Error("unicode should be deterministic")
+	}
+	h3 := taskHash("다른 작업")
+	if h1 == h3 {
+		t.Error("different unicode should differ")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// repairCooldown: concurrent access, 다중 task
+// ══════════════════════════════════════════════════════════════
+
+func TestRepairCooldown_DifferentTasks(t *testing.T) {
+	// 서로 다른 task는 독립적 cooldown
+	markRepairAttempted("task-alpha-unique-123")
+	if !isRepairCoolingDown("task-alpha-unique-123") {
+		t.Error("alpha should be cooling down")
+	}
+	if isRepairCoolingDown("task-beta-unique-456") {
+		t.Error("beta should NOT be cooling down")
+	}
+}
+
+func TestRepairCooldown_Concurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			task := "concurrent-cooldown-" + string(rune('A'+n%26))
+			markRepairAttempted(task)
+			_ = isRepairCoolingDown(task)
+		}(i)
+	}
+	wg.Wait()
+	// no panic/deadlock = pass
+}
+
+// ══════════════════════════════════════════════════════════════
+// selfRepair: 각 ErrorClass별 분기 검증
+// ══════════════════════════════════════════════════════════════
+
+func TestSelfRepair_InstructionsNoRetry(t *testing.T) {
+	retry, fix := selfRepair(
+		"instructions-test-unique-xxx",
+		"error: instructions.md has stale instruction referencing issue #42 in task.md",
+		nil,
+	)
+	if retry {
+		t.Error("instructions class should not retry")
+	}
+	if fix != "" {
+		t.Errorf("fix should be empty, got %q", fix)
+	}
+}
+
+func TestSelfRepair_UnknownNoRetry(t *testing.T) {
+	retry, fix := selfRepair(
+		"unknown-test-unique-yyy",
+		"something completely unexpected happened",
+		nil,
+	)
+	if retry {
+		t.Error("unknown class should not retry")
+	}
+	if fix != "" {
+		t.Errorf("fix should be empty, got %q", fix)
+	}
+}
+
+func TestSelfRepair_CooldownBlocksSecondAttempt(t *testing.T) {
+	task := "cooldown-block-test-zzz"
+	// First attempt
+	selfRepair(task, "unknown error", nil)
+	// Second attempt should be blocked by cooldown
+	retry, _ := selfRepair(task, "unknown error", nil)
+	if retry {
+		t.Error("second attempt should be blocked by cooldown")
+	}
+}
+
+// ══════════════════════════════════════════════════════════════
+// ErrorClass string values
+// ══════════════════════════════════════════════════════════════
+
+func TestErrorClass_StringValues(t *testing.T) {
+	if ErrClassEnv != "env" {
+		t.Errorf("ErrClassEnv = %q", ErrClassEnv)
+	}
+	if ErrClassDeps != "deps" {
+		t.Errorf("ErrClassDeps = %q", ErrClassDeps)
+	}
+	if ErrClassGit != "git" {
+		t.Errorf("ErrClassGit = %q", ErrClassGit)
+	}
+	if ErrClassInstructions != "instructions" {
+		t.Errorf("ErrClassInstructions = %q", ErrClassInstructions)
+	}
+	if ErrClassUnknown != "unknown" {
+		t.Errorf("ErrClassUnknown = %q", ErrClassUnknown)
+	}
+}


### PR DESCRIPTION
## Summary
- 모든 provider 에러에 `RecordFailure()` 호출하도록 수정 (auth 에러 제외)
- 기존: `isRetryable()`인 경우만 circuit에 기록 → "You've hit your limit" 같은 메시지가 circuit을 열지 못하는 버그
- `isRetryable`에 `hit your limit`, `usage limit`, `limit exceeded`, `quota exceeded` 키워드 추가
- 테스트 4파일 95개 추가 (circuit breaker 상태 머신, 타이밍 경계, 동시성, self-repair 분류, 유틸 edge case)

## Test plan
- [x] `go test ./...` 전체 6/6 PASS (202개 테스트)
- [x] 실제 발생했던 "You've hit your limit · resets 6pm (UTC)" 메시지 패턴 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)