### PR TITLE
feat: enrich run pages and completion links

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -90,6 +90,17 @@ func finishTrackedRun(taskID, status, output, errMsg string) {
 	}
 }
 
+func trackedRunURL(taskID string) string {
+	if taskID == "" {
+		return ""
+	}
+	externalURL := strings.TrimRight(os.Getenv("DALCENTER_EXTERNAL_URL"), "/")
+	if externalURL == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/runs/%s", externalURL, taskID)
+}
+
 func dalcenterClientOrFallback() (*daemon.Client, error) {
 	if client, err := daemon.NewClient(); err == nil {
 		return client, nil
@@ -315,14 +326,13 @@ func runAgentLoop(dalName string) error {
 			continue
 		}
 
-		externalURL := os.Getenv("DALCENTER_EXTERNAL_URL")
 		taskRunID := startTrackedRun(dalName, spec.UserTask)
 		var statusMsg string
-		if externalURL != "" && taskRunID != "" {
-			runURL := fmt.Sprintf("%s/runs/%s", strings.TrimRight(externalURL, "/"), taskRunID)
+		runURL := trackedRunURL(taskRunID)
+		if runURL != "" {
 			statusMsg = fmt.Sprintf("💬 작업 중... ([실행 보기](%s))", runURL)
-		} else if externalURL != "" {
-			logsURL := fmt.Sprintf("%s/api/logs/%s", strings.TrimRight(externalURL, "/"), dalName)
+		} else if externalURL := strings.TrimRight(os.Getenv("DALCENTER_EXTERNAL_URL"), "/"); externalURL != "" {
+			logsURL := fmt.Sprintf("%s/api/logs/%s", externalURL, dalName)
 			statusMsg = fmt.Sprintf("💬 작업 중... ([로그](%s))", logsURL)
 		} else {
 			statusMsg = "💬 작업 중..."
@@ -357,8 +367,12 @@ func runAgentLoop(dalName string) error {
 					result.State = TaskStateBlocked
 				}
 				finishTrackedRun(taskRunID, string(result.State), truncate(output, 12000), err.Error())
+				failureMsg := fmt.Sprintf("❌ 실패 (%s): %v\n```\n%s\n```", class, err, truncate(output, 500))
+				if runURL != "" {
+					failureMsg += fmt.Sprintf("\n\n[실행 보기](%s)", runURL)
+				}
 				mm.Send(bridge.Message{
-					Content: fmt.Sprintf("❌ 실패 (%s): %v\n```\n%s\n```", class, err, truncate(output, 500)),
+					Content: failureMsg,
 					Channel: spec.Channel,
 					ReplyTo: spec.ThreadID,
 				})
@@ -407,6 +421,9 @@ func runAgentLoop(dalName string) error {
 			response += "\n\n" + gitResult
 		}
 		finishTrackedRun(taskRunID, string(result.State), truncate(response, 12000), "")
+		if runURL != "" {
+			response += fmt.Sprintf("\n\n[실행 보기](%s)", runURL)
+		}
 
 		mm.Send(bridge.Message{
 			Content: response,

--- a/cmd/dalcli/report_test.go
+++ b/cmd/dalcli/report_test.go
@@ -111,6 +111,13 @@ func TestRunStatus_UsesRunPageLink(t *testing.T) {
 	}
 }
 
+func TestRunStatus_FinalResponsesKeepRunLink(t *testing.T) {
+	src := readSrc(t, "cmd_run.go")
+	if strings.Count(src, "[실행 보기]") < 2 {
+		t.Fatal("final success/failure replies should also include the run link")
+	}
+}
+
 // ── 타임아웃 테스트 ──────────────────────────────────────
 
 func TestTimeout_ContextUsed(t *testing.T) {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -718,6 +718,26 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
       <div class="label">Links</div>
       <a id="logsLink" href="/api/logs/{{.Dal}}" target="_blank" rel="noreferrer">dal logs</a>
     </div>
+
+    <div class="card">
+      <div class="label">Verification</div>
+      <pre id="verification">{{if .Completion}}{{if .Completion.Skipped}}skipped: {{.Completion.SkipReason}}{{else}}build={{.Completion.BuildOK}} test={{.Completion.TestOK}} duration={{.Completion.Duration}}{{end}}{{else}}pending{{end}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Git Diff</div>
+      <pre id="gitdiff">{{if .GitDiff}}{{.GitDiff}}{{else}}(none){{end}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Build Output</div>
+      <pre id="buildOutput">{{if and .Completion .Completion.BuildOutput}}{{.Completion.BuildOutput}}{{else}}(none){{end}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Test Output</div>
+      <pre id="testOutput">{{if and .Completion .Completion.TestOutput}}{{.Completion.TestOutput}}{{else}}(none){{end}}</pre>
+    </div>
   </div>
 
   <script>
@@ -732,6 +752,23 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
       document.getElementById("task").textContent = data.task || "";
       document.getElementById("output").textContent = data.output || "";
       document.getElementById("error").textContent = data.error || "";
+      document.getElementById("gitdiff").textContent = data.git_diff || "(none)";
+      const completion = data.completion || null;
+      let verification = "pending";
+      let buildOutput = "(none)";
+      let testOutput = "(none)";
+      if (completion) {
+        if (completion.skipped) {
+          verification = "skipped: " + (completion.skip_reason || "");
+        } else {
+          verification = "build=" + Boolean(completion.build_ok) + " test=" + Boolean(completion.test_ok) + " duration=" + (completion.duration || "");
+        }
+        if (completion.build_output) buildOutput = completion.build_output;
+        if (completion.test_output) testOutput = completion.test_output;
+      }
+      document.getElementById("verification").textContent = verification;
+      document.getElementById("buildOutput").textContent = buildOutput;
+      document.getElementById("testOutput").textContent = testOutput;
       if (data.started_at) document.getElementById("startedAt").textContent = data.started_at;
       if (!terminal.has(data.status)) window.setTimeout(refresh, 2000);
     }

--- a/internal/daemon/daemon_handlers_test.go
+++ b/internal/daemon/daemon_handlers_test.go
@@ -50,6 +50,13 @@ func TestHandleRunPage_TaskFound(t *testing.T) {
 	}
 	tr := d.tasks.New("leader", "triage issue")
 	tr.Output = "still running"
+	tr.GitDiff = "M  README.md"
+	tr.Completion = &CompletionResult{
+		BuildOK:    true,
+		TestOK:     false,
+		Duration:   "2.3s",
+		TestOutput: "FAIL test",
+	}
 
 	req := httptest.NewRequest("GET", "/runs/"+tr.ID, nil)
 	req.SetPathValue("id", tr.ID)
@@ -66,6 +73,12 @@ func TestHandleRunPage_TaskFound(t *testing.T) {
 	}
 	if !strings.Contains(body, `fetch("/api/task/" + taskId`) {
 		t.Fatalf("expected polling endpoint in body: %s", body)
+	}
+	if !strings.Contains(body, "Verification") || !strings.Contains(body, "Git Diff") {
+		t.Fatalf("expected verification sections in body: %s", body)
+	}
+	if !strings.Contains(body, tr.GitDiff) || !strings.Contains(body, tr.Completion.TestOutput) {
+		t.Fatalf("expected task detail content in body: %s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary
- keep the run page link in final Mattermost success/failure replies
- expand the run page with verification, git diff, build output, and test output sections
- cover the new run page content and final-link behavior with tests

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -run 'Test(RunStatus_UsesRunPageLink|RunStatus_FinalResponsesKeepRunLink|DM_AllSendCallsHaveChannel|DM_ResponseIncludesChannel)$'