### PR TITLE
fix: SetupBot 기존 봇 토큰 revoke-all + create-one (#355)

### DIFF
--- a/internal/talk/bot.go
+++ b/internal/talk/bot.go
@@ -41,21 +41,16 @@ func SetupBot(mmURL, adminToken, teamID, channelID, username, displayName, descr
 		}
 	}
 
-	// Reuse existing token if available, otherwise create new one
-	var token, tokenID string
+	// Revoke all existing tokens, then create exactly one new token
 	existingTokens, _ := mmAPI("GET", mmURL+"/api/v4/users/"+userID+"/tokens", adminToken, "")
 	if existingTokens != nil {
-		var tokens []map[string]interface{}
-		if json.Unmarshal(existingTokens, &tokens) == nil && len(tokens) > 0 {
-			// Reuse first active token's ID (can't read the token value, need new one)
-			// But if we already have too many tokens, revoke old ones first
-			for i, t := range tokens {
-				if i >= 2 { // keep max 2 tokens, revoke older ones
-					if tid, ok := t["id"].(string); ok {
-						mmAPI("POST", mmURL+"/api/v4/users/"+userID+"/tokens/revoke", adminToken,
-							fmt.Sprintf(`{"token_id":%q}`, tid))
-					}
-				}
+		var tokens []struct {
+			ID string `json:"id"`
+		}
+		if json.Unmarshal(existingTokens, &tokens) == nil {
+			for _, t := range tokens {
+				mmAPI("POST", mmURL+"/api/v4/users/"+userID+"/tokens/revoke", adminToken,
+					fmt.Sprintf(`{"token_id":%q}`, t.ID))
 			}
 		}
 	}
@@ -64,8 +59,8 @@ func SetupBot(mmURL, adminToken, teamID, channelID, username, displayName, descr
 	if err != nil {
 		return nil, fmt.Errorf("create token: %w", err)
 	}
-	token = jsonStr(tokenResp, "token")
-	tokenID = jsonStr(tokenResp, "id")
+	token := jsonStr(tokenResp, "token")
+	tokenID := jsonStr(tokenResp, "id")
 
 	// Add to team
 	_, err = mmAPI("POST", mmURL+"/api/v4/teams/"+teamID+"/members", adminToken,


### PR DESCRIPTION
## Summary
- `SetupBot`에서 기존 봇 재사용 시 **모든 기존 토큰을 revoke**한 후 새 토큰 1개만 생성
- 기존 "max 2 토큰 유지" 로직 제거 → 깔끔한 revoke-all + create-one 패턴
- `TeardownBot`과 동일한 토큰 정리 패턴 통일

## Problem
wake마다 `SetupBot` 호출 → 기존 토큰 일부만 정리 → 토큰 누적 → 봇 리소스 낭비

## Fix
기존 토큰 전부 revoke 후 새 토큰 1개만 생성. wisdom anti-pattern #8 ("wake마다 새 봇 생성") 해소.

## Test plan
- [ ] wake/sleep 반복 후 봇 토큰이 1개만 유지되는지 확인
- [ ] 기존 봇 재사용 시 mention(@username) 정상 동작 확인

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Authored-by: @dal-dev-dev202