### PR TITLE
fix: pass fallback creds and external run url

### DIFF
--- a/internal/daemon/bootstrap_test.go
+++ b/internal/daemon/bootstrap_test.go
@@ -261,6 +261,13 @@ func TestDockerRun_InjectsMattermostURL(t *testing.T) {
 	}
 }
 
+func TestDockerRun_InjectsExternalURL(t *testing.T) {
+	src := readSource(t, "docker.go")
+	if !strings.Contains(src, "DALCENTER_EXTERNAL_URL") {
+		t.Fatal("dockerRun must inject DALCENTER_EXTERNAL_URL into container when configured")
+	}
+}
+
 // ── restart 핸들러 ───────────────────────────────────────
 
 func TestRestartHandler_Exists(t *testing.T) {

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -101,6 +101,61 @@ func shouldDisableContainerDM(dal *localdal.DalProfile) bool {
 	return dal != nil && dal.ChannelOnly
 }
 
+func credentialPlayers(dal *localdal.DalProfile) []string {
+	if dal == nil {
+		return nil
+	}
+	var players []string
+	seen := make(map[string]bool)
+	add := func(player string) {
+		player = strings.TrimSpace(player)
+		if player == "" || seen[player] {
+			return
+		}
+		seen[player] = true
+		players = append(players, player)
+	}
+	add(dal.Player)
+	add(dal.FallbackPlayer)
+	return players
+}
+
+func appendCredentialMounts(args []string, hostHome string, players []string, warnings *[]string) []string {
+	for _, player := range players {
+		switch player {
+		case "claude":
+			credPath := filepath.Join(hostHome, ".claude", ".credentials.json")
+			if _, err := os.Stat(credPath); err == nil {
+				args = append(args, "-v", fmt.Sprintf("%s:%s/.credentials.json:ro", credPath, playerHome("claude")))
+				if expired, _ := isCredentialExpired(credPath); expired {
+					w := "Claude credential expired — run: pve-sync-creds"
+					log.Printf("WARNING: %s", w)
+					*warnings = append(*warnings, w)
+				}
+			} else {
+				w := fmt.Sprintf("Claude credential not found at %s", credPath)
+				log.Printf("WARNING: %s", w)
+				*warnings = append(*warnings, w)
+			}
+		case "codex":
+			credPath := filepath.Join(hostHome, ".codex", "auth.json")
+			if _, err := os.Stat(credPath); err == nil {
+				args = append(args, "-v", fmt.Sprintf("%s:%s/auth.json:ro", credPath, playerHome("codex")))
+				if expired, _ := isCredentialExpired(credPath); expired {
+					w := "Codex credential expired — run: pve-sync-creds"
+					log.Printf("WARNING: %s", w)
+					*warnings = append(*warnings, w)
+				}
+			} else {
+				w := fmt.Sprintf("Codex credential not found at %s", credPath)
+				log.Printf("WARNING: %s", w)
+				*warnings = append(*warnings, w)
+			}
+		}
+	}
+	return args
+}
+
 // dockerRun creates and starts a Docker container for a dal.
 // It returns the container ID, any credential warnings, and an error.
 func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *localdal.DalProfile) (string, []string, error) {
@@ -151,6 +206,9 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 		// Working directory
 		"-w", containerWorkDir,
 	)
+	if externalURL := strings.TrimSpace(os.Getenv("DALCENTER_EXTERNAL_URL")); externalURL != "" {
+		args = append(args, "-e", fmt.Sprintf("DALCENTER_EXTERNAL_URL=%s", externalURL))
+	}
 
 	// Mount service repo as workspace (shared mode) or leave empty for clone mode
 	isCloneMode := dal.Workspace == "clone"
@@ -160,36 +218,10 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", localdalRoot, filepath.Join(containerWorkDir, ".dal")))
 	}
 
-	// Mount credentials (player-specific)
+	// Mount credentials for primary + fallback players.
+	args = appendCredentialMounts(args, hostHome, credentialPlayers(dal), &warnings)
+
 	switch dal.Player {
-	case "claude":
-		credPath := filepath.Join(hostHome, ".claude", ".credentials.json")
-		if _, err := os.Stat(credPath); err == nil {
-			args = append(args, "-v", fmt.Sprintf("%s:%s/.credentials.json", credPath, home))
-			if expired, _ := isCredentialExpired(credPath); expired {
-				w := "Claude credential expired — run: pve-sync-creds"
-				log.Printf("WARNING: %s", w)
-				warnings = append(warnings, w)
-			}
-		} else {
-			w := fmt.Sprintf("Claude credential not found at %s", credPath)
-			log.Printf("WARNING: %s", w)
-			warnings = append(warnings, w)
-		}
-	case "codex":
-		credPath := filepath.Join(hostHome, ".codex", "auth.json")
-		if _, err := os.Stat(credPath); err == nil {
-			args = append(args, "-v", fmt.Sprintf("%s:%s/auth.json:ro", credPath, home))
-			if expired, _ := isCredentialExpired(credPath); expired {
-				w := "Codex credential expired — run: pve-sync-creds"
-				log.Printf("WARNING: %s", w)
-				warnings = append(warnings, w)
-			}
-		} else {
-			w := fmt.Sprintf("Codex credential not found at %s", credPath)
-			log.Printf("WARNING: %s", w)
-			warnings = append(warnings, w)
-		}
 	case "gemini":
 		// Gemini uses API key — resolve from dal.cue (VK:/env:), fallback to host env
 		key := dal.GeminiAPIKey

--- a/internal/daemon/docker_test.go
+++ b/internal/daemon/docker_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -178,6 +179,49 @@ func TestShouldDisableContainerDM(t *testing.T) {
 	}
 	if shouldDisableContainerDM(&localdal.DalProfile{ChannelOnly: false}) != false {
 		t.Fatal("default dal should keep DM enabled")
+	}
+}
+
+func TestCredentialPlayers(t *testing.T) {
+	dal := &localdal.DalProfile{Player: "claude", FallbackPlayer: "codex"}
+	got := credentialPlayers(dal)
+	if len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
+		t.Fatalf("credentialPlayers() = %v, want [claude codex]", got)
+	}
+
+	same := credentialPlayers(&localdal.DalProfile{Player: "codex", FallbackPlayer: "codex"})
+	if len(same) != 1 || same[0] != "codex" {
+		t.Fatalf("credentialPlayers() should dedupe fallback, got %v", same)
+	}
+}
+
+func TestAppendCredentialMounts(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	claudeFuture := time.Now().Add(time.Hour).UnixMilli()
+	codexFuture := time.Now().Add(time.Hour).Format(time.RFC3339)
+	if err := os.WriteFile(filepath.Join(home, ".claude", ".credentials.json"), []byte(fmt.Sprintf(`{"claudeAiOauth":{"expiresAt":%d}}`, claudeFuture)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex", "auth.json"), []byte(fmt.Sprintf(`{"tokens":{"expires_at":"%s"}}`, codexFuture)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	var warnings []string
+	args := appendCredentialMounts(nil, home, []string{"claude", "codex"}, &warnings)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, ".claude/.credentials.json") {
+		t.Fatalf("expected claude credential mount, got %q", joined)
+	}
+	if !strings.Contains(joined, ".codex/auth.json") {
+		t.Fatalf("expected codex credential mount, got %q", joined)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings, got %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary
- inject `DALCENTER_EXTERNAL_URL` into dal containers so run-page links can render in Mattermost
- mount credentials for both the primary and fallback players instead of only the primary player
- add daemon tests for external URL injection and fallback credential mounts

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -run 'Test(RunStatus_UsesRunPageLink|RunStatus_FinalResponsesKeepRunLink|RunStatus_FinalResponsesIncludeVerificationSummary)$'