### PR TITLE
fix: codex fallback 작업 디렉토리 수정

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -693,9 +693,10 @@ func runClaude(player, task string) (string, error) {
 	var cmd *exec.Cmd
 	switch player {
 	case "codex":
+		workDir, _ := os.Getwd()
 		cmd = exec.Command("codex", "exec",
 			"--dangerously-bypass-approvals-and-sandbox",
-			"-C", "/workspace",
+			"-C", workDir,
 			task)
 	default: // claude
 		// Build allowed tools based on role and extra permissions


### PR DESCRIPTION
## Summary
- codex exec의 -C 경로를 /workspace 하드코딩에서 os.Getwd()로 변경
- 호스트 모드(dalroot)에서 codex fallback 정상 작동 확인

## Test plan
- [x] codex exec --dangerously-bypass-approvals-and-sandbox -C $(pwd) 정상 실행
- [x] uptime 결과 정상 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)