### PR TITLE
feat: add run status pages for Mattermost tasks

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -63,6 +63,33 @@ func shouldDisableDM(raw string) bool {
 	return false
 }
 
+func startTrackedRun(dalName, task string) string {
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		return ""
+	}
+	result, err := client.StartTaskRun(dalName, truncate(task, 1000))
+	if err != nil {
+		log.Printf("[agent] task run start failed: %v", err)
+		return ""
+	}
+	return result.ID
+}
+
+func finishTrackedRun(taskID, status, output, errMsg string) {
+	if taskID == "" {
+		return
+	}
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		log.Printf("[agent] task run finish skipped for %s: %v", taskID, err)
+		return
+	}
+	if _, err := client.FinishTaskRun(taskID, status, output, errMsg); err != nil {
+		log.Printf("[agent] task run finish failed for %s: %v", taskID, err)
+	}
+}
+
 func dalcenterClientOrFallback() (*daemon.Client, error) {
 	if client, err := daemon.NewClient(); err == nil {
 		return client, nil
@@ -289,9 +316,13 @@ func runAgentLoop(dalName string) error {
 		}
 
 		externalURL := os.Getenv("DALCENTER_EXTERNAL_URL")
+		taskRunID := startTrackedRun(dalName, spec.UserTask)
 		var statusMsg string
-		if externalURL != "" {
-			logsURL := fmt.Sprintf("%s/api/logs/%s", externalURL, dalName)
+		if externalURL != "" && taskRunID != "" {
+			runURL := fmt.Sprintf("%s/runs/%s", strings.TrimRight(externalURL, "/"), taskRunID)
+			statusMsg = fmt.Sprintf("💬 작업 중... ([실행 보기](%s))", runURL)
+		} else if externalURL != "" {
+			logsURL := fmt.Sprintf("%s/api/logs/%s", strings.TrimRight(externalURL, "/"), dalName)
 			statusMsg = fmt.Sprintf("💬 작업 중... ([로그](%s))", logsURL)
 		} else {
 			statusMsg = "💬 작업 중..."
@@ -325,6 +356,7 @@ func runAgentLoop(dalName string) error {
 				if class == ErrClassEnv || class == ErrClassDeps {
 					result.State = TaskStateBlocked
 				}
+				finishTrackedRun(taskRunID, string(result.State), truncate(output, 12000), err.Error())
 				mm.Send(bridge.Message{
 					Content: fmt.Sprintf("❌ 실패 (%s): %v\n```\n%s\n```", class, err, truncate(output, 500)),
 					Channel: spec.Channel,
@@ -374,6 +406,7 @@ func runAgentLoop(dalName string) error {
 		if gitResult != "" {
 			response += "\n\n" + gitResult
 		}
+		finishTrackedRun(taskRunID, string(result.State), truncate(response, 12000), "")
 
 		mm.Send(bridge.Message{
 			Content: response,

--- a/cmd/dalcli/report_test.go
+++ b/cmd/dalcli/report_test.go
@@ -101,6 +101,16 @@ func TestDM_ResponseIncludesChannel(t *testing.T) {
 	}
 }
 
+func TestRunStatus_UsesRunPageLink(t *testing.T) {
+	src := readSrc(t, "cmd_run.go")
+	if !strings.Contains(src, "실행 보기") {
+		t.Fatal("status message should prefer run page link")
+	}
+	if !strings.Contains(src, "/runs/%s") {
+		t.Fatal("status message should link to /runs/{task_id}")
+	}
+}
+
 // ── 타임아웃 테스트 ──────────────────────────────────────
 
 func TestTimeout_ContextUsed(t *testing.T) {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -285,10 +285,12 @@ type TaskResult struct {
 	ID     string `json:"task_id,omitempty"`
 	Status string `json:"status"`
 	// Full result fields (when polling)
-	Dal    string `json:"dal,omitempty"`
-	Task   string `json:"task,omitempty"`
-	Output string `json:"output,omitempty"`
-	Error  string `json:"error,omitempty"`
+	Dal       string  `json:"dal,omitempty"`
+	Task      string  `json:"task,omitempty"`
+	Output    string  `json:"output,omitempty"`
+	Error     string  `json:"error,omitempty"`
+	StartedAt string  `json:"started_at,omitempty"`
+	DoneAt    *string `json:"done_at,omitempty"`
 }
 
 // Task submits a direct task to a dal container. If async=true, returns immediately with a task ID.
@@ -326,6 +328,56 @@ func (c *Client) TaskStatus(id string) (*TaskResult, error) {
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("task not found: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// StartTaskRun registers a tracked task for an external execution path such as Mattermost.
+func (c *Client) StartTaskRun(dal, task string) (*TaskResult, error) {
+	body := fmt.Sprintf(`{"dal":%q,"task":%q}`, dal, task)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task/start", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task start failed: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// FinishTaskRun finalizes a tracked task created by StartTaskRun.
+func (c *Client) FinishTaskRun(id, status, output, errMsg string) (*TaskResult, error) {
+	body := fmt.Sprintf(`{"status":%q,"output":%q,"error":%q}`, status, output, errMsg)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task/"+id+"/finish", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task finish failed: %s", strings.TrimSpace(string(b)))
 	}
 	var result TaskResult
 	json.Unmarshal(b, &result)

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -207,3 +207,43 @@ func TestClient_Logs(t *testing.T) {
 		t.Fatalf("Logs: %v", err)
 	}
 }
+
+func TestClient_StartAndFinishTaskRun(t *testing.T) {
+	var sawStart, sawFinish bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/task/start":
+			sawStart = true
+			w.Write([]byte(`{"task_id":"task-1234","status":"running"}`))
+		case "/api/task/task-1234/finish":
+			sawFinish = true
+			w.Write([]byte(`{"status":"done","dal":"leader","task":"triage","output":"ok"}`))
+		default:
+			t.Errorf("unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	started, err := c.StartTaskRun("leader", "triage")
+	if err != nil {
+		t.Fatalf("StartTaskRun: %v", err)
+	}
+	if started.ID != "task-1234" {
+		t.Fatalf("task id = %q, want task-1234", started.ID)
+	}
+	finished, err := c.FinishTaskRun("task-1234", "done", "ok", "")
+	if err != nil {
+		t.Fatalf("FinishTaskRun: %v", err)
+	}
+	if finished.Status != "done" {
+		t.Fatalf("status = %q, want done", finished.Status)
+	}
+	if !sawStart || !sawFinish {
+		t.Fatalf("expected both start and finish requests, got start=%v finish=%v", sawStart, sawFinish)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html/template"
 	"io"
 	"log"
 	"net/http"
@@ -226,6 +227,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /api/status/{name}", d.handleStatusOne)
 	mux.HandleFunc("POST /api/validate", d.handleValidate)
 	mux.HandleFunc("GET /api/logs/{name}", d.handleLogs)
+	mux.HandleFunc("GET /runs/{id}", d.handleRunPage)
 	// Write endpoints — require auth when DALCENTER_TOKEN is set
 	mux.HandleFunc("POST /api/wake/{name}", d.requireAuth(d.handleWake))
 	mux.HandleFunc("POST /api/sleep/{name}", d.requireAuth(d.handleSleep))
@@ -235,7 +237,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /api/agent-config/{name}", d.handleAgentConfig)
 	// Direct task execution (works without Mattermost)
 	mux.HandleFunc("POST /api/task", d.requireAuth(d.handleTask))
+	mux.HandleFunc("POST /api/task/start", d.requireAuth(d.handleTaskStart))
 	mux.HandleFunc("GET /api/task/{id}", d.handleTaskStatus)
+	mux.HandleFunc("POST /api/task/{id}/finish", d.requireAuth(d.handleTaskFinish))
 	mux.HandleFunc("GET /api/tasks", d.handleTaskList)
 	// Claims — dal feedback to host
 	mux.HandleFunc("POST /api/claim", d.handleClaim)
@@ -650,6 +654,95 @@ func (d *Daemon) handleLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/plain")
 	w.Write([]byte(logs))
+}
+
+func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	tr := d.tasks.Get(id)
+	if tr == nil {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+
+	const page = `<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>dalcenter run {{.ID}}</title>
+  <style>
+    :root { color-scheme: light; --bg:#f6f4ed; --panel:#fffdf7; --ink:#1a1a1a; --muted:#6b675d; --line:#d9d1bd; --accent:#0f766e; --warn:#b45309; --fail:#b91c1c; }
+    body { margin:0; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background:linear-gradient(180deg,#f3efe2,#f9f8f3); color:var(--ink); }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 28px 20px 40px; }
+    .hero { display:flex; justify-content:space-between; gap:16px; align-items:flex-start; margin-bottom:20px; }
+    .title { font-size: 28px; font-weight: 700; letter-spacing: -0.02em; }
+    .meta { color: var(--muted); font-size: 13px; margin-top: 8px; }
+    .badge { display:inline-block; padding: 4px 10px; border-radius: 999px; border:1px solid var(--line); background:var(--panel); font-size:12px; }
+    .badge.running { color: var(--accent); border-color: #8fd4ce; }
+    .badge.done { color: var(--accent); border-color: #8fd4ce; }
+    .badge.failed { color: var(--fail); border-color: #f0a7a7; }
+    .badge.blocked { color: var(--warn); border-color: #efc17e; }
+    .card { background:var(--panel); border:1px solid var(--line); border-radius:16px; padding:16px; margin-bottom:16px; box-shadow:0 6px 24px rgba(44,31,0,.06); }
+    .label { font-size:12px; text-transform:uppercase; letter-spacing:.08em; color:var(--muted); margin-bottom:8px; }
+    pre { margin:0; white-space:pre-wrap; word-break:break-word; font:inherit; line-height:1.5; }
+    a { color:#0b4f6c; text-decoration:none; }
+    a:hover { text-decoration:underline; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="hero">
+      <div>
+        <div class="title">run {{.ID}}</div>
+        <div class="meta">dal <strong>{{.Dal}}</strong> · started <span id="startedAt">{{.StartedAt}}</span></div>
+      </div>
+      <div class="badge {{.Status}}" id="status">{{.Status}}</div>
+    </div>
+
+    <div class="card">
+      <div class="label">Task</div>
+      <pre id="task">{{.Task}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Output</div>
+      <pre id="output">{{.Output}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Error</div>
+      <pre id="error">{{.Error}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Links</div>
+      <a id="logsLink" href="/api/logs/{{.Dal}}" target="_blank" rel="noreferrer">dal logs</a>
+    </div>
+  </div>
+
+  <script>
+    const taskId = "{{.ID}}";
+    const terminal = new Set(["done","failed","blocked","noop"]);
+    async function refresh() {
+      const res = await fetch("/api/task/" + taskId, {headers: {"Accept":"application/json"}});
+      if (!res.ok) return;
+      const data = await res.json();
+      document.getElementById("status").textContent = data.status || "";
+      document.getElementById("status").className = "badge " + (data.status || "");
+      document.getElementById("task").textContent = data.task || "";
+      document.getElementById("output").textContent = data.output || "";
+      document.getElementById("error").textContent = data.error || "";
+      if (data.started_at) document.getElementById("startedAt").textContent = data.started_at;
+      if (!terminal.has(data.status)) window.setTimeout(refresh, 2000);
+    }
+    window.setTimeout(refresh, 1500);
+  </script>
+</body>
+</html>`
+
+	tpl := template.Must(template.New("run").Parse(page))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	_ = tpl.Execute(w, tr)
 }
 
 func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/daemon_handlers_test.go
+++ b/internal/daemon/daemon_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -40,6 +41,46 @@ func TestHandleLogs_DalFound(t *testing.T) {
 	// Will fail because Docker is not available, but should NOT be 404
 	if w.Code == 404 {
 		t.Fatal("should find the dal, even if Docker fails")
+	}
+}
+
+func TestHandleRunPage_TaskFound(t *testing.T) {
+	d := &Daemon{
+		tasks: newTaskStore(),
+	}
+	tr := d.tasks.New("leader", "triage issue")
+	tr.Output = "still running"
+
+	req := httptest.NewRequest("GET", "/runs/"+tr.ID, nil)
+	req.SetPathValue("id", tr.ID)
+	w := httptest.NewRecorder()
+
+	d.handleRunPage(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "run "+tr.ID) {
+		t.Fatalf("expected run id in body: %s", body)
+	}
+	if !strings.Contains(body, `fetch("/api/task/" + taskId`) {
+		t.Fatalf("expected polling endpoint in body: %s", body)
+	}
+}
+
+func TestHandleRunPage_TaskNotFound(t *testing.T) {
+	d := &Daemon{
+		tasks: newTaskStore(),
+	}
+	req := httptest.NewRequest("GET", "/runs/task-404", nil)
+	req.SetPathValue("id", "task-404")
+	w := httptest.NewRecorder()
+
+	d.handleRunPage(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
 	}
 }
 
@@ -84,8 +125,8 @@ func TestDalCuePath(t *testing.T) {
 
 func TestHandleMessage_NoMM(t *testing.T) {
 	d := &Daemon{
-		mm:        nil,
-		channelID: "",
+		mm:         nil,
+		channelID:  "",
 		containers: map[string]*Container{},
 	}
 
@@ -123,10 +164,18 @@ func TestHandlePs_OutputFormat(t *testing.T) {
 }
 
 // nopCloser wraps a string as an io.ReadCloser for request body
-type nopReader struct{ data []byte; pos int }
-func (r *nopReader) Read(p []byte) (int, error) {
-	if r.pos >= len(r.data) { return 0, nil }
-	n := copy(p, r.data[r.pos:]); r.pos += n; return n, nil
+type nopReader struct {
+	data []byte
+	pos  int
 }
-func (r *nopReader) Close() error { return nil }
+
+func (r *nopReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, nil
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+func (r *nopReader) Close() error   { return nil }
 func nopCloser(s string) *nopReader { return &nopReader{data: []byte(s)} }

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -13,13 +13,13 @@ import (
 
 // taskResult holds the result of a direct task execution.
 type taskResult struct {
-	ID        string    `json:"id"`
-	Dal       string    `json:"dal"`
-	Task      string    `json:"task"`
-	Output    string    `json:"output"`
-	Error     string    `json:"error,omitempty"`
-	Status    string    `json:"status"` // "running", "done", "failed"
-	StartedAt time.Time `json:"started_at"`
+	ID        string     `json:"id"`
+	Dal       string     `json:"dal"`
+	Task      string     `json:"task"`
+	Output    string     `json:"output"`
+	Error     string     `json:"error,omitempty"`
+	Status    string     `json:"status"` // "running", "done", "failed", "blocked", "noop"
+	StartedAt time.Time  `json:"started_at"`
 	DoneAt    *time.Time `json:"done_at,omitempty"`
 	// Post-task verification
 	GitDiff    string `json:"git_diff,omitempty"`    // workspace git diff after task
@@ -85,6 +85,68 @@ func (s *taskStore) List() []*taskResult {
 		result = append(result, t)
 	}
 	return result
+}
+
+func (s *taskStore) Complete(id, status, output, errMsg string) *taskResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tr := s.tasks[id]
+	if tr == nil {
+		return nil
+	}
+	now := time.Now().UTC()
+	tr.Status = status
+	tr.Output = output
+	tr.Error = errMsg
+	tr.DoneAt = &now
+	return tr
+}
+
+// handleTaskStart registers a tracked task without executing it inside the daemon.
+// POST /api/task/start
+func (d *Daemon) handleTaskStart(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Dal  string `json:"dal"`
+		Task string `json:"task"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Dal == "" || req.Task == "" {
+		http.Error(w, "dal and task are required", http.StatusBadRequest)
+		return
+	}
+	tr := d.tasks.New(req.Dal, req.Task)
+	respondJSON(w, http.StatusAccepted, map[string]string{
+		"task_id": tr.ID,
+		"status":  tr.Status,
+	})
+}
+
+// handleTaskFinish marks a previously registered tracked task as complete.
+// POST /api/task/{id}/finish
+func (d *Daemon) handleTaskFinish(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req struct {
+		Status string `json:"status"`
+		Output string `json:"output"`
+		Error  string `json:"error"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.Status == "" {
+		http.Error(w, "status is required", http.StatusBadRequest)
+		return
+	}
+	tr := d.tasks.Complete(id, req.Status, req.Output, req.Error)
+	if tr == nil {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, tr)
 }
 
 // handleTask executes a task directly inside a dal container via docker exec.

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -110,6 +110,46 @@ func TestHandleTaskStatus_NotFound(t *testing.T) {
 	}
 }
 
+func TestHandleTaskStartAndFinish(t *testing.T) {
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
+
+	startReq := httptest.NewRequest("POST", "/api/task/start", strings.NewReader(`{"dal":"leader","task":"triage issue"}`))
+	startW := httptest.NewRecorder()
+	d.handleTaskStart(startW, startReq)
+	if startW.Code != http.StatusAccepted {
+		t.Fatalf("start status = %d, want 202", startW.Code)
+	}
+	var started map[string]string
+	if err := json.NewDecoder(startW.Body).Decode(&started); err != nil {
+		t.Fatal(err)
+	}
+	if started["task_id"] == "" {
+		t.Fatal("expected task_id")
+	}
+
+	finishReq := httptest.NewRequest("POST", "/api/task/"+started["task_id"]+"/finish", strings.NewReader(`{"status":"done","output":"ok","error":""}`))
+	finishReq.SetPathValue("id", started["task_id"])
+	finishW := httptest.NewRecorder()
+	d.handleTaskFinish(finishW, finishReq)
+	if finishW.Code != http.StatusOK {
+		t.Fatalf("finish status = %d, want 200", finishW.Code)
+	}
+
+	tr := d.tasks.Get(started["task_id"])
+	if tr == nil {
+		t.Fatal("expected tracked task")
+	}
+	if tr.Status != "done" {
+		t.Fatalf("status = %s, want done", tr.Status)
+	}
+	if tr.Output != "ok" {
+		t.Fatalf("output = %q, want ok", tr.Output)
+	}
+	if tr.DoneAt == nil {
+		t.Fatal("expected DoneAt to be set")
+	}
+}
+
 func TestTruncateStr(t *testing.T) {
 	if truncateStr("hello", 10) != "hello" {
 		t.Error("should not truncate short string")


### PR DESCRIPTION
## Summary
- add tracked run records for Mattermost-driven tasks
- expose a lightweight run status page at `/runs/{task_id}`
- change `💬 작업 중...` links to prefer the run page over plain dal logs

## What Changed
- daemon
  - add `POST /api/task/start`
  - add `POST /api/task/{id}/finish`
  - add `GET /runs/{id}` HTML status page that polls `GET /api/task/{id}`
- dalcli
  - register a tracked run before executing a Mattermost task
  - finalize the run on success or failure
  - emit `💬 작업 중... ([실행 보기](.../runs/{task_id}))` when `DALCENTER_EXTERNAL_URL` is set
- tests
  - add handler/client coverage for start/finish lifecycle and run page rendering
  - add a dalcli assertion for the new run page link text

## Why
The previous log link was only a dal-level surface and did not represent a specific task execution.
This PR adds a task-scoped run page so a Mattermost thread can point to a live status surface that behaves more like an execution view.

## Verification
- `go test ./internal/daemon`
- `go test ./cmd/dalcli -run 'Test(BuildThreadContext|BuildTaskSpec|CredentialStatusQueryInput_UsesLatestTaskOnly|HandleCredentialStatusQuery_FallbackOnStatusError|IsCredentialStatusQuery|DM_AllSendCallsHaveChannel|DM_ResponseIncludesChannel|RunStatus_UsesRunPageLink)$'`
