### PR TITLE
Fix soft-serve single-instance startup

### DIFF
--- a/internal/daemon/softserve.go
+++ b/internal/daemon/softserve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +14,11 @@ import (
 // startSoftServe starts soft-serve as a child process.
 // Returns nil cmd if soft-serve binary not found (non-fatal).
 func startSoftServe(ctx context.Context) (*exec.Cmd, error) {
+	if softServeAlreadyRunning(300 * time.Millisecond) {
+		log.Printf("[soft-serve] port %s already in use; assuming an existing instance and skipping child start", softServeSSHPort())
+		return nil, nil
+	}
+
 	softBin, err := exec.LookPath("soft")
 	if err != nil {
 		return nil, nil // not installed, skip
@@ -37,6 +43,15 @@ func startSoftServe(ctx context.Context) (*exec.Cmd, error) {
 	log.Printf("[soft-serve] data=%s", dataPath)
 
 	return cmd, nil
+}
+
+func softServeAlreadyRunning(timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", softServeSSHPort()), timeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
 }
 
 // softServeSSHPort returns the SSH port for soft-serve.

--- a/internal/daemon/softserve_test.go
+++ b/internal/daemon/softserve_test.go
@@ -1,0 +1,86 @@
+package daemon
+
+import (
+	"net"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestSoftServeSSHPort_UsesEnvOverride(t *testing.T) {
+	t.Setenv("SOFT_SERVE_SSH_PORT", "24567")
+	if got := softServeSSHPort(); got != "24567" {
+		t.Fatalf("softServeSSHPort() = %q, want %q", got, "24567")
+	}
+}
+
+func TestSoftServeAlreadyRunning_DetectsListener(t *testing.T) {
+	t.Setenv("SOFT_SERVE_SSH_PORT", "24568")
+
+	ln, err := net.Listen("tcp", "127.0.0.1:24568")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	if !softServeAlreadyRunning(200 * time.Millisecond) {
+		t.Fatal("softServeAlreadyRunning() = false, want true")
+	}
+}
+
+func TestSoftServeAlreadyRunning_ReturnsFalseWithoutListener(t *testing.T) {
+	port := "24569"
+	t.Setenv("SOFT_SERVE_SSH_PORT", port)
+
+	// Ensure the test port is currently free before checking.
+	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	ln.Close()
+
+	if softServeAlreadyRunning(200 * time.Millisecond) {
+		t.Fatal("softServeAlreadyRunning() = true, want false")
+	}
+}
+
+func TestStartSoftServe_SkipsWhenPortAlreadyInUse(t *testing.T) {
+	port := "24570"
+	t.Setenv("SOFT_SERVE_SSH_PORT", port)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:"+port)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	cmd, err := startSoftServe(t.Context())
+	if err != nil {
+		t.Fatalf("startSoftServe() error = %v", err)
+	}
+	if cmd != nil {
+		t.Fatal("startSoftServe() should skip child start when port is already in use")
+	}
+}
+
+func TestSoftServeDataPath_DefaultsUnderHome(t *testing.T) {
+	oldHome := os.Getenv("HOME")
+	t.Cleanup(func() {
+		if oldHome == "" {
+			_ = os.Unsetenv("HOME")
+			return
+		}
+		_ = os.Setenv("HOME", oldHome)
+	})
+
+	tmp := t.TempDir()
+	if err := os.Setenv("HOME", tmp); err != nil {
+		t.Fatalf("set HOME: %v", err)
+	}
+
+	got := softServeDataPath()
+	want := tmp + "/.dalcenter/soft-serve"
+	if got != want {
+		t.Fatalf("softServeDataPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary\n- skip child soft-serve startup when the configured SSH port is already in use\n- keep the existing non-fatal behavior when soft-serve is not installed\n- add regression tests for env port override, listener detection, and start skip\n\n## Testing\n- go test ./internal/daemon -run 'TestSoftServe' -count=1