### PR TITLE
feat: show last seen and idle time in dalcli-leader ps

### DIFF
--- a/cmd/dalcli-leader/main.go
+++ b/cmd/dalcli-leader/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/dalsoop/dalcenter/internal/daemon"
 	"github.com/spf13/cobra"
@@ -83,13 +84,21 @@ func psCmd() *cobra.Command {
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tCONTAINER")
+			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tIDLE\tLAST SEEN\tCONTAINER")
 			for _, c := range containers {
 				cid := c.ContainerID
 				if len(cid) > 12 {
 					cid = cid[:12]
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status, cid)
+				idle := c.IdleFor
+				if idle == "" {
+					idle = "-"
+				}
+				lastSeen := "-"
+				if !c.LastSeenAt.IsZero() {
+					lastSeen = c.LastSeenAt.Local().Format("2006-01-02 15:04:05")
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status, idle, lastSeen, cid)
 			}
 			w.Flush()
 			return nil
@@ -118,6 +127,12 @@ func statusCmd() *cobra.Command {
 					fmt.Printf("player:    %s\n", c.Player)
 					fmt.Printf("role:      %s\n", c.Role)
 					fmt.Printf("status:    %s\n", c.Status)
+					if c.IdleFor != "" {
+						fmt.Printf("idle:      %s\n", c.IdleFor)
+					}
+					if !c.LastSeenAt.IsZero() {
+						fmt.Printf("last_seen: %s\n", c.LastSeenAt.Local().Format(time.RFC3339))
+					}
 					fmt.Printf("container: %s\n", c.ContainerID[:12])
 					return nil
 				}


### PR DESCRIPTION
## Summary
- extend  to show  and  columns from the daemon metadata added in #487
- extend  to print the same activity metadata for a single dal

## Testing
- go test ./cmd/dalcli-leader
