### PR TITLE
fix: namespace Mattermost bot usernames per repo

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -26,6 +26,7 @@ import (
 type agentConfig struct {
 	DalName     string `json:"dal_name"`
 	BotToken    string `json:"bot_token"`
+	BotUsername string `json:"bot_username"`
 	ChannelID   string `json:"channel_id"`
 	MMURL       string `json:"mm_url"`
 	TeamMembers string `json:"team_members"`
@@ -528,7 +529,11 @@ func runAgentLoop(dalName string) error {
 	log.Printf("[agent] listening...")
 
 	uuidShort := os.Getenv("DAL_UUID_SHORT")
-	mention := fmt.Sprintf("@dal-%s", dalName)
+	stableMention := fmt.Sprintf("@dal-%s", dalName)
+	mention := stableMention
+	if cfg.BotUsername != "" {
+		mention = "@" + cfg.BotUsername
+	}
 	var legacyMention string
 	if uuidShort != "" {
 		legacyMention = fmt.Sprintf("@dal-%s-%s", dalName, uuidShort)
@@ -602,7 +607,7 @@ func runAgentLoop(dalName string) error {
 			continue
 		}
 
-		isDirectMention := containsAnyMention(msg.Content, mention, legacyMention, altMention)
+		isDirectMention := containsAnyMention(msg.Content, mention, stableMention, legacyMention, altMention)
 		isThreadReply := msg.RootID != "" && isActiveThread(&activeThreads, msg.RootID)
 		isDM := msg.Channel != "" && msg.Channel != cfg.ChannelID // DM = different channel than main
 
@@ -617,7 +622,7 @@ func runAgentLoop(dalName string) error {
 			log.Printf("[agent] skipped operational dal-bot message: %s", truncate(msg.Content, 60))
 			continue
 		}
-		if isDM && isDirectedAtDifferentDal(msg.Content, mention, legacyMention, altMention) {
+		if isDM && isDirectedAtDifferentDal(msg.Content, mention, stableMention, legacyMention, altMention) {
 			log.Printf("[agent] skipped DM for different dal: %s", truncate(msg.Content, 60))
 			continue
 		}
@@ -641,7 +646,7 @@ func runAgentLoop(dalName string) error {
 		task := extractTask(msg.Content, "작업 지시:")
 		if task == "" && isDirectMention {
 			// Free-form: strip mention, use entire message
-			task = stripMentions(msg.Content, mention, legacyMention, altMention)
+			task = stripMentions(msg.Content, mention, stableMention, legacyMention, altMention)
 		}
 		if task == "" && isThreadReply {
 			task = msg.Content

--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -644,6 +644,7 @@ func TestIsDirectedAtDifferentDal(t *testing.T) {
 		want    bool
 	}{
 		{"plain dm", "로그 좀 봐줘", false},
+		{"self actual mention", "@dal-leader-dalcent4f2a 확인해줘", false},
 		{"self stable mention", "@dal-leader 확인해줘", false},
 		{"self legacy mention", "@dal-leader-emotio 확인해줘", false},
 		{"self short mention", "@leader 확인해줘", false},
@@ -654,7 +655,7 @@ func TestIsDirectedAtDifferentDal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isDirectedAtDifferentDal(tt.content, "@dal-leader", "@dal-leader-emotio", "@leader")
+			got := isDirectedAtDifferentDal(tt.content, "@dal-leader-dalcent4f2a", "@dal-leader", "@dal-leader-emotio", "@leader")
 			if got != tt.want {
 				t.Fatalf("got %v, want %v", got, tt.want)
 			}

--- a/internal/daemon/bootstrap_test.go
+++ b/internal/daemon/bootstrap_test.go
@@ -124,17 +124,47 @@ func TestContainerHasBotUsername(t *testing.T) {
 
 func TestDalBotUsername_Format(t *testing.T) {
 	cases := []struct {
-		name, uuid, want string
+		repo string
+		name string
+		uuid string
 	}{
-		{"leader", "v2-leader-20260327", "dal-leader"},
-		{"dev", "dc-codex-dev-20260327", "dal-dev"},
-		{"verifier", "vk-verifier-20260326", "dal-verifier"},
+		{"/root/veilkey-v2", "leader", "v2-leader-20260327"},
+		{"/root/dalcenter", "dev", "dc-codex-dev-20260327"},
+		{"/root/veilkey-selfhosted", "verifier", "vk-verifier-20260326"},
 	}
 	for _, tc := range cases {
-		got := dalBotUsername(tc.name, tc.uuid)
-		if got != tc.want {
-			t.Errorf("dalBotUsername(%q, %q) = %q, want %q", tc.name, tc.uuid, got, tc.want)
+		got := dalBotUsername(tc.repo, tc.name, tc.uuid)
+		if !strings.HasPrefix(got, "dal-"+tc.name+"-") {
+			t.Errorf("dalBotUsername(%q, %q, %q) = %q, want prefix %q", tc.repo, tc.name, tc.uuid, got, "dal-"+tc.name+"-")
 		}
+		if len(got) > mattermostBotUsernameMaxLen {
+			t.Errorf("dalBotUsername(%q, %q, %q) too long: %q (%d)", tc.repo, tc.name, tc.uuid, got, len(got))
+		}
+	}
+}
+
+func TestDalBotUsername_DifferentRepos(t *testing.T) {
+	a := dalBotUsername("/root/dalcenter", "leader", "leader-20260326")
+	b := dalBotUsername("/root/veilkey-v2", "leader", "v2-leader-20260327")
+	if a == b {
+		t.Fatalf("expected different usernames per repo, got %q", a)
+	}
+}
+
+func TestDalBotUsername_ShortUUID(t *testing.T) {
+	result := dalBotUsername("/root/dalcenter", "dev", "abc")
+	if !strings.HasPrefix(result, "dal-dev-") {
+		t.Errorf("got %q", result)
+	}
+}
+
+func TestDalBotUsername_LongNameWithinLimit(t *testing.T) {
+	result := dalBotUsername("/root/bridge-of-gaya-script", "story-checker", "very-long-uuid-string-here")
+	if len(result) > mattermostBotUsernameMaxLen {
+		t.Fatalf("username too long: %q (%d)", result, len(result))
+	}
+	if !strings.HasPrefix(result, "dal-story") {
+		t.Fatalf("expected recognizable prefix, got %q", result)
 	}
 }
 
@@ -469,23 +499,6 @@ func TestTaskStore_ListAll(t *testing.T) {
 	all := ts.List()
 	if len(all) != 3 {
 		t.Fatalf("expected 3 tasks, got %d", len(all))
-	}
-}
-
-// ── dalBotUsername 추가 테스트 ────────────────────────────
-
-func TestDalBotUsername_ShortUUID(t *testing.T) {
-	result := dalBotUsername("dev", "abc")
-	if result != "dal-dev" {
-		t.Errorf("got %q", result)
-	}
-}
-
-func TestDalBotUsername_LongUUID(t *testing.T) {
-	result := dalBotUsername("leader", "very-long-uuid-string-here")
-	expected := "dal-leader"
-	if result != expected {
-		t.Errorf("got %q, want %q", result, expected)
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -103,10 +105,65 @@ func dalContainerName(name, uuid string) string {
 	return containerBasePrefix + name + "-" + uuidShort(uuid)
 }
 
-// dalBotUsername returns the MM bot username: dal-{name}
-// Uses a stable name (no UUID) so the bot is reused across wake cycles.
-func dalBotUsername(name, _ string) string {
-	return containerBasePrefix + name
+const (
+	mattermostBotUsernameMaxLen = 22
+	mattermostBotRepoHashLen    = 4
+)
+
+// dalBotUsername returns a repo-namespaced MM bot username.
+// Format: dal-{name}-{repoNs}, kept within Mattermost's username length limit.
+func dalBotUsername(serviceRepo, name, _ string) string {
+	namePart := sanitizeMMUsernamePart(name)
+	if namePart == "" {
+		namePart = "bot"
+	}
+
+	maxNameLen := mattermostBotUsernameMaxLen - len(containerBasePrefix) - 1 - mattermostBotRepoHashLen
+	if maxNameLen < 1 {
+		maxNameLen = 1
+	}
+	if len(namePart) > maxNameLen {
+		namePart = namePart[:maxNameLen]
+	}
+
+	repoPart := repoBotNamespace(serviceRepo, mattermostBotUsernameMaxLen-len(containerBasePrefix)-len(namePart)-1)
+	return containerBasePrefix + namePart + "-" + repoPart
+}
+
+func repoBotNamespace(serviceRepo string, maxLen int) string {
+	if maxLen < 1 {
+		return "x"
+	}
+	baseName := filepath.Base(serviceRepo)
+	if baseName == "" || baseName == "." {
+		baseName = "repo"
+	}
+	clean := sanitizeMMUsernamePart(baseName)
+	if clean == "" {
+		clean = "repo"
+	}
+	absPath, _ := filepath.Abs(serviceRepo)
+	sum := sha256.Sum256([]byte(absPath))
+	hash := hex.EncodeToString(sum[:])[:mattermostBotRepoHashLen]
+	if maxLen <= len(hash) {
+		return hash[:maxLen]
+	}
+	prefixLen := maxLen - len(hash)
+	if len(clean) > prefixLen {
+		clean = clean[:prefixLen]
+	}
+	return clean + hash
+}
+
+func sanitizeMMUsernamePart(raw string) string {
+	var b strings.Builder
+	b.Grow(len(raw))
+	for _, r := range strings.ToLower(raw) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
 }
 
 // requireAuth is middleware that checks Bearer token for write endpoints.
@@ -404,7 +461,7 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 	// Setup Mattermost bot for this dal
 	var botToken string
 	if d.mm != nil && d.mm.URL != "" && d.channelID != "" {
-		botUsername := dalBotUsername(dal.Name, dal.UUID)
+		botUsername := dalBotUsername(d.serviceRepo, dal.Name, dal.UUID)
 		teamID, _, _ := talk.GetTeamAndChannel(d.mm.URL, d.mm.AdminToken, d.mm.TeamName, filepath.Base(d.serviceRepo))
 		bot, err := talk.SetupBot(d.mm.URL, d.mm.AdminToken, teamID, d.channelID, botUsername, dal.Name, fmt.Sprintf("dal %s (%s)", dal.Name, dal.Role))
 		if err != nil {
@@ -429,7 +486,7 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 	if ws == "" {
 		ws = "shared"
 	}
-	botUser := dalBotUsername(dal.Name, dal.UUID)
+	botUser := dalBotUsername(d.serviceRepo, dal.Name, dal.UUID)
 	d.mu.Lock()
 	d.containers[instanceName] = &Container{
 		DalName:     instanceName,
@@ -899,7 +956,7 @@ func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 				if c.BotUsername != "" {
 					mention += c.BotUsername
 				} else {
-					mention += dalBotUsername(c.DalName, c.UUID)
+					mention += dalBotUsername(d.serviceRepo, c.DalName, c.UUID)
 				}
 				legacyMention := fmt.Sprintf("@dal-%s-%s", c.DalName, uuidShort(c.UUID))
 				altMention := "@" + c.DalName
@@ -1079,10 +1136,11 @@ func (d *Daemon) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := map[string]string{
-		"dal_name":   c.DalName,
-		"uuid":       c.UUID,
-		"bot_token":  c.BotToken,
-		"channel_id": d.channelID,
+		"dal_name":     c.DalName,
+		"uuid":         c.UUID,
+		"bot_token":    c.BotToken,
+		"bot_username": c.BotUsername,
+		"channel_id":   d.channelID,
 	}
 	if d.mm != nil {
 		resp["mm_url"] = d.mm.URL

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -10,8 +10,9 @@ func TestHandleAgentConfig_Found(t *testing.T) {
 	d := &Daemon{
 		containers: map[string]*Container{
 			"story-checker": {
-				DalName:  "story-checker",
-				BotToken: "bot-tok-123",
+				DalName:     "story-checker",
+				BotToken:    "bot-tok-123",
+				BotUsername: "dal-storychecker-abcd",
 			},
 		},
 		channelID: "ch-abc",
@@ -36,6 +37,9 @@ func TestHandleAgentConfig_Found(t *testing.T) {
 	}
 	if resp["bot_token"] != "bot-tok-123" {
 		t.Errorf("bot_token = %q", resp["bot_token"])
+	}
+	if resp["bot_username"] != "dal-storychecker-abcd" {
+		t.Errorf("bot_username = %q", resp["bot_username"])
 	}
 	if resp["channel_id"] != "ch-abc" {
 		t.Errorf("channel_id = %q", resp["channel_id"])


### PR DESCRIPTION
## Summary
- generate repo-namespaced Mattermost bot usernames within the 22-char limit
- expose bot_username in agent config and let dalcli recognize the real Mattermost username plus legacy aliases
- add regression coverage for repo-specific usernames and namespaced self-mentions

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -run 'Test(ShouldIgnoreDalBotMessage|IsDirectedAtDifferentDal|RunStatus_UsesRunPageLink|RunStatus_FinalResponsesKeepRunLink|RunStatus_FinalResponsesIncludeVerificationSummary)$'