### PR TITLE
feat: add run timeline events

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -90,6 +90,20 @@ func finishTrackedRun(taskID, status, output, errMsg string) {
 	}
 }
 
+func appendTrackedRunEvent(taskID, kind, message string) {
+	if taskID == "" || strings.TrimSpace(message) == "" {
+		return
+	}
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		log.Printf("[agent] task run event skipped for %s: %v", taskID, err)
+		return
+	}
+	if _, err := client.TaskEvent(taskID, kind, message); err != nil {
+		log.Printf("[agent] task run event failed for %s: %v", taskID, err)
+	}
+}
+
 func trackedRunURL(taskID string) string {
 	if taskID == "" {
 		return ""
@@ -351,6 +365,7 @@ func runAgentLoop(dalName string) error {
 			// Self-repair: try to fix and retry once
 			if shouldRetry, fix := selfRepair(spec.Prompt, output, err); shouldRetry {
 				log.Printf("[agent] self-repair applied: %s, retrying", fix)
+				appendTrackedRunEvent(taskRunID, "self_repair", fmt.Sprintf("Self-repair applied: %s", fix))
 				mm.Send(bridge.Message{
 					Content: fmt.Sprintf("🔧 자가 수리: %s — 재시도 중...", fix),
 					Channel: spec.Channel,
@@ -407,6 +422,7 @@ func runAgentLoop(dalName string) error {
 					prURL = strings.TrimSpace(line)
 				}
 			}
+			appendTrackedRunEvent(taskRunID, "git", "Auto git workflow produced follow-up output")
 		}
 
 		// History buffer: record completed task
@@ -419,6 +435,9 @@ func runAgentLoop(dalName string) error {
 		response := truncate(strings.TrimSpace(output), 3000)
 		if gitResult != "" {
 			response += "\n\n" + gitResult
+		}
+		if result.State == TaskStateNoop {
+			appendTrackedRunEvent(taskRunID, "result", "Task finished with no changes")
 		}
 		finishTrackedRun(taskRunID, string(result.State), truncate(response, 12000), "")
 		if runURL != "" {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -285,12 +285,19 @@ type TaskResult struct {
 	ID     string `json:"task_id,omitempty"`
 	Status string `json:"status"`
 	// Full result fields (when polling)
-	Dal       string  `json:"dal,omitempty"`
-	Task      string  `json:"task,omitempty"`
-	Output    string  `json:"output,omitempty"`
-	Error     string  `json:"error,omitempty"`
-	StartedAt string  `json:"started_at,omitempty"`
-	DoneAt    *string `json:"done_at,omitempty"`
+	Dal       string      `json:"dal,omitempty"`
+	Task      string      `json:"task,omitempty"`
+	Output    string      `json:"output,omitempty"`
+	Error     string      `json:"error,omitempty"`
+	StartedAt string      `json:"started_at,omitempty"`
+	DoneAt    *string     `json:"done_at,omitempty"`
+	Events    []TaskEvent `json:"events,omitempty"`
+}
+
+type TaskEvent struct {
+	At      string `json:"at,omitempty"`
+	Kind    string `json:"kind,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // Task submits a direct task to a dal container. If async=true, returns immediately with a task ID.
@@ -378,6 +385,31 @@ func (c *Client) FinishTaskRun(id, status, output, errMsg string) (*TaskResult, 
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("task finish failed: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// TaskEvent appends an event to a tracked task created by StartTaskRun.
+func (c *Client) TaskEvent(id, kind, message string) (*TaskResult, error) {
+	body := fmt.Sprintf(`{"kind":%q,"message":%q}`, kind, message)
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task/"+id+"/event", strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task event failed: %s", strings.TrimSpace(string(b)))
 	}
 	var result TaskResult
 	json.Unmarshal(b, &result)

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -209,12 +209,15 @@ func TestClient_Logs(t *testing.T) {
 }
 
 func TestClient_StartAndFinishTaskRun(t *testing.T) {
-	var sawStart, sawFinish bool
+	var sawStart, sawEvent, sawFinish bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/task/start":
 			sawStart = true
 			w.Write([]byte(`{"task_id":"task-1234","status":"running"}`))
+		case "/api/task/task-1234/event":
+			sawEvent = true
+			w.Write([]byte(`{"status":"running","events":[{"kind":"self_repair","message":"retry"}]}`))
 		case "/api/task/task-1234/finish":
 			sawFinish = true
 			w.Write([]byte(`{"status":"done","dal":"leader","task":"triage","output":"ok"}`))
@@ -236,6 +239,13 @@ func TestClient_StartAndFinishTaskRun(t *testing.T) {
 	if started.ID != "task-1234" {
 		t.Fatalf("task id = %q, want task-1234", started.ID)
 	}
+	updated, err := c.TaskEvent("task-1234", "self_repair", "retry")
+	if err != nil {
+		t.Fatalf("TaskEvent: %v", err)
+	}
+	if len(updated.Events) != 1 || updated.Events[0].Kind != "self_repair" {
+		t.Fatalf("unexpected task events: %+v", updated.Events)
+	}
 	finished, err := c.FinishTaskRun("task-1234", "done", "ok", "")
 	if err != nil {
 		t.Fatalf("FinishTaskRun: %v", err)
@@ -243,7 +253,7 @@ func TestClient_StartAndFinishTaskRun(t *testing.T) {
 	if finished.Status != "done" {
 		t.Fatalf("status = %q, want done", finished.Status)
 	}
-	if !sawStart || !sawFinish {
-		t.Fatalf("expected both start and finish requests, got start=%v finish=%v", sawStart, sawFinish)
+	if !sawStart || !sawEvent || !sawFinish {
+		t.Fatalf("expected start, event, finish requests, got start=%v event=%v finish=%v", sawStart, sawEvent, sawFinish)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -239,6 +239,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/task", d.requireAuth(d.handleTask))
 	mux.HandleFunc("POST /api/task/start", d.requireAuth(d.handleTaskStart))
 	mux.HandleFunc("GET /api/task/{id}", d.handleTaskStatus)
+	mux.HandleFunc("POST /api/task/{id}/event", d.requireAuth(d.handleTaskEvent))
 	mux.HandleFunc("POST /api/task/{id}/finish", d.requireAuth(d.handleTaskFinish))
 	mux.HandleFunc("GET /api/tasks", d.handleTaskList)
 	// Claims — dal feedback to host
@@ -664,6 +665,28 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	formatTimeline := func(events []taskEvent) string {
+		if len(events) == 0 {
+			return "(no events yet)"
+		}
+		var b strings.Builder
+		for _, ev := range events {
+			at := ev.At.Format(time.RFC3339)
+			if ev.At.IsZero() {
+				at = "unknown-time"
+			}
+			line := fmt.Sprintf("[%s] %s", at, ev.Message)
+			if ev.Kind != "" {
+				line = fmt.Sprintf("[%s] (%s) %s", at, ev.Kind, ev.Message)
+			}
+			if b.Len() > 0 {
+				b.WriteByte('\n')
+			}
+			b.WriteString(line)
+		}
+		return b.String()
+	}
+
 	const page = `<!doctype html>
 <html lang="ko">
 <head>
@@ -720,6 +743,18 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
     </div>
 
     <div class="card">
+      <div class="label">Summary</div>
+      <pre id="summary">{{if .DoneAt}}done={{.DoneAt}}{{else}}done=pending{{end}}
+git_changes={{.GitChanges}}
+verified={{if .Verified}}{{.Verified}}{{else}}pending{{end}}</pre>
+    </div>
+
+    <div class="card">
+      <div class="label">Timeline</div>
+      <pre id="timeline">{{timeline .Events}}</pre>
+    </div>
+
+    <div class="card">
       <div class="label">Verification</div>
       <pre id="verification">{{if .Completion}}{{if .Completion.Skipped}}skipped: {{.Completion.SkipReason}}{{else}}build={{.Completion.BuildOK}} test={{.Completion.TestOK}} duration={{.Completion.Duration}}{{end}}{{else}}pending{{end}}</pre>
     </div>
@@ -743,6 +778,20 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
   <script>
     const taskId = "{{.ID}}";
     const terminal = new Set(["done","failed","blocked","noop"]);
+    function formatSummary(data) {
+      const doneAt = data.done_at || "pending";
+      const gitChanges = Number.isFinite(data.git_changes) ? data.git_changes : 0;
+      const verified = data.verified || "pending";
+      return "done=" + doneAt + "\n" + "git_changes=" + gitChanges + "\n" + "verified=" + verified;
+    }
+    function formatTimeline(events) {
+      if (!events || events.length === 0) return "(no events yet)";
+      return events.map((event) => {
+        const at = event.at || "unknown-time";
+        const kind = event.kind ? " (" + event.kind + ")" : "";
+        return "[" + at + "]" + kind + " " + (event.message || "");
+      }).join("\n");
+    }
     async function refresh() {
       const res = await fetch("/api/task/" + taskId, {headers: {"Accept":"application/json"}});
       if (!res.ok) return;
@@ -752,6 +801,8 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
       document.getElementById("task").textContent = data.task || "";
       document.getElementById("output").textContent = data.output || "";
       document.getElementById("error").textContent = data.error || "";
+      document.getElementById("summary").textContent = formatSummary(data);
+      document.getElementById("timeline").textContent = formatTimeline(data.events || []);
       document.getElementById("gitdiff").textContent = data.git_diff || "(none)";
       const completion = data.completion || null;
       let verification = "pending";
@@ -777,7 +828,7 @@ func (d *Daemon) handleRunPage(w http.ResponseWriter, r *http.Request) {
 </body>
 </html>`
 
-	tpl := template.Must(template.New("run").Parse(page))
+	tpl := template.Must(template.New("run").Funcs(template.FuncMap{"timeline": formatTimeline}).Parse(page))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	_ = tpl.Execute(w, tr)
 }

--- a/internal/daemon/daemon_handlers_test.go
+++ b/internal/daemon/daemon_handlers_test.go
@@ -51,6 +51,9 @@ func TestHandleRunPage_TaskFound(t *testing.T) {
 	tr := d.tasks.New("leader", "triage issue")
 	tr.Output = "still running"
 	tr.GitDiff = "M  README.md"
+	tr.GitChanges = 1
+	tr.Verified = "yes"
+	tr.Events = append(tr.Events, taskEvent{Kind: "self_repair", Message: "Retrying after fix"})
 	tr.Completion = &CompletionResult{
 		BuildOK:    true,
 		TestOK:     false,
@@ -77,8 +80,14 @@ func TestHandleRunPage_TaskFound(t *testing.T) {
 	if !strings.Contains(body, "Verification") || !strings.Contains(body, "Git Diff") {
 		t.Fatalf("expected verification sections in body: %s", body)
 	}
+	if !strings.Contains(body, "Summary") || !strings.Contains(body, "Timeline") {
+		t.Fatalf("expected summary sections in body: %s", body)
+	}
 	if !strings.Contains(body, tr.GitDiff) || !strings.Contains(body, tr.Completion.TestOutput) {
 		t.Fatalf("expected task detail content in body: %s", body)
+	}
+	if !strings.Contains(body, "Retrying after fix") || !strings.Contains(body, "git_changes=1") {
+		t.Fatalf("expected timeline and summary content in body: %s", body)
 	}
 }
 

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -13,20 +13,27 @@ import (
 
 // taskResult holds the result of a direct task execution.
 type taskResult struct {
-	ID        string     `json:"id"`
-	Dal       string     `json:"dal"`
-	Task      string     `json:"task"`
-	Output    string     `json:"output"`
-	Error     string     `json:"error,omitempty"`
-	Status    string     `json:"status"` // "running", "done", "failed", "blocked", "noop"
-	StartedAt time.Time  `json:"started_at"`
-	DoneAt    *time.Time `json:"done_at,omitempty"`
+	ID        string      `json:"id"`
+	Dal       string      `json:"dal"`
+	Task      string      `json:"task"`
+	Output    string      `json:"output"`
+	Error     string      `json:"error,omitempty"`
+	Status    string      `json:"status"` // "running", "done", "failed", "blocked", "noop"
+	StartedAt time.Time   `json:"started_at"`
+	DoneAt    *time.Time  `json:"done_at,omitempty"`
+	Events    []taskEvent `json:"events,omitempty"`
 	// Post-task verification
 	GitDiff    string `json:"git_diff,omitempty"`    // workspace git diff after task
 	GitChanges int    `json:"git_changes,omitempty"` // number of files changed
 	Verified   string `json:"verified,omitempty"`    // "yes", "no_changes", "skipped"
 	// Post-task build/test verification
 	Completion *CompletionResult `json:"completion,omitempty"`
+}
+
+type taskEvent struct {
+	At      time.Time `json:"at"`
+	Kind    string    `json:"kind"`
+	Message string    `json:"message"`
 }
 
 // taskStore manages running and completed direct tasks.
@@ -51,6 +58,7 @@ func (s *taskStore) New(dal, task string) *taskResult {
 		Status:    "running",
 		StartedAt: time.Now().UTC(),
 	}
+	t.appendEvent("accepted", "Task accepted and running")
 	s.tasks[t.ID] = t
 
 	// Evict old tasks (keep last 50)
@@ -99,7 +107,54 @@ func (s *taskStore) Complete(id, status, output, errMsg string) *taskResult {
 	tr.Output = output
 	tr.Error = errMsg
 	tr.DoneAt = &now
+	message := taskStatusMessage(status, errMsg)
+	if message != "" {
+		tr.appendEvent(status, message)
+	}
 	return tr
+}
+
+func (s *taskStore) AddEvent(id, kind, message string) *taskResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tr := s.tasks[id]
+	if tr == nil {
+		return nil
+	}
+	tr.appendEvent(kind, message)
+	return tr
+}
+
+func (tr *taskResult) appendEvent(kind, message string) {
+	if strings.TrimSpace(message) == "" {
+		return
+	}
+	tr.Events = append(tr.Events, taskEvent{
+		At:      time.Now().UTC(),
+		Kind:    kind,
+		Message: message,
+	})
+}
+
+func taskStatusMessage(status, errMsg string) string {
+	switch status {
+	case "done":
+		return "Task completed"
+	case "blocked":
+		if strings.TrimSpace(errMsg) != "" {
+			return "Task blocked: " + errMsg
+		}
+		return "Task blocked"
+	case "failed":
+		if strings.TrimSpace(errMsg) != "" {
+			return "Task failed: " + errMsg
+		}
+		return "Task failed"
+	case "noop":
+		return "Task completed with no changes"
+	default:
+		return ""
+	}
 }
 
 // handleTaskStart registers a tracked task without executing it inside the daemon.
@@ -142,6 +197,30 @@ func (d *Daemon) handleTaskFinish(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tr := d.tasks.Complete(id, req.Status, req.Output, req.Error)
+	if tr == nil {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, tr)
+}
+
+// handleTaskEvent appends an event to a previously registered tracked task.
+// POST /api/task/{id}/event
+func (d *Daemon) handleTaskEvent(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req struct {
+		Kind    string `json:"kind"`
+		Message string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.Message) == "" {
+		http.Error(w, "message is required", http.StatusBadRequest)
+		return
+	}
+	tr := d.tasks.AddEvent(id, strings.TrimSpace(req.Kind), req.Message)
 	if tr == nil {
 		http.Error(w, "task not found", http.StatusNotFound)
 		return

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -20,6 +20,12 @@ func TestTaskStore_New(t *testing.T) {
 	if tr.Status != "running" {
 		t.Errorf("expected status=running, got %s", tr.Status)
 	}
+	if len(tr.Events) != 1 {
+		t.Fatalf("expected initial event, got %d", len(tr.Events))
+	}
+	if tr.Events[0].Kind != "accepted" {
+		t.Fatalf("expected initial accepted event, got %q", tr.Events[0].Kind)
+	}
 }
 
 func TestTaskStore_Get(t *testing.T) {
@@ -147,6 +153,33 @@ func TestHandleTaskStartAndFinish(t *testing.T) {
 	}
 	if tr.DoneAt == nil {
 		t.Fatal("expected DoneAt to be set")
+	}
+	if len(tr.Events) < 2 {
+		t.Fatalf("expected completion event, got %d events", len(tr.Events))
+	}
+	if tr.Events[len(tr.Events)-1].Kind != "done" {
+		t.Fatalf("expected final done event, got %q", tr.Events[len(tr.Events)-1].Kind)
+	}
+}
+
+func TestHandleTaskEvent(t *testing.T) {
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
+	tr := d.tasks.New("leader", "triage issue")
+
+	req := httptest.NewRequest("POST", "/api/task/"+tr.ID+"/event", strings.NewReader(`{"kind":"self_repair","message":"Retrying after fix"}`))
+	req.SetPathValue("id", tr.ID)
+	w := httptest.NewRecorder()
+	d.handleTaskEvent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	updated := d.tasks.Get(tr.ID)
+	if updated == nil {
+		t.Fatal("expected tracked task")
+	}
+	if got := updated.Events[len(updated.Events)-1]; got.Kind != "self_repair" || got.Message != "Retrying after fix" {
+		t.Fatalf("unexpected event: %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add tracked task events so run pages can show a timeline instead of only final output
- expose a task event API and client helper for Mattermost-driven runs
- extend the run page with summary and timeline sections and cover them with tests

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -run 'Test(RunStatus_UsesRunPageLink|RunStatus_FinalResponsesKeepRunLink|DM_AllSendCallsHaveChannel|DM_ResponseIncludesChannel)$'