### PR TITLE
fix: refresh provider status on cooldown expiry

### DIFF
--- a/internal/daemon/provider_circuit.go
+++ b/internal/daemon/provider_circuit.go
@@ -64,16 +64,18 @@ func (pc *ProviderCircuit) ActiveProvider() string {
 
 // Status returns circuit state for API response.
 func (pc *ProviderCircuit) Status() map[string]interface{} {
+	active := pc.ActiveProvider()
+
 	pc.mu.RLock()
 	defer pc.mu.RUnlock()
 
 	result := map[string]interface{}{
-		"active_provider": pc.activePlayer,
+		"active_provider": active,
 		"primary":         pc.primary,
 		"fallback":        pc.fallback,
 		"cooldown":        pc.cooldown.String(),
 	}
-	if pc.activePlayer == pc.fallback && !pc.trippedAt.IsZero() {
+	if active == pc.fallback && !pc.trippedAt.IsZero() {
 		remaining := pc.cooldown - time.Since(pc.trippedAt)
 		if remaining < 0 {
 			remaining = 0

--- a/internal/daemon/provider_circuit_test.go
+++ b/internal/daemon/provider_circuit_test.go
@@ -1,0 +1,49 @@
+package daemon
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProviderCircuitStatusResetsAfterCooldown(t *testing.T) {
+	pc := &ProviderCircuit{
+		primary:      "claude",
+		fallback:     "codex",
+		activePlayer: "codex",
+		cooldown:     50 * time.Millisecond,
+		trippedAt:    time.Now().Add(-time.Minute),
+		trippedBy:    "leader",
+		reason:       "rate limit",
+	}
+
+	status := pc.Status()
+	if got := status["active_provider"]; got != "claude" {
+		t.Fatalf("active_provider = %v, want claude", got)
+	}
+	if pc.activePlayer != "claude" {
+		t.Fatalf("activePlayer = %q, want claude", pc.activePlayer)
+	}
+	if _, ok := status["resets_in"]; ok {
+		t.Fatal("status should not expose resets_in after cooldown reset")
+	}
+}
+
+func TestProviderCircuitStatusKeepsFallbackWithinCooldown(t *testing.T) {
+	pc := &ProviderCircuit{
+		primary:      "claude",
+		fallback:     "codex",
+		activePlayer: "codex",
+		cooldown:     time.Hour,
+		trippedAt:    time.Now().Add(-time.Minute),
+		trippedBy:    "leader",
+		reason:       "rate limit",
+	}
+
+	status := pc.Status()
+	if got := status["active_provider"]; got != "codex" {
+		t.Fatalf("active_provider = %v, want codex", got)
+	}
+	if _, ok := status["resets_in"]; !ok {
+		t.Fatal("status should expose resets_in while cooldown remains")
+	}
+}


### PR DESCRIPTION
## Summary
- make provider status refresh active provider before returning API state
- add regression coverage for cooldown-expired and cooldown-active status reads

## Testing
- go test ./internal/daemon -run 'TestProviderCircuitStatus'\n- go test ./internal/daemon