### PR TITLE
feat: 중앙 provider 서킷브레이커 (4시간 codex 전환)

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -568,6 +568,46 @@ func notifyCredentialRefresh(dalName string) {
 	log.Printf("[agent] credential refresh requested for %s", dalName)
 }
 
+// fetchCentralProvider checks the dalcenter daemon's centralized provider circuit.
+// Returns the active provider (e.g. "codex") or empty string if unavailable.
+func fetchCentralProvider() string {
+	dcURL := os.Getenv("DALCENTER_URL")
+	if dcURL == "" {
+		return ""
+	}
+	resp, err := http.Get(dcURL + "/api/provider-status")
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return ""
+	}
+	var result struct {
+		ActiveProvider string `json:"active_provider"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ""
+	}
+	return result.ActiveProvider
+}
+
+// reportCentralTrip reports a rate limit to the dalcenter daemon's centralized circuit.
+func reportCentralTrip(dalName, reason string) {
+	dcURL := os.Getenv("DALCENTER_URL")
+	if dcURL == "" {
+		return
+	}
+	body := fmt.Sprintf(`{"dal_name":%q,"reason":%q}`, dalName, reason)
+	resp, err := http.Post(dcURL+"/api/provider-trip", "application/json", strings.NewReader(body))
+	if err != nil {
+		log.Printf("[central-circuit] trip report failed: %v", err)
+		return
+	}
+	resp.Body.Close()
+	log.Printf("[central-circuit] reported trip to daemon (by %s)", dalName)
+}
+
 func fetchAgentConfig(dalName string) (*agentConfig, error) {
 	dcURL := os.Getenv("DALCENTER_URL")
 	if dcURL == "" {
@@ -598,7 +638,17 @@ func executeTask(task string) (string, error) {
 	player := os.Getenv("DAL_PLAYER")
 	fallbackPlayer := detectFallback(player)
 
-	// If circuit is open, try fallback provider first
+	// Check centralized provider circuit first (dalcenter daemon level)
+	if centralPlayer := fetchCentralProvider(); centralPlayer != "" && centralPlayer != player {
+		log.Printf("[central-circuit] using %s (central override)", centralPlayer)
+		out, err := runProvider(centralPlayer, task)
+		if err == nil {
+			return out, nil
+		}
+		log.Printf("[central-circuit] %s failed: %v, falling through to local circuit", centralPlayer, err)
+	}
+
+	// Local circuit breaker fallback
 	if providerCircuit.ShouldFallback() && fallbackPlayer != "" {
 		log.Printf("[circuit] primary %s is open, trying fallback %s", player, fallbackPlayer)
 		out, err := runProvider(fallbackPlayer, task)
@@ -606,7 +656,6 @@ func executeTask(task string) (string, error) {
 			return out, nil
 		}
 		log.Printf("[circuit] fallback %s also failed: %v", fallbackPlayer, err)
-		// Fall through to retry primary
 	}
 
 	var lastOut string
@@ -634,6 +683,11 @@ func executeTask(task string) (string, error) {
 
 		// 모든 provider 에러 → circuit breaker에 기록
 		providerCircuit.RecordFailure()
+
+		// Rate limit → 중앙 서킷브레이커에 보고
+		if isRetryable(out) && providerCircuit.ShouldFallback() {
+			reportCentralTrip(os.Getenv("DAL_NAME"), truncate(out, 200))
+		}
 
 		// circuit open → fallback 시도
 		if providerCircuit.ShouldFallback() && fallbackPlayer != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -243,6 +243,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /api/escalations", d.handleEscalations)
 	mux.HandleFunc("POST /api/escalations/{id}/resolve", d.requireAuth(d.handleResolveEscalation))
 	// A2A protocol endpoints
+	mux.HandleFunc("GET /api/provider-status", d.handleProviderStatus)
+	mux.HandleFunc("POST /api/provider-trip", d.handleProviderTrip)
+
 	mux.HandleFunc("GET /.well-known/agent-card.json", d.handleAgentCard)
 	mux.HandleFunc("POST /rpc", d.requireAuth(d.handleA2ARPC))
 

--- a/internal/daemon/provider_circuit.go
+++ b/internal/daemon/provider_circuit.go
@@ -1,0 +1,125 @@
+package daemon
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ProviderCircuit is a centralized circuit breaker for AI provider rate limits.
+// When any dal reports a rate limit, ALL dals switch to fallback for the cooldown period.
+type ProviderCircuit struct {
+	mu           sync.RWMutex
+	primary      string        // default provider (e.g. "claude")
+	fallback     string        // fallback provider (e.g. "codex")
+	activePlayer string        // currently active provider
+	trippedAt    time.Time     // when circuit was tripped
+	cooldown     time.Duration // how long to stay on fallback
+	trippedBy    string        // which dal triggered it
+	reason       string        // error message
+}
+
+var globalCircuit = &ProviderCircuit{
+	primary:      "claude",
+	fallback:     "codex",
+	activePlayer: "claude",
+	cooldown:     4 * time.Hour,
+}
+
+// Trip switches all dals to fallback provider.
+func (pc *ProviderCircuit) Trip(dalName, reason string) {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.activePlayer == pc.fallback {
+		// Already on fallback
+		return
+	}
+
+	pc.activePlayer = pc.fallback
+	pc.trippedAt = time.Now()
+	pc.trippedBy = dalName
+	pc.reason = reason
+	log.Printf("[provider-circuit] TRIPPED by %s: %s → %s for %s (reason: %s)",
+		dalName, pc.primary, pc.fallback, pc.cooldown, reason)
+}
+
+// ActiveProvider returns the currently active provider, resetting if cooldown elapsed.
+func (pc *ProviderCircuit) ActiveProvider() string {
+	pc.mu.Lock()
+	defer pc.mu.Unlock()
+
+	if pc.activePlayer == pc.fallback && !pc.trippedAt.IsZero() {
+		if time.Since(pc.trippedAt) > pc.cooldown {
+			pc.activePlayer = pc.primary
+			log.Printf("[provider-circuit] cooldown elapsed → back to %s", pc.primary)
+		}
+	}
+	return pc.activePlayer
+}
+
+// Status returns circuit state for API response.
+func (pc *ProviderCircuit) Status() map[string]interface{} {
+	pc.mu.RLock()
+	defer pc.mu.RUnlock()
+
+	result := map[string]interface{}{
+		"active_provider": pc.activePlayer,
+		"primary":         pc.primary,
+		"fallback":        pc.fallback,
+		"cooldown":        pc.cooldown.String(),
+	}
+	if pc.activePlayer == pc.fallback && !pc.trippedAt.IsZero() {
+		remaining := pc.cooldown - time.Since(pc.trippedAt)
+		if remaining < 0 {
+			remaining = 0
+		}
+		result["tripped_at"] = pc.trippedAt.Format(time.RFC3339)
+		result["tripped_by"] = pc.trippedBy
+		result["reason"] = pc.reason
+		result["resets_in"] = remaining.String()
+	}
+	return result
+}
+
+// handleProviderStatus returns the current provider circuit state.
+func (d *Daemon) handleProviderStatus(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(globalCircuit.Status())
+}
+
+// handleProviderTrip allows a dal to report a rate limit, tripping the circuit.
+func (d *Daemon) handleProviderTrip(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DalName string `json:"dal_name"`
+		Reason  string `json:"reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), 400)
+		return
+	}
+	if req.DalName == "" {
+		http.Error(w, "dal_name required", 400)
+		return
+	}
+
+	globalCircuit.Trip(req.DalName, req.Reason)
+
+	// Notify via Mattermost if available
+	if d.mm != nil && d.channelID != "" {
+		msg := fmt.Sprintf("⚡ **Provider Circuit Tripped** by %s\n전체 dal이 **%s → %s**로 전환 (4시간)\n사유: %s",
+			req.DalName, globalCircuit.primary, globalCircuit.fallback, req.Reason)
+		body := fmt.Sprintf(`{"channel_id":%q,"message":%q}`, d.channelID, msg)
+		r2, _ := http.NewRequest("POST", d.mm.URL+"/api/v4/posts", strings.NewReader(body))
+		r2.Header.Set("Authorization", "Bearer "+d.mm.AdminToken)
+		r2.Header.Set("Content-Type", "application/json")
+		http.DefaultClient.Do(r2)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(globalCircuit.Status())
+}


### PR DESCRIPTION
## Summary
- dalcenter 데몬에 중앙 서킷브레이커 추가
- 아무 dal이든 Claude rate limit 보고 → 전체 dal이 codex로 4시간 전환
- `/api/provider-status` — 현재 active provider 조회
- `/api/provider-trip` — rate limit 보고 (자동 전환 트리거)
- MM 채널에 자동 공지

## Flow
1. dal-dev가 Claude rate limit 3회 실패
2. `POST /api/provider-trip` → 중앙 circuit trip
3. 이후 모든 dal이 `GET /api/provider-status` → active_provider=codex
4. 4시간 후 자동으로 claude 복귀

## Test plan
- [x] `/api/provider-status` 정상 응답
- [x] `/api/provider-trip` → active_provider codex 전환
- [x] resets_in 카운트다운 확인
- [x] 데몬 재시작 → 리셋 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)