### PR TITLE
test: avoid executeTask hangs in dalcli tests

### DIFF
--- a/cmd/dalcli/circuit_breaker_edge_test.go
+++ b/cmd/dalcli/circuit_breaker_edge_test.go
@@ -6,11 +6,27 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+func installFailingProviders(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	script := []byte("#!/bin/sh\nexit 1\n")
+	for _, name := range []string{"claude", "codex"} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, script, 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+
+	t.Setenv("PATH", dir)
+}
 
 // ══════════════════════════════════════════════════════════════
 // Circuit Breaker: timing & boundary edge cases
@@ -363,6 +379,7 @@ func TestDetectFallback_AllPlayers(t *testing.T) {
 func TestExecuteTask_AnyErrorRecordsFailure(t *testing.T) {
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
+	installFailingProviders(t)
 
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
@@ -395,6 +412,7 @@ func TestExecuteTask_AnyErrorRecordsFailure(t *testing.T) {
 func TestExecuteTask_RepeatedFailuresOpenCircuit(t *testing.T) {
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
+	installFailingProviders(t)
 
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")

--- a/cmd/dalcli/cmd_autotask_test.go
+++ b/cmd/dalcli/cmd_autotask_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestRunAutoTaskOnly_ExitsWithoutClaude(t *testing.T) {
+	installFailingProviders(t)
 	// runAutoTaskOnly calls executeTask which calls claude
 	// Without claude binary, it should still run (fail task but not crash)
 	os.Setenv("DAL_PLAYER", "claude")
@@ -57,6 +58,7 @@ func TestRunAutoTaskOnly_DefaultInterval(t *testing.T) {
 }
 
 func TestAutoTaskOnlyMode_TriggeredWhenMMUnavailable(t *testing.T) {
+	installFailingProviders(t)
 	// When MM is not available and DAL_AUTO_TASK is set,
 	// runAgentLoop should enter auto-task-only mode
 	os.Setenv("DAL_PLAYER", "claude")

--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -859,6 +859,7 @@ func TestRefreshAgentConfig_Success(t *testing.T) {
 // ── executeTask role branching (verify command construction) ──
 
 func TestExecuteTask_RoleBranching(t *testing.T) {
+	installFailingProviders(t)
 	// We can't actually run claude in tests, but we verify the function
 	// handles missing binary gracefully
 	os.Setenv("DAL_ROLE", "member")
@@ -980,6 +981,7 @@ func TestIsRetryable(t *testing.T) {
 // ── executeTask retry (no claude binary → fails fast, not retryable) ──
 
 func TestExecuteTask_NonRetryable_NoLoop(t *testing.T) {
+	installFailingProviders(t)
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_PLAYER", "claude")
 	defer os.Unsetenv("DAL_ROLE")


### PR DESCRIPTION
## Summary
- add a helper that installs stub failing provider binaries for executeTask failure-path tests
- use the helper in circuit breaker, role branching, and auto-task tests that previously retried real providers
- keep the tests focused on failure handling instead of provider availability

## Testing
- go test ./cmd/dalcli -run 'TestExecuteTask_(AnyErrorRecordsFailure|RepeatedFailuresOpenCircuit)$' -count=1 -timeout 20s
- go test ./cmd/dalcli -run 'Test(ExecuteTask_RoleBranching|ExecuteTask_NonRetryable_NoLoop|RunAutoTaskOnly_ExitsWithoutClaude|AutoTaskOnlyMode_TriggeredWhenMMUnavailable)$' -count=1 -timeout 20s
- go test ./cmd/dalcli -timeout 45s

Closes #484