### PR TITLE
fix: 멘션 인식 + 자기 메시지 루프 방지

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -95,6 +95,9 @@ func runAgentLoop(dalName string) error {
 	}()
 
 	mm := bridge.NewMattermostBridge(cfg.MMURL, cfg.BotToken, cfg.ChannelID, 5*time.Second)
+	if os.Getenv("DAL_NO_DM") == "1" {
+		mm.NoDM = true
+	}
 	if err := mm.Connect(); err != nil {
 		return fmt.Errorf("mattermost connect: %w", err)
 	}
@@ -109,6 +112,8 @@ func runAgentLoop(dalName string) error {
 	} else {
 		mention = fmt.Sprintf("@dal-%s", dalName)
 	}
+	// Also respond to @{dalName} directly (e.g. @dalroot without dal- prefix)
+	altMention := fmt.Sprintf("@%s", dalName)
 	var activeThreads sync.Map
 
 	// Periodic auto-task support: DAL_AUTO_TASK + DAL_AUTO_INTERVAL
@@ -175,7 +180,7 @@ func runAgentLoop(dalName string) error {
 			continue
 		}
 
-		isDirectMention := strings.Contains(msg.Content, mention)
+		isDirectMention := strings.Contains(msg.Content, mention) || strings.Contains(msg.Content, altMention)
 		isThreadReply := msg.RootID != "" && isActiveThread(&activeThreads, msg.RootID)
 		isDM := msg.Channel != "" && msg.Channel != cfg.ChannelID // DM = different channel than main
 
@@ -195,6 +200,7 @@ func runAgentLoop(dalName string) error {
 		if task == "" && isDirectMention {
 			// Free-form: strip mention, use entire message
 			task = strings.TrimSpace(strings.ReplaceAll(msg.Content, mention, ""))
+			task = strings.TrimSpace(strings.ReplaceAll(task, altMention, ""))
 		}
 		if task == "" && isThreadReply {
 			task = msg.Content

--- a/internal/bridge/mattermost.go
+++ b/internal/bridge/mattermost.go
@@ -22,6 +22,7 @@ type MattermostBridge struct {
 	Token        string
 	ChannelID    string
 	BotUserID    string
+	NoDM         bool             // disable DM channel polling
 	dmLastAt     map[string]int64 // per-DM-channel lastAt
 	PollInterval time.Duration
 
@@ -91,6 +92,9 @@ func (m *MattermostBridge) poll() {
 		}
 
 		posts, err := m.fetchNewPosts()
+		if len(posts) > 0 {
+			log.Printf("[bridge] fetched %d posts", len(posts))
+		}
 		if err != nil {
 			// Non-retryable: auth failure → stop polling
 			if errors.Is(err, ErrAuthFailed) {
@@ -140,7 +144,7 @@ func (m *MattermostBridge) poll() {
 
 func (m *MattermostBridge) fetchNewPosts() ([]Message, error) {
 	channels := []string{m.ChannelID}
-	if m.BotUserID != "" {
+	if m.BotUserID != "" && !m.NoDM {
 		if dms, err := m.fetchDMChannelIDs(); err == nil {
 			channels = append(channels, dms...)
 		}
@@ -200,7 +204,11 @@ func (m *MattermostBridge) fetchNewPosts() ([]Message, error) {
 			if post.CreateAt > m.lastAt {
 				m.lastAt = post.CreateAt
 			}
-			allMsgs = append(allMsgs, Message{
+			// Skip own messages at bridge level to prevent self-response loops
+		if post.UserID == m.BotUserID {
+			continue
+		}
+		allMsgs = append(allMsgs, Message{
 				ID:        post.ID,
 				From:      post.UserID,
 				Channel:   post.ChannelID,


### PR DESCRIPTION
## Summary
- bridge에서 자기 UserID 메시지 필터 (self-response loop 방지)
- NoDM 플래그로 DM 채널 폴링 비활성화 (DAL_NO_DM=1)
- altMention으로 @{name} 직접 멘션 인식 (@dalroot 등)

## Context
dalroot를 PVE 호스트에서 실행 시 발생한 3가지 문제 해결:
1. 자기 메시지에 반복 반응 (무한 루프)
2. 다른 dal의 DM에 반응
3. @dalroot 멘션을 @dal-dalroot로 기대해서 인식 실패

## Test plan
- [x] dalroot가 @dalroot 멘션에 응답
- [x] 응답 후 자기 메시지에 재반응하지 않음
- [x] DM 채널 메시지에 반응하지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)