### PR TITLE
feat: dal-leaders 공유 채널 — leader 간 cross-project 소통

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -153,6 +153,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 		} else {
 			d.channelID = channelID
 			log.Printf("[daemon] mattermost: team=%s channel=%s (%s)", teamID, channelID[:8], repoName)
+
+			// dal-leaders 공유 채널 자동 생성 (cross-project leader 소통)
+			if leadersChID, err := talk.FindOrCreateChannel(d.mm.URL, d.mm.AdminToken, teamID, "dal-leaders"); err == nil {
+				log.Printf("[daemon] dal-leaders channel ready: %s", leadersChID[:8])
+			}
 		}
 	}
 
@@ -349,6 +354,16 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		} else {
 			botToken = bot.Token
 			log.Printf("[daemon] mattermost bot: %s (user=%s)", botUsername, bot.UserID[:8])
+
+			// Leader → dal-leaders 공유 채널에도 자동 참여 (cross-project 소통)
+			if dal.Role == "leader" {
+				leadersChName := "dal-leaders"
+				if leadersChID, err := talk.FindOrCreateChannel(d.mm.URL, d.mm.AdminToken, teamID, leadersChName); err == nil {
+					if err := talk.AddUserToChannel(d.mm.URL, d.mm.AdminToken, leadersChID, bot.UserID); err == nil {
+						log.Printf("[daemon] leader %s joined dal-leaders channel", botUsername)
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/talk/bot.go
+++ b/internal/talk/bot.go
@@ -259,6 +259,26 @@ func DeleteChannel(mmURL, token, channelID string) error {
 	return err
 }
 
+// FindOrCreateChannel finds an existing channel by name, or creates it.
+func FindOrCreateChannel(mmURL, adminToken, teamID, channelName string) (string, error) {
+	mmURL = strings.TrimRight(mmURL, "/")
+	resp, err := mmAPI("GET", mmURL+"/api/v4/teams/"+teamID+"/channels/name/"+channelName, adminToken, "")
+	if err == nil {
+		if id := jsonStr(resp, "id"); id != "" {
+			return id, nil
+		}
+	}
+	return CreateChannel(mmURL, adminToken, teamID, channelName)
+}
+
+// AddUserToChannel adds a user to a Mattermost channel.
+func AddUserToChannel(mmURL, adminToken, channelID, userID string) error {
+	mmURL = strings.TrimRight(mmURL, "/")
+	body := fmt.Sprintf(`{"user_id":%q}`, userID)
+	_, err := mmAPI("POST", mmURL+"/api/v4/channels/"+channelID+"/members", adminToken, body)
+	return err
+}
+
 func mmAPI(method, url, token, body string) ([]byte, error) {
 	var bodyReader io.Reader
 	if body != "" {


### PR DESCRIPTION
## Summary
- `dalcenter serve` 시 `dal-leaders` 채널 자동 생성
- leader `wake` 시 해당 채널에 자동 참여
- 5개 프로젝트의 leader가 하나의 채널에서 소통 가능
- bridge가 이미 참여한 모든 채널을 polling하므로 추가 변경 없음

## 소통 구조
```
dal-leaders 채널 (공유)
  ├── dalcenter leader
  ├── veilkey leader
  ├── bridge-of-gaya leader
  ├── veilkey-v2 leader
  └── dal-qa-team leader

각 프로젝트 채널 (독립)
  └── leader ↔ member (assign/report)
```