### PR TITLE
Retry Mattermost sends after bot token refresh

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -450,6 +451,50 @@ func dalcenterClientOrFallback() (*daemon.Client, error) {
 	return nil, fmt.Errorf("DALCENTER_URL not set")
 }
 
+func refreshAgentConfig(dalName string) (*agentConfig, error) {
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		return nil, err
+	}
+	result, err := client.RefreshAgentToken(dalName)
+	if err != nil {
+		return nil, err
+	}
+	return &agentConfig{
+		DalName:     result["dal_name"],
+		BotToken:    result["bot_token"],
+		BotUsername: result["bot_username"],
+		ChannelID:   result["channel_id"],
+		MMURL:       result["mm_url"],
+		TeamMembers: result["team_members"],
+	}, nil
+}
+
+func sendMattermostMessage(mm *bridge.MattermostBridge, dalName string, cfg *agentConfig, msg bridge.Message) error {
+	err := mm.Send(msg)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, bridge.ErrAuthFailed) {
+		return err
+	}
+	refreshed, refreshErr := refreshAgentConfig(dalName)
+	if refreshErr != nil {
+		return fmt.Errorf("refresh bot token: %w", refreshErr)
+	}
+	if refreshed.BotToken == "" {
+		return fmt.Errorf("refresh bot token: empty token")
+	}
+	mm.UpdateToken(refreshed.BotToken)
+	if cfg != nil {
+		*cfg = *refreshed
+		if refreshed.TeamMembers != "" {
+			os.Setenv("DAL_TEAM_MEMBERS", refreshed.TeamMembers)
+		}
+	}
+	return mm.Send(msg)
+}
+
 func runCmd(dalName string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "run",
@@ -679,11 +724,13 @@ func runAgentLoop(dalName string) error {
 		} else {
 			statusMsg = "💬 작업 중..."
 		}
-		mm.Send(bridge.Message{
+		if err := sendMattermostMessage(mm, dalName, cfg, bridge.Message{
 			Content: statusMsg,
 			Channel: spec.Channel,
 			ReplyTo: spec.ThreadID,
-		})
+		}); err != nil {
+			log.Printf("[agent] status send failed: %v", err)
+		}
 
 		beforeVerification, beforeErr := captureWorkspaceGitState()
 		if beforeErr != nil {
@@ -699,11 +746,13 @@ func runAgentLoop(dalName string) error {
 			if shouldRetry, fix := selfRepair(spec.Prompt, output, err); shouldRetry {
 				log.Printf("[agent] self-repair applied: %s, retrying", fix)
 				appendTrackedRunEvent(taskRunID, "self_repair", fmt.Sprintf("Self-repair applied: %s", fix))
-				mm.Send(bridge.Message{
+				if err := sendMattermostMessage(mm, dalName, cfg, bridge.Message{
 					Content: fmt.Sprintf("🔧 자가 수리: %s — 재시도 중...", fix),
 					Channel: spec.Channel,
 					ReplyTo: spec.ThreadID,
-				})
+				}); err != nil {
+					log.Printf("[agent] self-repair send failed: %v", err)
+				}
 				result = runTaskSpec(spec)
 				output, err = result.Output, result.Err
 			}
@@ -719,11 +768,13 @@ func runAgentLoop(dalName string) error {
 				if runURL != "" {
 					failureMsg += fmt.Sprintf("\n\n[실행 보기](%s)", runURL)
 				}
-				mm.Send(bridge.Message{
+				if err := sendMattermostMessage(mm, dalName, cfg, bridge.Message{
 					Content: failureMsg,
 					Channel: spec.Channel,
 					ReplyTo: spec.ThreadID,
-				})
+				}); err != nil {
+					log.Printf("[agent] failure send failed: %v", err)
+				}
 				appendHistoryBuffer(dalName, spec.Prompt, err.Error(), string(result.State))
 				escalateToHost(dalName, spec.Prompt, output, string(class))
 				daemon.DispatchTaskFailed(dalName, truncate(spec.Prompt, 200), err.Error(), len(output))
@@ -784,11 +835,13 @@ func runAgentLoop(dalName string) error {
 			response += fmt.Sprintf("\n\n[실행 보기](%s)", runURL)
 		}
 
-		mm.Send(bridge.Message{
+		if err := sendMattermostMessage(mm, dalName, cfg, bridge.Message{
 			Content: response,
 			Channel: spec.Channel,
 			ReplyTo: spec.ThreadID,
-		})
+		}); err != nil {
+			log.Printf("[agent] final send failed: %v", err)
+		}
 
 		// Report to leader: when a member dal receives a direct task from user (not from leader),
 		// notify the leader so they stay in the loop

--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -823,6 +823,39 @@ func TestFetchAgentConfig_ServerError(t *testing.T) {
 	}
 }
 
+func TestRefreshAgentConfig_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/agent-config/writer/refresh-token" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"dal_name":     "writer",
+			"bot_token":    "fresh-token",
+			"bot_username": "dal-writer-abcd",
+			"channel_id":   "ch-abc",
+			"mm_url":       "http://mm:8065",
+		})
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	cfg, err := refreshAgentConfig("writer")
+	if err != nil {
+		t.Fatalf("refreshAgentConfig: %v", err)
+	}
+	if cfg.BotToken != "fresh-token" {
+		t.Fatalf("token = %q", cfg.BotToken)
+	}
+	if cfg.BotUsername != "dal-writer-abcd" {
+		t.Fatalf("bot username = %q", cfg.BotUsername)
+	}
+}
+
 // ── executeTask role branching (verify command construction) ──
 
 func TestExecuteTask_RoleBranching(t *testing.T) {

--- a/internal/bridge/bridge.go
+++ b/internal/bridge/bridge.go
@@ -19,5 +19,6 @@ type Bridge interface {
 	Listen() <-chan Message
 	Errors() <-chan error
 	Send(msg Message) error
+	UpdateToken(token string)
 	Close() error
 }

--- a/internal/bridge/mattermost.go
+++ b/internal/bridge/mattermost.go
@@ -19,13 +19,14 @@ var ErrAuthFailed = errors.New("auth failed (token invalid or expired)")
 // MattermostBridge implements Bridge using Mattermost REST API polling.
 type MattermostBridge struct {
 	URL          string
-	Token        string
 	ChannelID    string
 	BotUserID    string
 	NoDM         bool             // disable DM channel polling
 	dmLastAt     map[string]int64 // per-DM-channel lastAt
 	PollInterval time.Duration
 
+	tokenMu  sync.RWMutex
+	Token    string
 	messages chan Message
 	errors   chan error
 	done     chan struct{}
@@ -62,6 +63,17 @@ func (m *MattermostBridge) Connect() error {
 
 func (m *MattermostBridge) Listen() <-chan Message { return m.messages }
 func (m *MattermostBridge) Errors() <-chan error   { return m.errors }
+func (m *MattermostBridge) UpdateToken(token string) {
+	m.tokenMu.Lock()
+	defer m.tokenMu.Unlock()
+	m.Token = token
+}
+
+func (m *MattermostBridge) token() string {
+	m.tokenMu.RLock()
+	defer m.tokenMu.RUnlock()
+	return m.Token
+}
 
 func (m *MattermostBridge) Send(msg Message) error {
 	rootID := msg.RootID
@@ -213,10 +225,10 @@ func (m *MattermostBridge) fetchNewPosts() ([]Message, error) {
 				m.lastAt = post.CreateAt
 			}
 			// Skip own messages at bridge level to prevent self-response loops
-		if post.UserID == m.BotUserID {
-			continue
-		}
-		allMsgs = append(allMsgs, Message{
+			if post.UserID == m.BotUserID {
+				continue
+			}
+			allMsgs = append(allMsgs, Message{
 				ID:        post.ID,
 				From:      post.UserID,
 				Channel:   post.ChannelID,
@@ -280,7 +292,7 @@ func (m *MattermostBridge) fetchDMChannelIDs() ([]string, error) {
 
 func (m *MattermostBridge) apiGet(path string) ([]byte, error) {
 	req, _ := http.NewRequest("GET", m.URL+path, nil)
-	req.Header.Set("Authorization", "Bearer "+m.Token)
+	req.Header.Set("Authorization", "Bearer "+m.token())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -298,7 +310,7 @@ func (m *MattermostBridge) apiGet(path string) ([]byte, error) {
 
 func (m *MattermostBridge) apiPost(path, jsonBody string) ([]byte, error) {
 	req, _ := http.NewRequest("POST", m.URL+path, strings.NewReader(jsonBody))
-	req.Header.Set("Authorization", "Bearer "+m.Token)
+	req.Header.Set("Authorization", "Bearer "+m.token())
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -448,6 +448,32 @@ func (c *Client) UpdateTaskRun(id string, update TaskMetadataUpdate) (*TaskResul
 	return &result, nil
 }
 
+// RefreshAgentToken asks the daemon to recreate a dal bot token and returns the fresh config.
+func (c *Client) RefreshAgentToken(name string) (map[string]string, error) {
+	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/agent-config/"+name+"/refresh-token", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.apiToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.apiToken)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("daemon unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("refresh agent token failed: %s", strings.TrimSpace(string(body)))
+	}
+	var result map[string]string
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("json unmarshal: %w", err)
+	}
+	return result, nil
+}
+
 // Feedback submits a task result for persistent tracking.
 func (c *Client) Feedback(dal, taskID, task, result, errMsg string, gitChanges int, durationMs int64) (*Feedback, error) {
 	body := fmt.Sprintf(`{"dal":%q,"task_id":%q,"task":%q,"result":%q,"error":%q,"git_changes":%d,"duration_ms":%d}`,

--- a/internal/daemon/client_extra_test.go
+++ b/internal/daemon/client_extra_test.go
@@ -99,3 +99,28 @@ func TestClient_Logs_Content(t *testing.T) {
 		t.Error("logs should not be empty")
 	}
 }
+
+func TestClient_RefreshAgentToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/api/agent-config/leader/refresh-token" {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"dal_name":  "leader",
+			"bot_token": "fresh-token",
+		})
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	resp, err := c.RefreshAgentToken("leader")
+	if err != nil {
+		t.Fatalf("RefreshAgentToken: %v", err)
+	}
+	if resp["bot_token"] != "fresh-token" {
+		t.Fatalf("bot_token = %q", resp["bot_token"])
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -292,6 +292,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/sync", d.requireAuth(d.handleSync))
 	mux.HandleFunc("POST /api/message", d.requireAuth(d.handleMessage))
 	mux.HandleFunc("GET /api/agent-config/{name}", d.handleAgentConfig)
+	mux.HandleFunc("POST /api/agent-config/{name}/refresh-token", d.handleAgentTokenRefresh)
 	// Direct task execution (works without Mattermost)
 	mux.HandleFunc("POST /api/task", d.requireAuth(d.handleTask))
 	mux.HandleFunc("POST /api/task/start", d.requireAuth(d.handleTaskStart))
@@ -1127,14 +1128,34 @@ func extractInstanceName(containerName string) string {
 // Called by dalcli run inside the container.
 func (d *Daemon) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
-	d.mu.RLock()
-	c, ok := d.containers[name]
-	d.mu.RUnlock()
+	c, ok := d.agentContainer(name)
 	if !ok {
 		http.Error(w, "dal not found", 404)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(d.agentConfigResponse(name, c))
+}
 
+func (d *Daemon) handleAgentTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	c, err := d.refreshAgentBotToken(name)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(d.agentConfigResponse(name, c))
+}
+
+func (d *Daemon) agentContainer(name string) (*Container, bool) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	c, ok := d.containers[name]
+	return c, ok
+}
+
+func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]string {
 	resp := map[string]string{
 		"dal_name":     c.DalName,
 		"uuid":         c.UUID,
@@ -1158,9 +1179,64 @@ func (d *Daemon) handleAgentConfig(w http.ResponseWriter, r *http.Request) {
 	if len(teammates) > 0 {
 		resp["team_members"] = strings.Join(teammates, ",")
 	}
+	return resp
+}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(resp)
+func (d *Daemon) refreshAgentBotToken(name string) (*Container, error) {
+	if d.mm == nil || d.mm.URL == "" || d.channelID == "" {
+		return nil, fmt.Errorf("mattermost not configured")
+	}
+	c, ok := d.agentContainer(name)
+	if !ok {
+		return nil, fmt.Errorf("dal %q not found", name)
+	}
+
+	dal, err := localdal.ReadDalCue(d.dalCuePath(name), name)
+	if err != nil {
+		if idx := strings.LastIndex(name, "-"); idx > 0 {
+			baseName := name[:idx]
+			dal, err = localdal.ReadDalCue(d.dalCuePath(baseName), baseName)
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load dal profile: %w", err)
+	}
+
+	teamID, _, err := talk.GetTeamAndChannel(d.mm.URL, d.mm.AdminToken, d.mm.TeamName, filepath.Base(d.serviceRepo))
+	if err != nil {
+		return nil, fmt.Errorf("resolve mattermost team/channel: %w", err)
+	}
+
+	botUsername := c.BotUsername
+	if botUsername == "" {
+		botUsername = dalBotUsername(d.serviceRepo, dal.Name, dal.UUID)
+	}
+	bot, err := talk.SetupBot(d.mm.URL, d.mm.AdminToken, teamID, d.channelID, botUsername, dal.Name, fmt.Sprintf("dal %s (%s)", dal.Name, dal.Role))
+	if err != nil {
+		return nil, fmt.Errorf("refresh bot token: %w", err)
+	}
+
+	d.mu.Lock()
+	current, ok := d.containers[name]
+	if !ok {
+		d.mu.Unlock()
+		return nil, fmt.Errorf("dal %q disappeared during refresh", name)
+	}
+	current.BotToken = bot.Token
+	current.BotUsername = botUsername
+	currentCopy := *current
+	d.mu.Unlock()
+
+	d.registry.Set(currentCopy.UUID, RegistryEntry{
+		Name:        name,
+		Repo:        d.serviceRepo,
+		ContainerID: currentCopy.ContainerID,
+		BotToken:    bot.Token,
+		Status:      currentCopy.Status,
+	})
+
+	log.Printf("[daemon] refreshed mattermost bot token for %s (%s)", name, botUsername)
+	return &currentCopy, nil
 }
 
 func (d *Daemon) dalCuePath(name string) string {

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 )
@@ -85,5 +86,23 @@ func TestHandleAgentConfig_NoMM(t *testing.T) {
 
 	if resp["mm_url"] != "" {
 		t.Errorf("mm_url should be empty when mm is nil, got %q", resp["mm_url"])
+	}
+}
+
+func TestHandleAgentTokenRefresh_RequiresMattermost(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"leader": {DalName: "leader", UUID: "leader-uuid"},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/agent-config/leader/refresh-token", nil)
+	req.SetPathValue("name", "leader")
+	w := httptest.NewRecorder()
+
+	d.handleAgentTokenRefresh(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## Summary
- retry Mattermost sends after bot token auth failure by refreshing the dal bot token from daemon
- expose a daemon endpoint to rotate a dal bot token and update the registry/container state
- add tests for refresh client/config paths