### PR TITLE
feat: add tracked run verification metadata

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -104,6 +104,164 @@ func appendTrackedRunEvent(taskID, kind, message string) {
 	}
 }
 
+type taskVerificationSnapshot struct {
+	GitDiff    string
+	GitChanges int
+	Verified   string
+	Completion *daemon.CompletionResult
+}
+
+func updateTrackedRunMetadata(taskID string, snapshot *taskVerificationSnapshot) {
+	if taskID == "" || snapshot == nil {
+		return
+	}
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		log.Printf("[agent] task run metadata skipped for %s: %v", taskID, err)
+		return
+	}
+	update := daemon.TaskMetadataUpdate{
+		GitDiff:    snapshot.GitDiff,
+		GitChanges: snapshot.GitChanges,
+		Verified:   snapshot.Verified,
+		Completion: snapshot.Completion,
+	}
+	if _, err := client.UpdateTaskRun(taskID, update); err != nil {
+		log.Printf("[agent] task run metadata failed for %s: %v", taskID, err)
+	}
+}
+
+func collectTaskVerification() *taskVerificationSnapshot {
+	snapshot := &taskVerificationSnapshot{
+		Verified: "skipped",
+		Completion: &daemon.CompletionResult{
+			Skipped:    true,
+			SkipReason: "verification not collected",
+		},
+	}
+
+	diffOut, statusOut, err := workspaceGitSnapshot()
+	if err != nil {
+		snapshot.Completion.SkipReason = "git status failed"
+		return snapshot
+	}
+
+	var diffParts []string
+	if strings.TrimSpace(diffOut) != "" {
+		diffParts = append(diffParts, strings.TrimSpace(diffOut))
+	}
+	if strings.TrimSpace(statusOut) != "" {
+		diffParts = append(diffParts, strings.TrimSpace(statusOut))
+	}
+	snapshot.GitDiff = truncate(strings.Join(diffParts, "\n"), 4000)
+	snapshot.GitChanges = countGitStatusLines(statusOut)
+	if snapshot.GitChanges == 0 {
+		snapshot.Verified = "no_changes"
+		snapshot.Completion.SkipReason = "no code changes detected"
+		return snapshot
+	}
+
+	snapshot.Verified = "yes"
+	snapshot.Completion = collectWorkspaceCompletion()
+	return snapshot
+}
+
+func workspaceGitSnapshot() (string, string, error) {
+	diffCmd := exec.Command("git", "diff", "--stat", "HEAD")
+	diffCmd.Dir = "/workspace"
+	diffOut, diffErr := diffCmd.Output()
+
+	statusCmd := exec.Command("git", "status", "--porcelain")
+	statusCmd.Dir = "/workspace"
+	statusOut, statusErr := statusCmd.Output()
+
+	if diffErr != nil || statusErr != nil {
+		if diffErr != nil {
+			return "", "", diffErr
+		}
+		return "", "", statusErr
+	}
+	return strings.TrimSpace(string(diffOut)), strings.TrimSpace(string(statusOut)), nil
+}
+
+func countGitStatusLines(status string) int {
+	if strings.TrimSpace(status) == "" {
+		return 0
+	}
+	count := 0
+	for _, line := range strings.Split(status, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func collectWorkspaceCompletion() *daemon.CompletionResult {
+	if _, err := os.Stat("/workspace/go.mod"); err != nil {
+		return &daemon.CompletionResult{
+			Skipped:    true,
+			SkipReason: "go.mod not found",
+		}
+	}
+
+	start := time.Now()
+	result := &daemon.CompletionResult{}
+
+	buildOut, buildErr := runWorkspaceCommand("go", "build", "./...")
+	if buildErr != nil {
+		result.BuildOutput = truncate(buildOut, 2000)
+	} else {
+		result.BuildOK = true
+		if strings.TrimSpace(buildOut) != "" {
+			result.BuildOutput = truncate(buildOut, 2000)
+		}
+	}
+
+	testOut, testErr := runWorkspaceCommand("go", "test", "./...")
+	if testErr != nil {
+		result.TestOutput = truncate(testOut, 2000)
+	} else {
+		result.TestOK = true
+		if strings.TrimSpace(testOut) != "" {
+			result.TestOutput = truncate(testOut, 2000)
+		}
+	}
+
+	result.Duration = time.Since(start).Round(time.Millisecond).String()
+	return result
+}
+
+func runWorkspaceCommand(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = "/workspace"
+	out, err := cmd.CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+func verificationSummaryLine(snapshot *taskVerificationSnapshot) string {
+	if snapshot == nil {
+		return ""
+	}
+	parts := []string{
+		"검증:",
+		fmt.Sprintf("verified=%s", snapshot.Verified),
+		fmt.Sprintf("changes=%d", snapshot.GitChanges),
+	}
+	if snapshot.Completion != nil {
+		if snapshot.Completion.Skipped {
+			parts = append(parts, "build/test=skipped", fmt.Sprintf("reason=%s", snapshot.Completion.SkipReason))
+		} else {
+			parts = append(parts,
+				fmt.Sprintf("build=%t", snapshot.Completion.BuildOK),
+				fmt.Sprintf("test=%t", snapshot.Completion.TestOK),
+				fmt.Sprintf("duration=%s", snapshot.Completion.Duration),
+			)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
 func trackedRunURL(taskID string) string {
 	if taskID == "" {
 		return ""
@@ -404,6 +562,10 @@ func runAgentLoop(dalName string) error {
 
 		log.Printf("[agent] done (%d bytes)", len(output))
 
+		verification := collectTaskVerification()
+		updateTrackedRunMetadata(taskRunID, verification)
+		appendTrackedRunEvent(taskRunID, "verification", verificationSummaryLine(verification))
+
 		// Check if files were modified → auto git workflow (member only — leader는 라우터, 직접 커밋 안 함)
 		var gitResult string
 		if os.Getenv("DAL_ROLE") != "leader" {
@@ -435,6 +597,9 @@ func runAgentLoop(dalName string) error {
 		response := truncate(strings.TrimSpace(output), 3000)
 		if gitResult != "" {
 			response += "\n\n" + gitResult
+		}
+		if summary := verificationSummaryLine(verification); summary != "" {
+			response += "\n\n" + summary
 		}
 		if result.State == TaskStateNoop {
 			appendTrackedRunEvent(taskRunID, "result", "Task finished with no changes")

--- a/cmd/dalcli/report_test.go
+++ b/cmd/dalcli/report_test.go
@@ -118,6 +118,16 @@ func TestRunStatus_FinalResponsesKeepRunLink(t *testing.T) {
 	}
 }
 
+func TestRunStatus_FinalResponsesIncludeVerificationSummary(t *testing.T) {
+	src := readSrc(t, "cmd_run.go")
+	if !strings.Contains(src, "검증:") {
+		t.Fatal("final success replies should include a verification summary line")
+	}
+	if !strings.Contains(src, "updateTrackedRunMetadata") {
+		t.Fatal("tracked runs should upload verification metadata before finish")
+	}
+}
+
 // ── 타임아웃 테스트 ──────────────────────────────────────
 
 func TestTimeout_ContextUsed(t *testing.T) {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -285,13 +285,17 @@ type TaskResult struct {
 	ID     string `json:"task_id,omitempty"`
 	Status string `json:"status"`
 	// Full result fields (when polling)
-	Dal       string      `json:"dal,omitempty"`
-	Task      string      `json:"task,omitempty"`
-	Output    string      `json:"output,omitempty"`
-	Error     string      `json:"error,omitempty"`
-	StartedAt string      `json:"started_at,omitempty"`
-	DoneAt    *string     `json:"done_at,omitempty"`
-	Events    []TaskEvent `json:"events,omitempty"`
+	Dal        string            `json:"dal,omitempty"`
+	Task       string            `json:"task,omitempty"`
+	Output     string            `json:"output,omitempty"`
+	Error      string            `json:"error,omitempty"`
+	StartedAt  string            `json:"started_at,omitempty"`
+	DoneAt     *string           `json:"done_at,omitempty"`
+	Events     []TaskEvent       `json:"events,omitempty"`
+	GitDiff    string            `json:"git_diff,omitempty"`
+	GitChanges int               `json:"git_changes,omitempty"`
+	Verified   string            `json:"verified,omitempty"`
+	Completion *CompletionResult `json:"completion,omitempty"`
 }
 
 type TaskEvent struct {
@@ -410,6 +414,34 @@ func (c *Client) TaskEvent(id, kind, message string) (*TaskResult, error) {
 	b, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("task event failed: %s", strings.TrimSpace(string(b)))
+	}
+	var result TaskResult
+	json.Unmarshal(b, &result)
+	return &result, nil
+}
+
+// UpdateTaskRun updates verification metadata for a tracked task.
+func (c *Client) UpdateTaskRun(id string, update TaskMetadataUpdate) (*TaskResult, error) {
+	bodyBytes, err := json.Marshal(update)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task/"+id+"/metadata", strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("task metadata update failed: %s", strings.TrimSpace(string(b)))
 	}
 	var result TaskResult
 	json.Unmarshal(b, &result)

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -218,6 +218,8 @@ func TestClient_StartAndFinishTaskRun(t *testing.T) {
 		case "/api/task/task-1234/event":
 			sawEvent = true
 			w.Write([]byte(`{"status":"running","events":[{"kind":"self_repair","message":"retry"}]}`))
+		case "/api/task/task-1234/metadata":
+			w.Write([]byte(`{"status":"running","verified":"yes","git_changes":2,"completion":{"build_ok":true,"test_ok":true,"duration":"2s"}}`))
 		case "/api/task/task-1234/finish":
 			sawFinish = true
 			w.Write([]byte(`{"status":"done","dal":"leader","task":"triage","output":"ok"}`))
@@ -245,6 +247,18 @@ func TestClient_StartAndFinishTaskRun(t *testing.T) {
 	}
 	if len(updated.Events) != 1 || updated.Events[0].Kind != "self_repair" {
 		t.Fatalf("unexpected task events: %+v", updated.Events)
+	}
+	meta, err := c.UpdateTaskRun("task-1234", TaskMetadataUpdate{
+		GitDiff:    "M README.md",
+		GitChanges: 2,
+		Verified:   "yes",
+		Completion: &CompletionResult{BuildOK: true, TestOK: true, Duration: "2s"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateTaskRun: %v", err)
+	}
+	if meta.Verified != "yes" || meta.GitChanges != 2 {
+		t.Fatalf("unexpected metadata result: %+v", meta)
 	}
 	finished, err := c.FinishTaskRun("task-1234", "done", "ok", "")
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -240,6 +240,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/task/start", d.requireAuth(d.handleTaskStart))
 	mux.HandleFunc("GET /api/task/{id}", d.handleTaskStatus)
 	mux.HandleFunc("POST /api/task/{id}/event", d.requireAuth(d.handleTaskEvent))
+	mux.HandleFunc("POST /api/task/{id}/metadata", d.requireAuth(d.handleTaskMetadata))
 	mux.HandleFunc("POST /api/task/{id}/finish", d.requireAuth(d.handleTaskFinish))
 	mux.HandleFunc("GET /api/tasks", d.handleTaskList)
 	// Claims — dal feedback to host

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -36,6 +36,13 @@ type taskEvent struct {
 	Message string    `json:"message"`
 }
 
+type TaskMetadataUpdate struct {
+	GitDiff    string            `json:"git_diff"`
+	GitChanges int               `json:"git_changes"`
+	Verified   string            `json:"verified"`
+	Completion *CompletionResult `json:"completion"`
+}
+
 // taskStore manages running and completed direct tasks.
 type taskStore struct {
 	mu    sync.RWMutex
@@ -122,6 +129,20 @@ func (s *taskStore) AddEvent(id, kind, message string) *taskResult {
 		return nil
 	}
 	tr.appendEvent(kind, message)
+	return tr
+}
+
+func (s *taskStore) UpdateMetadata(id string, update TaskMetadataUpdate) *taskResult {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tr := s.tasks[id]
+	if tr == nil {
+		return nil
+	}
+	tr.GitDiff = update.GitDiff
+	tr.GitChanges = update.GitChanges
+	tr.Verified = update.Verified
+	tr.Completion = update.Completion
 	return tr
 }
 
@@ -221,6 +242,23 @@ func (d *Daemon) handleTaskEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	tr := d.tasks.AddEvent(id, strings.TrimSpace(req.Kind), req.Message)
+	if tr == nil {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+	respondJSON(w, http.StatusOK, tr)
+}
+
+// handleTaskMetadata updates verification metadata for a tracked task.
+// POST /api/task/{id}/metadata
+func (d *Daemon) handleTaskMetadata(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	var req TaskMetadataUpdate
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	tr := d.tasks.UpdateMetadata(id, req)
 	if tr == nil {
 		http.Error(w, "task not found", http.StatusNotFound)
 		return

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -183,6 +183,30 @@ func TestHandleTaskEvent(t *testing.T) {
 	}
 }
 
+func TestHandleTaskMetadata(t *testing.T) {
+	d := New(":0", "/tmp/test", t.TempDir(), nil)
+	tr := d.tasks.New("leader", "triage issue")
+
+	req := httptest.NewRequest("POST", "/api/task/"+tr.ID+"/metadata", strings.NewReader(`{"git_diff":"M README.md","git_changes":1,"verified":"yes","completion":{"build_ok":true,"test_ok":false,"duration":"1.2s"}}`))
+	req.SetPathValue("id", tr.ID)
+	w := httptest.NewRecorder()
+	d.handleTaskMetadata(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	updated := d.tasks.Get(tr.ID)
+	if updated == nil {
+		t.Fatal("expected tracked task")
+	}
+	if updated.Verified != "yes" || updated.GitChanges != 1 {
+		t.Fatalf("unexpected metadata: %+v", updated)
+	}
+	if updated.Completion == nil || updated.Completion.Duration != "1.2s" {
+		t.Fatalf("unexpected completion metadata: %+v", updated.Completion)
+	}
+}
+
 func TestTruncateStr(t *testing.T) {
 	if truncateStr("hello", 10) != "hello" {
 		t.Error("should not truncate short string")


### PR DESCRIPTION
## Summary
- let Mattermost tracked runs upload git diff and verification metadata before finishing
- add a verification summary line to final Mattermost replies so the channel can see build/test status at a glance
- cover the metadata API/client path and the new reply contract with tests

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -run 'Test(RunStatus_UsesRunPageLink|RunStatus_FinalResponsesKeepRunLink|RunStatus_FinalResponsesIncludeVerificationSummary|DM_AllSendCallsHaveChannel|DM_ResponseIncludesChannel)$'