### PR TITLE
fix: post-review — scribe dal, wisdom path, stateDir hash, .dal ro overlay

### DIFF
--- a/.dal/scribe/dal.cue
+++ b/.dal/scribe/dal.cue
@@ -1,0 +1,15 @@
+uuid:           "scribe-auto"
+name:           "scribe"
+version:        "1.0.0"
+player:         "claude"
+model:          "haiku"
+role:           "member"
+skills:         ["skills/history-hygiene", "skills/inbox-protocol"]
+hooks:          []
+auto_task:      "1. /workspace/decisions/inbox/ 파일 → decisions.md 병합 (중복 제거 후 삭제). 2. 각 dal /workspace/history-buffer/ → .dal/{name}/history.md 병합. 3. /workspace/wisdom-inbox/ → wisdom.md 병합. 4. history.md 12KB 초과 시 Core Context 압축. 5. decisions.md 50KB 초과 시 30일+ 항목 archive. 6. 변경 시 git add + commit + push."
+auto_interval:  "30m"
+git: {
+	user:         "dal-scribe"
+	email:        "dal-scribe@dalcenter.local"
+	github_token: "env:GITHUB_TOKEN"
+}

--- a/.dal/scribe/instructions.md
+++ b/.dal/scribe/instructions.md
@@ -1,0 +1,21 @@
+# Scribe — 문서 관리자
+
+## Role
+팀 공유 기억의 유일한 file writer + committer.
+
+## Responsibilities
+1. /workspace/decisions/inbox/ → decisions.md 병합 (중복 제거: By + What 조합 기준)
+2. /workspace/wisdom-inbox/ → wisdom.md 병합
+3. /workspace/history-buffer/{name}.md → .dal/{name}/history.md 병합
+4. history.md 12KB 초과 시 Core Context로 압축
+5. decisions.md 50KB 초과 시 30일+ 항목 → decisions-archive.md
+6. 변경 시 git add + commit + push
+
+## Boundaries
+I handle: inbox 병합, history 압축, 아카이빙, 자동 커밋
+I don't handle: 코드, 리뷰, 테스트, 라우팅, Mattermost 대화
+
+## Rules
+- push 실패 시 재시도만. force push, reset 금지. 3회 실패 시 leader에게 claim.
+- 병합 후 inbox 파일 삭제.
+- history에는 최종 결과만. 중간 상태 금지.

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -146,6 +146,8 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 	isCloneMode := dal.Workspace == "clone"
 	if serviceRepo != "" && !isCloneMode {
 		args = append(args, "-v", fmt.Sprintf("%s:%s", serviceRepo, containerWorkDir))
+		// .dal/ ro overlay — member가 .dal/ 우회 수정 방지 (Docker 후순위 mount가 이김)
+		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", localdalRoot, filepath.Join(containerWorkDir, ".dal")))
 	}
 
 	// Mount credentials (player-specific)

--- a/internal/daemon/persist.go
+++ b/internal/daemon/persist.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"log"
 	"os"
@@ -42,10 +44,14 @@ func stateDir(serviceRepo string) string {
 	if base == "" {
 		base = "/var/lib/dalcenter/state"
 	}
-	repoName := filepath.Base(serviceRepo)
-	if repoName == "" || repoName == "." {
-		repoName = "default"
+	// Use basename + short hash to avoid collisions between same-named repos
+	baseName := filepath.Base(serviceRepo)
+	if baseName == "" || baseName == "." {
+		baseName = "default"
 	}
+	absPath, _ := filepath.Abs(serviceRepo)
+	h := sha256.Sum256([]byte(absPath))
+	repoName := baseName + "-" + hex.EncodeToString(h[:])[:6]
 	dir := filepath.Join(base, repoName)
 	os.MkdirAll(dir, 0o755)
 	return dir

--- a/internal/daemon/persist_state_test.go
+++ b/internal/daemon/persist_state_test.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -11,8 +12,9 @@ func TestStateDir_CreatesDirectory(t *testing.T) {
 	t.Setenv("DALCENTER_STATE_DIR", tmp)
 
 	dir := stateDir("/path/to/myrepo")
-	if filepath.Base(dir) != "myrepo" {
-		t.Errorf("got %s, want myrepo suffix", dir)
+	base := filepath.Base(dir)
+	if !strings.HasPrefix(base, "myrepo-") {
+		t.Errorf("got %s, want myrepo-{hash} prefix", base)
 	}
 	if _, err := os.Stat(dir); err != nil {
 		t.Errorf("directory not created: %v", err)
@@ -24,8 +26,9 @@ func TestStateDir_DefaultName(t *testing.T) {
 	t.Setenv("DALCENTER_STATE_DIR", tmp)
 
 	dir := stateDir("")
-	if filepath.Base(dir) != "default" {
-		t.Errorf("got %s, want default", filepath.Base(dir))
+	base := filepath.Base(dir)
+	if !strings.HasPrefix(base, "default-") {
+		t.Errorf("got %s, want default-{hash} prefix", base)
 	}
 }
 

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -153,10 +153,11 @@ const defaultScribeCue = `uuid:           "scribe-auto"
 name:           "scribe"
 version:        "1.0.0"
 player:         "claude"
+model:          "haiku"
 role:           "member"
 skills:         []
 hooks:          []
-auto_task:      "1. /workspace/decisions/inbox/ 파일 → decisions.md 병합 (중복 제거 후 삭제). 2. 각 dal history-buffer → .dal/{name}/history.md 병합. 3. wisdom/inbox → wisdom.md 병합. 4. history.md 12KB 초과 시 Core Context 압축. 5. decisions.md 50KB 초과 시 30일+ 항목 archive. 6. 변경 시 git add + commit + push."
+auto_task:      "1. /workspace/decisions/inbox/ 파일 → decisions.md 병합 (중복 제거 후 삭제). 2. 각 dal /workspace/history-buffer/ → .dal/{name}/history.md 병합. 3. /workspace/wisdom-inbox/ → wisdom.md 병합. 4. history.md 12KB 초과 시 Core Context 압축. 5. decisions.md 50KB 초과 시 30일+ 항목 archive. 6. 변경 시 git add + commit + push."
 auto_interval:  "30m"
 git: {
 	user:         "dal-scribe"
@@ -171,9 +172,9 @@ const defaultScribeInstructions = `# Scribe — 문서 관리자
 팀 공유 기억의 유일한 file writer + committer. 사용자에게 보이지 않는 백그라운드 dal.
 
 ## Responsibilities
-1. decisions/inbox/ → decisions.md 병합 (중복 제거: By + What 조합 기준)
-2. wisdom/inbox/ → wisdom.md 병합
-3. history-buffer/{name}.md → .dal/{name}/history.md 병합
+1. /workspace/decisions/inbox/ → decisions.md 병합 (중복 제거: By + What 조합 기준)
+2. /workspace/wisdom-inbox/ → wisdom.md 병합
+3. /workspace/history-buffer/{name}.md → .dal/{name}/history.md 병합
 4. history.md 12KB 초과 시 Core Context로 압축
 5. decisions.md 50KB 초과 시 30일+ 항목 → decisions-archive.md
 6. 변경 시 git add + commit + push


### PR DESCRIPTION
## Summary
리뷰 피드백 6건 반영:
1. `.dal/scribe/` 실제 생성 (dal.cue + instructions.md)
2. scribe 경로 통일 (`wisdom/inbox` → `/workspace/wisdom-inbox`)
3. scribe `model: "haiku"` 추가
4. stateDir에 절대경로 해시 추가 (동명 레포 충돌 방지)
5. `.dal/` ro overlay mount (`docker.go`) — member 우회 수정 방지
6. Init() 기본 scribe 템플릿 동기화

## Test plan
- [x] `go build ./...` 7/7
- [x] `go test ./...` 7/7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)