### PR TITLE
fix: gitignore state mount files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ channels/mattermost/bun.lock
 channels/mattermost/node_modules/
 channels/mattermost/bun.lock
 .claude/worktrees/
+
+# State files mounted from /var/lib/dalcenter/state/ (git 밖)
+now.md
+decisions/inbox/
+history-buffer/
+wisdom-inbox/


### PR DESCRIPTION
state mount 파일(now.md, inbox, history-buffer, wisdom-inbox)이 git에 잡히지 않도록 .gitignore 추가. PR #332 재발 방지.