### PR TITLE
fix: check charter.md exists before bind mount (#499)

### DIFF
--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -272,10 +272,22 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr string, dal *
 		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", skillPath, targetPath))
 	}
 
-	// Mount charter.md as the right filename
+	// Mount charter.md as the right filename (e.g. CLAUDE.md, AGENTS.md, GEMINI.md).
+	// The source file MUST exist before docker run; otherwise Docker creates the
+	// mount-point as an empty directory instead of a file (GitHub #499).
 	instrSrc := filepath.Join(dalDir, "charter.md")
 	instrDst := filepath.Join(home, instructionsFileName(dal.Player))
-	args = append(args, "-v", fmt.Sprintf("%s:%s:ro", instrSrc, instrDst))
+	if info, err := os.Stat(instrSrc); err != nil {
+		w := fmt.Sprintf("charter.md not found at %s — skipping instructions mount", instrSrc)
+		log.Printf("WARNING: %s", w)
+		warnings = append(warnings, w)
+	} else if info.IsDir() {
+		w := fmt.Sprintf("charter.md is a directory at %s — skipping instructions mount", instrSrc)
+		log.Printf("WARNING: %s", w)
+		warnings = append(warnings, w)
+	} else {
+		args = append(args, "-v", fmt.Sprintf("%s:%s:ro", instrSrc, instrDst))
+	}
 
 	// Mount decisions.md as shared team memory (read-only — scribe commits changes)
 	decisionsPath := filepath.Join(localdalRoot, "decisions.md")


### PR DESCRIPTION
## Summary
- Fixes #499: `CLAUDE.md` created as empty directory instead of file inside dal containers
- Before adding the bind mount for `charter.md` -> `CLAUDE.md` (or `AGENTS.md`/`GEMINI.md`), verify the source file exists and is a regular file
- If `charter.md` is missing or is a directory, skip the mount and emit a warning instead of letting Docker create an empty directory at the mount point

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/daemon/` passes
- [ ] Manual: `dalcenter wake dev` with valid `charter.md` — verify `CLAUDE.md` is mounted as a file
- [ ] Manual: `dalcenter wake dev` with missing `charter.md` — verify warning is returned and no empty directory is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)