### PR TITLE
fix: bridge 버퍼 블로킹 + tell UUID 멘션 (#448)

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -177,12 +177,16 @@ func runAgentLoop(dalName string) error {
 
 		// --- MM message handling (existing logic) ---
 		if msg.From == mm.BotUserID {
+			log.Printf("[agent] skipped own message: %s", truncate(msg.Content, 40))
 			continue
 		}
 
 		isDirectMention := strings.Contains(msg.Content, mention) || strings.Contains(msg.Content, altMention)
 		isThreadReply := msg.RootID != "" && isActiveThread(&activeThreads, msg.RootID)
 		isDM := msg.Channel != "" && msg.Channel != cfg.ChannelID // DM = different channel than main
+
+		log.Printf("[agent] msg from=%s mention=%v(m=%q alt=%q) thread=%v dm=%v content=%s",
+			msg.From[:8], isDirectMention, mention, altMention, isThreadReply, isDM, truncate(msg.Content, 60))
 
 		if !isDirectMention && !isThreadReply && !isDM {
 			continue

--- a/internal/bridge/mattermost.go
+++ b/internal/bridge/mattermost.go
@@ -54,7 +54,8 @@ func (m *MattermostBridge) Connect() error {
 	if m.BotUserID == "" {
 		return fmt.Errorf("could not determine bot user ID")
 	}
-	m.lastAt = time.Now().UnixMilli()
+	// Use channel's latest message timestamp to avoid fetching old messages
+	m.lastAt = m.fetchChannelLatestAt(m.ChannelID)
 	go m.poll()
 	return nil
 }
@@ -131,6 +132,13 @@ func (m *MattermostBridge) poll() {
 			case m.messages <- p:
 			case <-m.done:
 				return
+			default:
+				// Buffer full — drop oldest to prevent blocking
+				select {
+				case <-m.messages:
+				default:
+				}
+				m.messages <- p
 			}
 		}
 
@@ -167,7 +175,7 @@ func (m *MattermostBridge) fetchNewPosts() ([]Message, error) {
 				m.dmLastAt[chID] = sinceAt
 			}
 		}
-		path := fmt.Sprintf("/api/v4/channels/%s/posts?since=%d", chID, sinceAt)
+		path := fmt.Sprintf("/api/v4/channels/%s/posts?since=%d&per_page=50", chID, sinceAt)
 		data, err := m.apiGet(path)
 		if err != nil {
 			continue

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -691,12 +691,30 @@ func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 	// the dal's bridge will skip the message as "self".
 	token := d.mm.AdminToken
 
+	// Auto-prefix leader mention so the leader's dalcli picks up the message
+	// dalcli uses: mention=@dal-{name}-{uuidShort} or altMention=@{name}
+	msg := req.Message
+	d.mu.RLock()
+	for _, c := range d.containers {
+		if c.Role == "leader" {
+			// Construct exact mention: @dal-{name}-{uuidShort}
+			short := uuidShort(c.UUID)
+			mention := fmt.Sprintf("@dal-%s-%s", c.DalName, short)
+			altMention := "@" + c.DalName
+			if !strings.Contains(msg, mention) && !strings.Contains(msg, altMention) {
+				msg = mention + " " + msg
+			}
+			break
+		}
+	}
+	d.mu.RUnlock()
+
 	// Post message (with optional thread)
 	var body string
 	if req.ThreadID != "" {
-		body = fmt.Sprintf(`{"channel_id":%q,"message":%q,"root_id":%q}`, d.channelID, req.Message, req.ThreadID)
+		body = fmt.Sprintf(`{"channel_id":%q,"message":%q,"root_id":%q}`, d.channelID, msg, req.ThreadID)
 	} else {
-		body = fmt.Sprintf(`{"channel_id":%q,"message":%q}`, d.channelID, req.Message)
+		body = fmt.Sprintf(`{"channel_id":%q,"message":%q}`, d.channelID, msg)
 	}
 	respBody, err := mmPost(d.mm.URL, token, "/api/v4/posts", body)
 	if err != nil {


### PR DESCRIPTION
## Summary
- bridge per_page=50, non-blocking send, lastAt 초기화
- handleMessage에서 @dal-{name}-{uuidShort} 정확한 멘션 prefix  
- dalcli 디버그 로그

## Test
- [x] dalcenter tell veilkey-v2 → leader 수신 → dev에 지시 → 결과 보고
- [x] git log --oneline -3 결과 채널에 정상 출력

Closes #448
🤖 Generated with [Claude Code](https://claude.com/claude-code)