### PR TITLE
feat: use UUID task and feedback IDs

### DIFF
--- a/internal/daemon/feedback.go
+++ b/internal/daemon/feedback.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"sync"
 	"time"
@@ -23,17 +22,16 @@ type Feedback struct {
 
 // DalStats holds aggregated success/failure counts for a single dal.
 type DalStats struct {
-	Dal        string  `json:"dal"`
-	Total      int     `json:"total"`
-	Success    int     `json:"success"`
-	Failure    int     `json:"failure"`
+	Dal         string  `json:"dal"`
+	Total       int     `json:"total"`
+	Success     int     `json:"success"`
+	Failure     int     `json:"failure"`
 	SuccessRate float64 `json:"success_rate"` // 0.0 ~ 1.0
 }
 
 type feedbackStore struct {
 	mu       sync.RWMutex
 	items    []Feedback
-	seq      int
 	filePath string
 }
 
@@ -58,13 +56,6 @@ func (s *feedbackStore) load() {
 		return
 	}
 	s.items = items
-	for _, f := range items {
-		var n int
-		fmt.Sscanf(f.ID, "fb-%d", &n)
-		if n > s.seq {
-			s.seq = n
-		}
-	}
 }
 
 func (s *feedbackStore) save() {
@@ -77,8 +68,6 @@ func (s *feedbackStore) save() {
 func (s *feedbackStore) Add(dal, taskID, task, result, errMsg string, gitChanges int, durationMs int64) Feedback {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.seq++
-
 	if len(task) > 500 {
 		task = task[:500]
 	}
@@ -87,7 +76,7 @@ func (s *feedbackStore) Add(dal, taskID, task, result, errMsg string, gitChanges
 	}
 
 	fb := Feedback{
-		ID:         fmt.Sprintf("fb-%04d", s.seq),
+		ID:         newPrefixedUUID("fb"),
 		Dal:        dal,
 		TaskID:     taskID,
 		Task:       task,

--- a/internal/daemon/feedback_test.go
+++ b/internal/daemon/feedback_test.go
@@ -1,0 +1,14 @@
+package daemon
+
+import "testing"
+
+func TestFeedbackStore_AddUsesUUIDStyleID(t *testing.T) {
+	s := newFeedbackStore()
+	fb := s.Add("dev", "task-123", "triage issue", "success", "", 0, 42)
+	if !prefixedUUIDPattern.MatchString(fb.ID) {
+		t.Fatalf("expected feedback UUID-style id, got %s", fb.ID)
+	}
+	if fb.TaskID != "task-123" {
+		t.Fatalf("task id = %q, want task-123", fb.TaskID)
+	}
+}

--- a/internal/daemon/id.go
+++ b/internal/daemon/id.go
@@ -1,0 +1,31 @@
+package daemon
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+var idFallbackSeq uint64
+
+func newPrefixedUUID(prefix string) string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err == nil {
+		b[6] = (b[6] & 0x0f) | 0x40
+		b[8] = (b[8] & 0x3f) | 0x80
+		return prefix + "-" + formatUUID(b[:])
+	}
+	return fmt.Sprintf("%s-%d-%d", prefix, time.Now().UTC().UnixNano(), atomic.AddUint64(&idFallbackSeq, 1))
+}
+
+func formatUUID(raw []byte) string {
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		hex.EncodeToString(raw[0:4]),
+		hex.EncodeToString(raw[4:6]),
+		hex.EncodeToString(raw[6:8]),
+		hex.EncodeToString(raw[8:10]),
+		hex.EncodeToString(raw[10:16]),
+	)
+}

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -47,7 +47,6 @@ type TaskMetadataUpdate struct {
 type taskStore struct {
 	mu    sync.RWMutex
 	tasks map[string]*taskResult
-	seq   int
 }
 
 func newTaskStore() *taskStore {
@@ -57,9 +56,8 @@ func newTaskStore() *taskStore {
 func (s *taskStore) New(dal, task string) *taskResult {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.seq++
 	t := &taskResult{
-		ID:        fmt.Sprintf("task-%04d", s.seq),
+		ID:        newPrefixedUUID("task"),
 		Dal:       dal,
 		Task:      task,
 		Status:    "running",

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -4,15 +4,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"regexp"
 	"strings"
 	"testing"
 )
 
+var prefixedUUIDPattern = regexp.MustCompile(`^(task|fb)-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+
 func TestTaskStore_New(t *testing.T) {
 	s := newTaskStore()
 	tr := s.New("dev", "go test ./...")
-	if tr.ID != "task-0001" {
-		t.Errorf("expected task-0001, got %s", tr.ID)
+	if !prefixedUUIDPattern.MatchString(tr.ID) {
+		t.Fatalf("expected task UUID-style id, got %s", tr.ID)
 	}
 	if tr.Dal != "dev" {
 		t.Errorf("expected dal=dev, got %s", tr.Dal)
@@ -25,6 +28,15 @@ func TestTaskStore_New(t *testing.T) {
 	}
 	if tr.Events[0].Kind != "accepted" {
 		t.Fatalf("expected initial accepted event, got %q", tr.Events[0].Kind)
+	}
+}
+
+func TestTaskStore_NewGeneratesUniqueIDs(t *testing.T) {
+	s := newTaskStore()
+	first := s.New("dev", "task1")
+	second := s.New("dev", "task2")
+	if first.ID == second.ID {
+		t.Fatalf("expected unique task IDs, got %q", first.ID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace sequential task IDs with UUID-based IDs
- replace sequential feedback IDs with UUID-based IDs
- add tests for UUID-style ID format and uniqueness

## Testing
- go test ./internal/daemon

Closes #441