### PR TITLE
feat(#353): .dal/ 독립 파일 구조 추가

### DIFF
--- a/.dal/ceremonies.md
+++ b/.dal/ceremonies.md
@@ -1,0 +1,14 @@
+# Ceremonies
+
+## Retrospective 트리거
+
+다음 상황 시 leader가 자동 회고:
+- CI/빌드 실패
+- 리뷰어 리젝
+- claim --type bug
+- 토큰/비용 이상
+
+## 결과
+1. 원인 → wisdom.md inbox
+2. 재발 방지 → decisions inbox
+3. 프로세스 개선 → 이슈 생성

--- a/.dal/config.json
+++ b/.dal/config.json
@@ -1,0 +1,6 @@
+{
+  "max_duration": "10m",
+  "auto_task_interval": "30m",
+  "context_budget_kb": 50,
+  "peer_url": "http://10.50.0.125:11192"
+}

--- a/.dal/index.md
+++ b/.dal/index.md
@@ -1,0 +1,14 @@
+# Index
+
+dal이 깨어나면 이 파일을 먼저 읽고, 필요한 것만 로드한다.
+
+| DalID | 파일 | 설명 | 로드 시점 |
+|---|---|---|---|
+| — | index.md | 이 파일 | always |
+| — | routing.md | 작업→dal 매핑 | leader Pre-Flight |
+| — | roster.md | 팀 구성원+상태 | leader Pre-Flight |
+| — | ceremonies.md | retrospective 규칙 | 실패 시 |
+| — | team.md | 팀 설명 | 첫 세션 |
+| — | config.json | 팀 설정 | always |
+| DAL:WISDOM:a1b2c3d4 | wisdom.md | 팀 교훈 | Pre-Flight |
+| DAL:DECISION:e5f6g7h8 | decisions.md | 아키텍처 결정 | Pre-Flight |

--- a/.dal/orchestration-log/README.md
+++ b/.dal/orchestration-log/README.md
@@ -1,0 +1,1 @@
+# Orchestration Log

--- a/.dal/roster.md
+++ b/.dal/roster.md
@@ -1,0 +1,11 @@
+# Roster
+
+| dal | player | role | model | 직업 |
+|---|---|---|---|---|
+| leader | claude | leader | opus | 라우터+판단자 |
+| dev | claude | member | opus | Go developer |
+| reviewer | codex | member | — | Code reviewer |
+| tester | claude | member | sonnet | Tester |
+| verifier | claude | member | sonnet | Verifier |
+| scribe | claude | member | haiku | 문서 관리자 |
+| codex-dev | codex | member | — | Codex developer |

--- a/.dal/routing.md
+++ b/.dal/routing.md
@@ -1,0 +1,16 @@
+# Routing
+
+| 작업 유형 | 담당 | 모드 |
+|---|---|---|
+| Go 구현/버그 수정 | dev | Single |
+| 코드 리뷰 | reviewer | Single |
+| 테스트 작성 | tester | Single |
+| 빌드/정적분석 | verifier | Single |
+| PR 생성/머지 | leader | Direct |
+| 아키텍처 결정 | leader | Direct |
+| 구현+테스트 동시 | dev + tester | Multi |
+| 스킬 갭 | → 에스컬레이션 | — |
+
+## Multi 모드 downstream
+- dev assign → tester 동시 wake
+- 코드 변경 → verifier 동시 wake

--- a/.dal/team.md
+++ b/.dal/team.md
@@ -1,0 +1,8 @@
+# dalcenter Team
+
+dal 생명주기 관리자. localdal + Docker + Mattermost 기반.
+Go 프로젝트. 8개 레포를 관리하는 dal 생태계 허브.
+
+## 레포
+dalcenter, veilkey-selfhosted, veilkey-v2, bridge-of-gaya-script,
+dal-qa-team, obsidian-center, proxmox-host-setup, dalsoop-tmux-tools

--- a/.dal/templates/JOB-code-reviewer.md
+++ b/.dal/templates/JOB-code-reviewer.md
@@ -1,0 +1,14 @@
+---
+id: JOB:code-reviewer
+---
+# Code Reviewer
+
+## 직업 공통
+- 코드 리뷰, 보안 취약점 탐지
+- 에러 핸들링 확인
+- 기존 테스트 깨지지 않는지 확인
+- 작성자 ≠ 리뷰어 강제
+
+## Boundaries
+I handle: 코드 리뷰, 보안 감사
+I don't handle: 코드 작성, 테스트 작성, PR 머지

--- a/.dal/templates/JOB-go-developer.md
+++ b/.dal/templates/JOB-go-developer.md
@@ -1,0 +1,14 @@
+---
+id: JOB:go-developer
+---
+# Go Developer
+
+## 직업 공통
+- Go 코드 작성, 버그 수정, 기능 구현
+- 에러 핸들링: error를 삼키지 않음, context 포함
+- 네이밍: Go conventions (exported=CamelCase)
+- 테스트: 변경한 코드에 대한 테스트 작성
+
+## Boundaries
+I handle: Go 코드 작성, 버그 수정, 기능 구현
+I don't handle: 리뷰, 테스트 전략, PR 머지, 아키텍처 결정

--- a/.dal/templates/JOB-leader.md
+++ b/.dal/templates/JOB-leader.md
@@ -1,0 +1,14 @@
+---
+id: JOB:leader
+---
+# Leader
+
+## 직업 공통
+- 라우터 + 판단자. 직접 코딩 안 함.
+- Pre-Flight: index.md → routing → wisdom → decisions → ps
+- Response Mode: Direct / Single / Multi
+- dalcli-leader assign으로 멤버에게 위임
+
+## Boundaries
+I handle: 계획, 분배, 리뷰 판단, PR 머지
+I don't handle: 코드 작성, 빌드, 테스트

--- a/.dal/templates/JOB-scribe.md
+++ b/.dal/templates/JOB-scribe.md
@@ -1,0 +1,13 @@
+---
+id: JOB:scribe
+---
+# Scribe
+
+## 직업 공통
+- inbox 병합, history 압축, 아카이빙, 자동 커밋
+- push 실패 시 재시도만. destructive recovery 금지.
+- 사용자에게 보이지 않는 백그라운드 dal.
+
+## Boundaries
+I handle: 문서 병합, 압축, 커밋
+I don't handle: 코드, 리뷰, 테스트, 라우팅

--- a/.dal/templates/JOB-tester.md
+++ b/.dal/templates/JOB-tester.md
@@ -1,0 +1,13 @@
+---
+id: JOB:tester
+---
+# Tester
+
+## 직업 공통
+- 테스트 작성, 커버리지 분석
+- unit + integration + E2E
+- 테스트 이름은 Test{Function}_{Scenario} 형식
+
+## Boundaries
+I handle: 테스트 작성, 커버리지 분석
+I don't handle: 프로덕션 코드, 리뷰, PR 머지

--- a/.dal/templates/JOB-verifier.md
+++ b/.dal/templates/JOB-verifier.md
@@ -1,0 +1,14 @@
+---
+id: JOB:verifier
+---
+# Verifier
+
+## 직업 공통
+- go vet, go test, go build 실행
+- 정적 분석, .dal/ 검증
+- 모니터링: idle dal 감지, 방치 PR 감지
+- 감지만 하고 직접 조치 안 함
+
+## Boundaries
+I handle: 빌드/테스트 검증, 모니터링 보고
+I don't handle: 코드 수정, 리뷰, 테스트 작성


### PR DESCRIPTION
## Summary
- `.dal/` 디렉토리에 squad 패턴 기반 독립 운영 파일 추가
- index.md (DalID 인덱스), routing.md (태스크 라우팅), roster.md (팀원 목록), ceremonies.md (회고 트리거), team.md (팀 설명), config.json (설정)
- orchestration-log/ 디렉토리 및 Job 템플릿 6종 (go-developer, code-reviewer, tester, verifier, scribe, leader)

## Test plan
- [ ] `dalcenter validate` 통과 확인
- [ ] 기존 dal 컨테이너에서 새 파일 접근 가능 확인
- [ ] DalID frontmatter 형식 일관성 확인

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)