### PR TITLE
fix: localdal 테스트 Init() 자동 프로필 대응

### DIFF
--- a/internal/localdal/localdal_test.go
+++ b/internal/localdal/localdal_test.go
@@ -55,7 +55,8 @@ func TestCreateAndListDal(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
 
-	p, err := CreateDal(root, "dev", "claude")
+	// Init() auto-creates leader + dev + scribe, so use a different name
+	p, err := CreateDal(root, "reviewer", "claude")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,23 +75,23 @@ func TestCreateAndListDal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Init() auto-creates scribe dal, so expect 2 (scribe + dev)
-	if len(dals) != 2 {
-		t.Fatalf("got %d dals, want 2 (scribe + dev)", len(dals))
+	// Init() auto-creates scribe + leader + dev = 3, plus reviewer = 4
+	if len(dals) != 4 {
+		t.Fatalf("got %d dals, want 4 (scribe + leader + dev + reviewer)", len(dals))
 	}
 	names := make(map[string]bool)
 	for _, d := range dals {
 		names[d.Name] = true
 	}
-	if !names["dev"] {
-		t.Fatal("dev dal not found")
+	if !names["reviewer"] {
+		t.Fatal("reviewer dal not found")
 	}
 }
 
 func TestCreateDalDuplicate(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	CreateDal(root, "dev", "claude")
+	// dev is auto-created by Init(), so creating it again should fail
 	if _, err := CreateDal(root, "dev", "claude"); err == nil {
 		t.Fatal("expected error for duplicate")
 	}
@@ -99,13 +100,12 @@ func TestCreateDalDuplicate(t *testing.T) {
 func TestDeleteDal(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	CreateDal(root, "dev", "claude")
 
+	// dev is auto-created by Init()
 	if err := DeleteDal(root, "dev"); err != nil {
 		t.Fatal(err)
 	}
 	dals, _ := ListDals(root)
-	// scribe remains after deleting dev
 	names := make(map[string]bool)
 	for _, d := range dals {
 		names[d.Name] = true
@@ -126,14 +126,15 @@ func TestDeleteDalNotFound(t *testing.T) {
 func TestSkillCreateAddRemoveDelete(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	CreateDal(root, "dev", "claude")
+
+	// Use a fresh dal (not auto-created dev which has default skills)
+	CreateDal(root, "reviewer", "claude")
 
 	// Create skill
 	if err := CreateSkill(root, "code-review"); err != nil {
 		t.Fatal(err)
 	}
 	skills, _ := ListSkills(root)
-	// Init() auto-creates 6 ops skills + we created code-review = 7
 	found := false
 	for _, s := range skills {
 		if s == "code-review" {
@@ -145,24 +146,24 @@ func TestSkillCreateAddRemoveDelete(t *testing.T) {
 	}
 
 	// Add to dal
-	if err := AddSkillToDal(root, "dev", "code-review"); err != nil {
+	if err := AddSkillToDal(root, "reviewer", "code-review"); err != nil {
 		t.Fatal(err)
 	}
-	p, _ := ReadDalCue(filepath.Join(root, "dev", "dal.cue"), "dev")
+	p, _ := ReadDalCue(filepath.Join(root, "reviewer", "dal.cue"), "reviewer")
 	if len(p.Skills) != 1 || p.Skills[0] != "skills/code-review" {
 		t.Fatalf("skills = %v", p.Skills)
 	}
 
 	// Add duplicate
-	if err := AddSkillToDal(root, "dev", "code-review"); err == nil {
+	if err := AddSkillToDal(root, "reviewer", "code-review"); err == nil {
 		t.Fatal("expected error for duplicate skill")
 	}
 
 	// Remove from dal
-	if err := RemoveSkillFromDal(root, "dev", "code-review"); err != nil {
+	if err := RemoveSkillFromDal(root, "reviewer", "code-review"); err != nil {
 		t.Fatal(err)
 	}
-	p, _ = ReadDalCue(filepath.Join(root, "dev", "dal.cue"), "dev")
+	p, _ = ReadDalCue(filepath.Join(root, "reviewer", "dal.cue"), "reviewer")
 	if len(p.Skills) != 0 {
 		t.Fatalf("skills should be empty: %v", p.Skills)
 	}
@@ -182,9 +183,9 @@ func TestSkillCreateAddRemoveDelete(t *testing.T) {
 func TestDeleteSkillInUse(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	CreateDal(root, "dev", "claude")
+	CreateDal(root, "reviewer", "claude")
 	CreateSkill(root, "testing")
-	AddSkillToDal(root, "dev", "testing")
+	AddSkillToDal(root, "reviewer", "testing")
 
 	if err := DeleteSkill(root, "testing"); err == nil {
 		t.Fatal("expected error: skill in use")

--- a/internal/localdal/validate_test.go
+++ b/internal/localdal/validate_test.go
@@ -35,7 +35,9 @@ func TestValidateValid(t *testing.T) {
 func TestValidateNoLeader(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	CreateDal(root, "dev", "claude")
+
+	// Init() auto-creates leader, so remove it to test the validation
+	DeleteDal(root, "leader")
 
 	errors := Validate(root)
 	found := false


### PR DESCRIPTION
## Summary
- Init()이 leader/dev/scribe를 자동 생성하면서 기존 테스트 3개 실패
- 자동 생성되는 dal과 충돌하지 않도록 테스트 수정
- 이 PR이 머지되면 #501, #502, #505의 CI도 통과됨

## Test plan
- [x] `go test ./internal/localdal/...` 통과
- [x] `go test ./...` 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)