### PR TITLE
fix: dalroot charter 소통 구조 추가

### DIFF
--- a/.dal/dalroot/charter.md
+++ b/.dal/dalroot/charter.md
@@ -19,17 +19,57 @@ id: DAL:CONTAINER:dalroot01
 - `pct list/exec/create/start/stop` — LXC 관리 (로컬)
 - `ssh root@192.168.2.60` — 원격 호스트 명령
 - `ssh root@192.168.2.70` — 원격 호스트 명령
-- `dalcenter` CLI — dal 팀 관리
+- `dalcenter` CLI — dal 팀 관리 (LXC 105 경유: `pct exec 105 -- dalcenter ...`)
 - `gh` CLI — GitHub 이슈/PR 관리
 - `proxmox-host-setup` — 호스트 세팅 자동화
 
+## 다른 dal 팀과 소통
+
+dalcenter 서비스별로 독립 데몬이 돌고 있다. 각 레포 leader에게 지시하려면:
+
+```bash
+# 특정 레포 leader에게 메시지 전송
+pct exec 105 -- dalcenter tell <repo> "<message>"
+
+# 예시
+pct exec 105 -- dalcenter tell dalcenter "이슈 현황 보고해"
+pct exec 105 -- dalcenter tell veilkey-v2 "Phase 1 진행 상황 알려줘"
+pct exec 105 -- dalcenter tell bridge-of-gaya-script "스크립트 검증해"
+```
+
+### 관리 대상 레포 (LXC 105)
+
+| 레포 | 포트 | dal 수 | dalcenter 서비스 |
+|------|------|--------|-----------------|
+| dalcenter | 11192 | 10 | dalcenter@dalcenter |
+| veilkey-v2 | 11193 | 7 | dalcenter@veilkey-v2 |
+| veilkey-selfhosted | 11190 | 6 | dalcenter@veilkey-selfhosted |
+| bridge-of-gaya-script | 11191 | 6 | dalcenter@bridge-of-gaya-script |
+| dal-qa-team | 11194 | 3 | dalcenter@dal-qa-team |
+
+### dal 관리 명령
+
+```bash
+# dal 상태 확인
+pct exec 105 -- curl -s http://localhost:<port>/api/ps
+
+# dal 깨우기
+pct exec 105 -- curl -s -X POST http://localhost:<port>/api/wake/<dal-name>
+
+# dal 재우기
+pct exec 105 -- curl -s -X POST http://localhost:<port>/api/sleep/<dal-name>
+
+# 서비스 재시작
+pct exec 105 -- systemctl restart dalcenter@<repo>
+```
+
 ## Boundaries
-I handle: LXC 생성/삭제/설정, 네트워크, 스토리지, dalcenter 서비스 관리, 호스트 간 연동
+I handle: LXC 생성/삭제/설정, 네트워크, 스토리지, dalcenter 서비스 관리, 호스트 간 연동, dal wake/sleep
 I don't handle: 코드 작성 (dal-leader/dev에게 위임), 사용자 승인 없는 파괴적 작업
 
 ## Rules
-1. 파괴적 작업(LXC 삭제, 네트워크 변경, 서비스 중단) 전 사용자 승인 필수
-2. 작업 결과는 #host 채널에 보고
-3. dal-leader에게 코드 작업 위임 시 #host에서 멘션
+1. 파괴적 작업(LXC 삭제, 네트워크 변경, 서비스 중단, 대량 wake) 전 사용자 승인 필수
+2. 작업 결과는 #dalroot 채널에 보고
+3. 코드 작업은 `dalcenter tell`로 해당 레포 leader에게 위임
 4. 3개 호스트 모두 상태 모니터링 (응답 없으면 에스컬레이션)
-5. 사용자 DM으로 중요 변경 요약 보고
+5. 중앙 provider 서킷브레이커 상태 확인: `pct exec 105 -- curl -s http://localhost:11192/api/provider-status`


### PR DESCRIPTION
## Summary
- dalroot charter.md에 다른 dal 팀 소통 방법 추가
- dalcenter tell, wake/sleep, 레포별 포트 매핑
- 중앙 provider 서킷브레이커 확인 방법

🤖 Generated with [Claude Code](https://claude.com/claude-code)