### PR TITLE
feat: show last seen and idle time in dalcli ps

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -451,6 +451,16 @@ func dalcenterClientOrFallback() (*daemon.Client, error) {
 	return nil, fmt.Errorf("DALCENTER_URL not set")
 }
 
+func recordDalActivity(dalName string) {
+	client, err := dalcenterClientOrFallback()
+	if err != nil {
+		return
+	}
+	if _, err := client.Activity(dalName); err != nil {
+		log.Printf("[agent] activity update failed: %v", err)
+	}
+}
+
 func refreshAgentConfig(dalName string) (*agentConfig, error) {
 	client, err := dalcenterClientOrFallback()
 	if err != nil {
@@ -622,6 +632,7 @@ func runAgentLoop(dalName string) error {
 				continue
 			}
 			log.Printf("[agent] auto-task triggered")
+			recordDalActivity(dalName)
 			output, err := executeTask(autoTask)
 			if err != nil {
 				log.Printf("[agent] auto-task failed: %v", err)
@@ -705,6 +716,7 @@ func runAgentLoop(dalName string) error {
 
 		spec := buildTaskSpec(dalName, mm, msg, task, isDirectMention, isThreadReply, isDM)
 		log.Printf("[agent] message: %s (intent=%s source=%s)", truncate(spec.UserTask, 80), spec.Intent, spec.Source)
+		recordDalActivity(dalName)
 
 		if handled, err := handleCredentialStatusQuery(dalName, credentialStatusQueryInput(spec.UserTask, spec.Prompt), spec.ThreadID, spec.Channel, mm); err != nil {
 			log.Printf("[agent] credential status reply failed: %v", err)
@@ -1533,6 +1545,7 @@ func runAutoTaskOnly(dalName, autoTask string) error {
 		log.Printf("[agent] auto-task initial run skipped: no git changes")
 	} else {
 		log.Printf("[agent] auto-task initial run")
+		recordDalActivity(dalName)
 		output, err := executeTask(autoTask)
 		if err != nil {
 			log.Printf("[agent] auto-task failed: %v", err)
@@ -1549,6 +1562,7 @@ func runAutoTaskOnly(dalName, autoTask string) error {
 			continue
 		}
 		log.Printf("[agent] auto-task triggered")
+		recordDalActivity(dalName)
 		output, err := executeTask(autoTask)
 		if err != nil {
 			log.Printf("[agent] auto-task failed: %v", err)

--- a/cmd/dalcli/main.go
+++ b/cmd/dalcli/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+	"time"
 
 	"github.com/dalsoop/dalcenter/internal/daemon"
 	"github.com/spf13/cobra"
@@ -47,6 +48,12 @@ func statusCmd(dalName string) *cobra.Command {
 					fmt.Printf("player:    %s\n", c.Player)
 					fmt.Printf("role:      %s\n", c.Role)
 					fmt.Printf("status:    %s\n", c.Status)
+					if c.IdleFor != "" {
+						fmt.Printf("idle:      %s\n", c.IdleFor)
+					}
+					if !c.LastSeenAt.IsZero() {
+						fmt.Printf("last_seen: %s\n", c.LastSeenAt.Local().Format(time.RFC3339))
+					}
 					fmt.Printf("container: %s\n", c.ContainerID[:12])
 					return nil
 				}
@@ -74,9 +81,17 @@ func psCmd() *cobra.Command {
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS")
+			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tIDLE\tLAST SEEN")
 			for _, c := range containers {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status)
+				idle := c.IdleFor
+				if idle == "" {
+					idle = "-"
+				}
+				lastSeen := "-"
+				if !c.LastSeenAt.IsZero() {
+					lastSeen = c.LastSeenAt.Local().Format("2006-01-02 15:04:05")
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status, idle, lastSeen)
 			}
 			w.Flush()
 			return nil

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -103,6 +103,11 @@ func (c *Client) MessageThread(from, message, threadID string) (*MessageResult, 
 	return &result, nil
 }
 
+// Activity records a dal's latest task activity time.
+func (c *Client) Activity(name string) (map[string]string, error) {
+	return c.postJSON(fmt.Sprintf("/api/activity/%s", name))
+}
+
 // Ps returns running containers.
 func (c *Client) Ps() ([]*Container, error) {
 	resp, err := c.http.Get(c.baseURL + "/api/ps")

--- a/internal/daemon/client_test.go
+++ b/internal/daemon/client_test.go
@@ -61,6 +61,27 @@ func TestClient_Ps(t *testing.T) {
 	}
 }
 
+func TestClient_Activity(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if r.URL.Path != "/api/activity/dev" {
+			t.Errorf("path = %s, want /api/activity/dev", r.URL.Path)
+		}
+		w.Write([]byte(`{"status":"ok","dal":"dev"}`))
+	}))
+	defer srv.Close()
+
+	os.Setenv("DALCENTER_URL", srv.URL)
+	defer os.Unsetenv("DALCENTER_URL")
+
+	c, _ := NewClient()
+	if _, err := c.Activity("dev"); err != nil {
+		t.Fatalf("Activity: %v", err)
+	}
+}
+
 func TestClient_Ps_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(500)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -51,16 +51,18 @@ type Daemon struct {
 
 // Container tracks a running dal Docker container.
 type Container struct {
-	DalName     string `json:"dal_name"`
-	UUID        string `json:"uuid"`
-	Player      string `json:"player"`
-	Role        string `json:"role"`
-	ContainerID string `json:"container_id"`
-	Status      string `json:"status"`    // "running", "stopped"
-	Workspace   string `json:"workspace"` // "shared" or "clone"
-	Skills      int    `json:"skills"`
-	BotToken    string `json:"-"` // Mattermost bot token
-	BotUsername string `json:"-"` // Mattermost bot @username
+	DalName     string    `json:"dal_name"`
+	UUID        string    `json:"uuid"`
+	Player      string    `json:"player"`
+	Role        string    `json:"role"`
+	ContainerID string    `json:"container_id"`
+	Status      string    `json:"status"`    // "running", "stopped"
+	Workspace   string    `json:"workspace"` // "shared" or "clone"
+	Skills      int       `json:"skills"`
+	LastSeenAt  time.Time `json:"last_seen_at,omitempty"`
+	IdleFor     string    `json:"idle_for,omitempty"`
+	BotToken    string    `json:"-"` // Mattermost bot token
+	BotUsername string    `json:"-"` // Mattermost bot @username
 }
 
 // New creates a daemon.
@@ -291,6 +293,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/restart/{name}", d.requireAuth(d.handleRestart))
 	mux.HandleFunc("POST /api/sync", d.requireAuth(d.handleSync))
 	mux.HandleFunc("POST /api/message", d.requireAuth(d.handleMessage))
+	mux.HandleFunc("POST /api/activity/{name}", d.requireAuth(d.handleActivity))
 	mux.HandleFunc("GET /api/agent-config/{name}", d.handleAgentConfig)
 	mux.HandleFunc("POST /api/agent-config/{name}/refresh-token", d.handleAgentTokenRefresh)
 	// Direct task execution (works without Mattermost)
@@ -362,11 +365,41 @@ func (d *Daemon) handlePs(w http.ResponseWriter, r *http.Request) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
+	now := time.Now()
 	containers := make([]*Container, 0, len(d.containers))
 	for _, c := range d.containers {
-		containers = append(containers, c)
+		snapshot := *c
+		if !snapshot.LastSeenAt.IsZero() {
+			snapshot.IdleFor = now.Sub(snapshot.LastSeenAt).Truncate(time.Second).String()
+		}
+		containers = append(containers, &snapshot)
 	}
 	json.NewEncoder(w).Encode(containers)
+}
+
+func (d *Daemon) markActivity(name string, seenAt time.Time) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	c, ok := d.containers[name]
+	if !ok {
+		return false
+	}
+	c.LastSeenAt = seenAt
+	return true
+}
+
+func (d *Daemon) handleActivity(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	seenAt := time.Now().UTC()
+	if !d.markActivity(name, seenAt) {
+		http.Error(w, fmt.Sprintf("dal %q is not awake", name), http.StatusNotFound)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":       "ok",
+		"dal":          name,
+		"last_seen_at": seenAt,
+	})
 }
 
 func (d *Daemon) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -498,6 +531,7 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		Status:      "running",
 		Workspace:   ws,
 		Skills:      len(dal.Skills),
+		LastSeenAt:  time.Now().UTC(),
 		BotToken:    botToken,
 		BotUsername: botUser,
 	}
@@ -660,6 +694,7 @@ func (d *Daemon) runSync() (synced, restarted []string) {
 				ContainerID: newID,
 				Status:      "running",
 				Skills:      len(dal.Skills),
+				LastSeenAt:  time.Now().UTC(),
 				BotToken:    c.BotToken,
 			}
 			d.mu.Unlock()
@@ -1078,6 +1113,7 @@ func (d *Daemon) reconcile() {
 				ContainerID: c.ID,
 				Status:      "running",
 				Skills:      len(dal.Skills),
+				LastSeenAt:  time.Now().UTC(),
 				BotToken:    botToken,
 			}
 			d.mu.Unlock()

--- a/internal/daemon/daemon_handlers_test.go
+++ b/internal/daemon/daemon_handlers_test.go
@@ -6,7 +6,58 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+func TestHandleActivityUpdatesLastSeen(t *testing.T) {
+	before := time.Now().Add(-2 * time.Minute).UTC()
+	d := &Daemon{
+		containers: map[string]*Container{
+			"dev": {DalName: "dev", Status: "running", LastSeenAt: before},
+		},
+	}
+	req := httptest.NewRequest("POST", "/api/activity/dev", nil)
+	req.SetPathValue("name", "dev")
+	w := httptest.NewRecorder()
+
+	d.handleActivity(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !d.containers["dev"].LastSeenAt.After(before) {
+		t.Fatalf("last_seen_at not updated: before=%s after=%s", before, d.containers["dev"].LastSeenAt)
+	}
+}
+
+func TestHandlePs_IncludesIdleMetadata(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"dev": {DalName: "dev", Player: "claude", Role: "member", Status: "running", LastSeenAt: time.Now().Add(-90 * time.Second).UTC()},
+		},
+	}
+	req := httptest.NewRequest("GET", "/api/ps", nil)
+	w := httptest.NewRecorder()
+
+	d.handlePs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var containers []Container
+	if err := json.NewDecoder(w.Body).Decode(&containers); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(containers) != 1 {
+		t.Fatalf("got %d containers, want 1", len(containers))
+	}
+	if containers[0].IdleFor == "" {
+		t.Fatal("idle_for should be present")
+	}
+	if containers[0].LastSeenAt.IsZero() {
+		t.Fatal("last_seen_at should be present")
+	}
+}
 
 func TestHandleLogs_DalNotFound(t *testing.T) {
 	d := &Daemon{


### PR DESCRIPTION
## Summary
- add daemon-side activity tracking so running dals expose  and computed  in 
- record activity from  when a real task or auto-task is handled, instead of using a liveness heartbeat that would hide idle time
- surface the new metadata in  and 

## Testing
- go test ./internal/daemon
- go test ./cmd/dalcli -timeout 45s
