### PR TITLE
fix: infer default fallback credential mounts

### DIFF
--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -101,6 +101,17 @@ func shouldDisableContainerDM(dal *localdal.DalProfile) bool {
 	return dal != nil && dal.ChannelOnly
 }
 
+func inferredFallbackPlayer(primary string) string {
+	switch strings.TrimSpace(primary) {
+	case "claude":
+		return "codex"
+	case "codex":
+		return "claude"
+	default:
+		return ""
+	}
+}
+
 func credentialPlayers(dal *localdal.DalProfile) []string {
 	if dal == nil {
 		return nil
@@ -116,7 +127,11 @@ func credentialPlayers(dal *localdal.DalProfile) []string {
 		players = append(players, player)
 	}
 	add(dal.Player)
-	add(dal.FallbackPlayer)
+	fallback := dal.FallbackPlayer
+	if strings.TrimSpace(fallback) == "" {
+		fallback = inferredFallbackPlayer(dal.Player)
+	}
+	add(fallback)
 	return players
 }
 

--- a/internal/daemon/docker_test.go
+++ b/internal/daemon/docker_test.go
@@ -182,11 +182,28 @@ func TestShouldDisableContainerDM(t *testing.T) {
 	}
 }
 
+func TestInferredFallbackPlayer(t *testing.T) {
+	if got := inferredFallbackPlayer("claude"); got != "codex" {
+		t.Fatalf("inferredFallbackPlayer(claude) = %q, want codex", got)
+	}
+	if got := inferredFallbackPlayer("codex"); got != "claude" {
+		t.Fatalf("inferredFallbackPlayer(codex) = %q, want claude", got)
+	}
+	if got := inferredFallbackPlayer("gemini"); got != "" {
+		t.Fatalf("inferredFallbackPlayer(gemini) = %q, want empty", got)
+	}
+}
+
 func TestCredentialPlayers(t *testing.T) {
 	dal := &localdal.DalProfile{Player: "claude", FallbackPlayer: "codex"}
 	got := credentialPlayers(dal)
 	if len(got) != 2 || got[0] != "claude" || got[1] != "codex" {
 		t.Fatalf("credentialPlayers() = %v, want [claude codex]", got)
+	}
+
+	inferred := credentialPlayers(&localdal.DalProfile{Player: "claude"})
+	if len(inferred) != 2 || inferred[0] != "claude" || inferred[1] != "codex" {
+		t.Fatalf("credentialPlayers() should infer codex fallback, got %v", inferred)
 	}
 
 	same := credentialPlayers(&localdal.DalProfile{Player: "codex", FallbackPlayer: "codex"})


### PR DESCRIPTION
## Summary
- infer the default provider fallback when `FallbackPlayer` is not explicitly set in `dal.cue`
- mount fallback credentials for claude/codex dals even when the profile relies on the default fallback behavior
- add daemon tests for inferred fallback player selection

## Testing
- go test ./internal/daemon