### PR TITLE
fix: file credential refresh as host claim

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -175,6 +175,7 @@ pve-sync-creds [CT_ID]   # 기본값: 105
 - **Claude**: 만료 시 호스트에서 `claude auth login` → `pve-sync-creds`
 - **Codex**: 만료 시 호스트에서 `codex auth login` → `pve-sync-creds`
 - **Gemini**: API 키 (만료 없음). `GEMINI_API_KEY` 환경변수 설정.
+- 실행 중인 dal이 인증 실패를 만나면 이제 dalcli가 host action용 claim을 자동 생성하고, 채널에는 짧은 credential sync 안내만 남깁니다.
 
 ## 기여
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Uses `tee` (in-place write) to preserve file inode — Docker bind mounts stay i
 - **Claude**: OAuth token. If expired, run `claude auth login` on the host, then `pve-sync-creds`.
 - **Codex**: ChatGPT OAuth. If expired, run `codex auth login` on the host, then `pve-sync-creds`.
 - **Gemini**: API key (no expiry). Set `GEMINI_API_KEY` env var on the dalcenter host.
+- When a running dal hits an auth failure, dalcli now auto-files a host-action claim and posts a short credential-sync notice instead of only emitting a plain chat message.
 
 ## Contributing
 

--- a/cmd/dalcli/circuit_breaker_edge_test.go
+++ b/cmd/dalcli/circuit_breaker_edge_test.go
@@ -251,10 +251,76 @@ func TestClassify_AuthIsUnknown(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestNotifyCredentialRefresh_WithServer(t *testing.T) {
-	var received string
+	credentialRefreshCooldown.mu.Lock()
+	credentialRefreshCooldown.last = make(map[string]time.Time)
+	credentialRefreshCooldown.mu.Unlock()
+
+	var claimBody string
+	var messageBody string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, _ := io.ReadAll(r.Body)
-		received = string(b)
+		switch r.URL.Path {
+		case "/api/claim":
+			claimBody = string(b)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"claim-0001","status":"open"}`))
+			return
+		case "/api/message":
+			messageBody = string(b)
+		}
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	os.Setenv("DAL_PLAYER", "codex")
+	defer os.Unsetenv("DALCENTER_URL")
+	defer os.Unsetenv("DAL_PLAYER")
+
+	notifyCredentialRefresh("test-dal")
+
+	if !strings.Contains(claimBody, "test-dal") {
+		t.Errorf("claim body should contain dal name, got: %s", claimBody)
+	}
+	if !strings.Contains(claimBody, "sync-dal-creds.sh") || !strings.Contains(claimBody, "blocked") {
+		t.Errorf("claim body should request host sync, got: %s", claimBody)
+	}
+	if !strings.Contains(messageBody, "claim-0001") || !strings.Contains(messageBody, "credential") {
+		t.Errorf("message body should include claim id and credential notice, got: %s", messageBody)
+	}
+}
+
+func TestNotifyCredentialRefresh_ServerDown(t *testing.T) {
+	credentialRefreshCooldown.mu.Lock()
+	credentialRefreshCooldown.last = make(map[string]time.Time)
+	credentialRefreshCooldown.mu.Unlock()
+
+	os.Setenv("DALCENTER_URL", "http://127.0.0.1:1") // 연결 불가 포트
+	defer os.Unsetenv("DALCENTER_URL")
+
+	// panic 없이 리턴해야 함
+	notifyCredentialRefresh("test-dal")
+}
+
+func TestNotifyCredentialRefresh_DedupesWithinCooldown(t *testing.T) {
+	credentialRefreshCooldown.mu.Lock()
+	credentialRefreshCooldown.last = make(map[string]time.Time)
+	credentialRefreshCooldown.mu.Unlock()
+
+	var claimCount int
+	var messageCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/claim":
+			claimCount++
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(200)
+			_, _ = w.Write([]byte(`{"id":"claim-0002","status":"open"}`))
+			return
+		case "/api/message":
+			messageCount++
+		}
 		w.WriteHeader(200)
 	}))
 	defer srv.Close()
@@ -263,21 +329,14 @@ func TestNotifyCredentialRefresh_WithServer(t *testing.T) {
 	defer os.Unsetenv("DALCENTER_URL")
 
 	notifyCredentialRefresh("test-dal")
-
-	if !strings.Contains(received, "test-dal") {
-		t.Errorf("request body should contain dal name, got: %s", received)
-	}
-	if !strings.Contains(received, "credential") || !strings.Contains(received, "만료") {
-		t.Errorf("request body should contain credential expiry message, got: %s", received)
-	}
-}
-
-func TestNotifyCredentialRefresh_ServerDown(t *testing.T) {
-	os.Setenv("DALCENTER_URL", "http://127.0.0.1:1") // 연결 불가 포트
-	defer os.Unsetenv("DALCENTER_URL")
-
-	// panic 없이 리턴해야 함
 	notifyCredentialRefresh("test-dal")
+
+	if claimCount != 1 {
+		t.Fatalf("claim count = %d, want 1", claimCount)
+	}
+	if messageCount != 1 {
+		t.Fatalf("message count = %d, want 1", messageCount)
+	}
 }
 
 // ══════════════════════════════════════════════════════════════

--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -27,6 +27,41 @@ type agentConfig struct {
 	TeamMembers string `json:"team_members"`
 }
 
+var credentialRefreshCooldown = struct {
+	mu   sync.Mutex
+	last map[string]time.Time
+	ttl  time.Duration
+}{
+	last: make(map[string]time.Time),
+	ttl:  10 * time.Minute,
+}
+
+func shouldNotifyCredentialRefresh(dalName string) bool {
+	if dalName == "" {
+		return false
+	}
+	credentialRefreshCooldown.mu.Lock()
+	defer credentialRefreshCooldown.mu.Unlock()
+	now := time.Now()
+	last, ok := credentialRefreshCooldown.last[dalName]
+	if ok && now.Sub(last) < credentialRefreshCooldown.ttl {
+		return false
+	}
+	credentialRefreshCooldown.last[dalName] = now
+	return true
+}
+
+func dalcenterClientOrFallback() (*daemon.Client, error) {
+	if client, err := daemon.NewClient(); err == nil {
+		return client, nil
+	}
+	if os.Getenv("DALCENTER_URL") == "" {
+		_ = os.Setenv("DALCENTER_URL", "http://host.docker.internal:11190")
+		return daemon.NewClient()
+	}
+	return nil, fmt.Errorf("DALCENTER_URL not set")
+}
+
 func runCmd(dalName string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "run",
@@ -556,18 +591,36 @@ func buildThreadContext(mm *bridge.MattermostBridge, newMsg bridge.Message, dalN
 }
 
 // notifyCredentialRefresh tells dalcenter daemon that credentials need refresh.
-// The daemon can log this or trigger external sync.
+// It files a host-action claim and posts a short channel notice once per cooldown window.
 func notifyCredentialRefresh(dalName string) {
-	dcURL := os.Getenv("DALCENTER_URL")
-	if dcURL == "" {
+	if !shouldNotifyCredentialRefresh(dalName) {
+		log.Printf("[agent] credential refresh already requested recently for %s", dalName)
 		return
 	}
-	body := fmt.Sprintf(`{"dal":"%s","message":"[%s] ⚠️ credential 만료. 호스트에서 sync-dal-creds.sh 실행 필요."}`, dalName, dalName)
-	req, _ := http.NewRequest("POST", dcURL+"/api/message", strings.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
-	if err == nil {
-		resp.Body.Close()
+
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		log.Printf("[agent] credential refresh request skipped for %s: %v", dalName, err)
+		return
+	}
+
+	player := os.Getenv("DAL_PLAYER")
+	title := "credential 만료로 호스트 sync 필요"
+	detail := fmt.Sprintf("%s credential/auth failed; host에서 sync-dal-creds.sh 실행 필요", player)
+	context := fmt.Sprintf("player=%s", player)
+	claim, err := client.Claim(dalName, "blocked", title, detail, context)
+	if err != nil {
+		log.Printf("[agent] credential refresh claim failed for %s: %v", dalName, err)
+	} else {
+		log.Printf("[agent] credential refresh claim filed for %s: %s", dalName, claim.ID)
+	}
+
+	notice := fmt.Sprintf("[%s] ⚠️ credential 만료. 호스트에서 sync-dal-creds.sh 실행 필요.", dalName)
+	if claim != nil && claim.ID != "" {
+		notice = fmt.Sprintf("%s claim=%s", notice, claim.ID)
+	}
+	if _, err := client.Message(dalName, notice); err != nil {
+		log.Printf("[agent] credential refresh notice failed for %s: %v", dalName, err)
 	}
 	log.Printf("[agent] credential refresh requested for %s", dalName)
 }


### PR DESCRIPTION
## Summary
- file a host-action claim when dal auth/credential refresh is required
- post a short deduped channel notice instead of only emitting a plain message
- document the new credential refresh behavior in both READMEs

## Testing
- go test ./cmd/dalcli -run 'TestNotifyCredentialRefresh|TestExecuteTask_AnyErrorRecordsFailure'

## Notes
- leaves unrelated user file .dal/decisions-archive.md untouched in the local worktree
