### PR TITLE
fix: init --repo creates .dal/ at correct path

### DIFF
--- a/cmd/dalcenter/cmd_localdal.go
+++ b/cmd/dalcenter/cmd_localdal.go
@@ -73,6 +73,11 @@ func newInitCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			root := localdalRoot()
 			if repoPath != "" {
+				abs, err := filepath.Abs(repoPath)
+				if err != nil {
+					return fmt.Errorf("resolve path: %w", err)
+				}
+				repoPath = abs
 				root = filepath.Join(repoPath, ".dal")
 			}
 			if err := localdal.Init(root); err != nil {


### PR DESCRIPTION
## Summary
- Fix `dalcenter init --repo <path>` creating `.dal/` at CWD instead of inside the specified repo path
- When `--repo` flag is provided, override the default `localdalRoot()` with `filepath.Join(repoPath, ".dal")`
- Matches how `register` and `serve` commands already handle the `--repo` flag correctly

Closes #493

## Test plan
- [ ] Run `dalcenter init --repo /tmp/test-project` and verify `.dal/` is created at `/tmp/test-project/.dal/`
- [ ] Run `dalcenter init` without `--repo` and verify it still uses CWD
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] `go test ./cmd/dalcenter/ ./internal/localdal/` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)