### PR TITLE
feat: Dockerfile Node 22 + quorum-audit + CCW

### DIFF
--- a/dockerfiles/claude-go.Dockerfile
+++ b/dockerfiles/claude-go.Dockerfile
@@ -2,7 +2,12 @@ FROM ubuntu:24.04
 
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-      bash git curl ca-certificates nodejs npm gpg wget && \
+      bash git curl ca-certificates gpg wget build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (nodesource)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Go 1.24
@@ -26,7 +31,10 @@ RUN mkdir -p /root/.claude/skills /root/.claude/hooks
 RUN git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
 
 # Quorum — multi-agent consensus & orchestration
-RUN npm install -g quorum
+RUN npm install -g quorum-audit
+
+# CCW — JSON-driven multi-agent workflow orchestration
+RUN npm install -g claude-code-workflow && ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=claude

--- a/dockerfiles/claude-rust.Dockerfile
+++ b/dockerfiles/claude-rust.Dockerfile
@@ -2,8 +2,13 @@ FROM ubuntu:24.04
 
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-      bash git curl ca-certificates nodejs npm gpg wget \
+      bash git curl ca-certificates gpg wget \
       build-essential pkg-config libssl-dev && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (nodesource)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Rust (stable)
@@ -24,7 +29,10 @@ RUN mkdir -p /root/.claude/skills /root/.claude/hooks
 RUN git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
 
 # Quorum — multi-agent consensus & orchestration
-RUN npm install -g quorum
+RUN npm install -g quorum-audit
+
+# CCW — JSON-driven multi-agent workflow orchestration
+RUN npm install -g claude-code-workflow && ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=claude

--- a/dockerfiles/claude.Dockerfile
+++ b/dockerfiles/claude.Dockerfile
@@ -2,7 +2,12 @@ FROM ubuntu:24.04
 
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-      bash git curl ca-certificates nodejs npm gpg && \
+      bash git curl ca-certificates gpg build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (nodesource)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @anthropic-ai/claude-code
@@ -20,7 +25,10 @@ RUN mkdir -p /root/.claude/skills /root/.claude/hooks
 RUN git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
 
 # Quorum — multi-agent consensus & orchestration (plan → implement → review → merge)
-RUN npm install -g quorum
+RUN npm install -g quorum-audit
+
+# CCW — JSON-driven multi-agent workflow orchestration (codex/gemini/claude)
+RUN npm install -g claude-code-workflow && ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=claude

--- a/dockerfiles/codex.Dockerfile
+++ b/dockerfiles/codex.Dockerfile
@@ -2,7 +2,12 @@ FROM ubuntu:24.04
 
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-      bash git curl ca-certificates nodejs npm gpg && \
+      bash git curl ca-certificates gpg build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (nodesource)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN npm install -g @openai/codex
@@ -20,7 +25,10 @@ RUN git config --global credential.helper '!f() { echo username=x-access-token; 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Quorum — multi-agent consensus & orchestration
-RUN npm install -g quorum
+RUN npm install -g quorum-audit
+
+# CCW — JSON-driven multi-agent workflow orchestration
+RUN npm install -g claude-code-workflow && ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=codex

--- a/dockerfiles/gemini.Dockerfile
+++ b/dockerfiles/gemini.Dockerfile
@@ -2,7 +2,12 @@ FROM ubuntu:24.04
 
 RUN apt-get update -qq && \
     apt-get install -y -qq --no-install-recommends \
-      bash git curl ca-certificates python3 python3-pip nodejs npm && \
+      bash git curl ca-certificates python3 python3-pip build-essential && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js 22 (nodesource)
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y -qq nodejs && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --break-system-packages gemini-cli || true
@@ -10,7 +15,10 @@ RUN pip3 install --break-system-packages gemini-cli || true
 RUN mkdir -p /root/.gemini/skills
 
 # Quorum — multi-agent consensus & orchestration
-RUN npm install -g quorum
+RUN npm install -g quorum-audit
+
+# CCW — JSON-driven multi-agent workflow orchestration
+RUN npm install -g claude-code-workflow && ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=gemini


### PR DESCRIPTION
## Summary
- Node.js 18 → 22 (nodesource) 업그레이드
- `build-essential` 추가 (quorum-audit node-gyp 빌드 필요)
- `quorum-audit` 0.4.5 설치 (합의 엔진 — stagnation 감지, 3역할 parliament)
- `claude-code-workflow` 7.2.29 설치 (워크플로우 오케스트레이터 — 27 agent, 60+ skill)
- 5개 Dockerfile 전부 적용

## 이미지 크기
- 기존: 791MB
- 변경: ~1.2GB (+400MB)

## Test plan
- [x] `dalcenter/claude:ccw-test` 이미지 빌드 성공 (LXC 140)
- [x] quorum-audit 0.4.5 설치 확인
- [x] CCW 7.2.29 설치 확인
- [ ] 나머지 이미지 (codex, claude-go, claude-rust, gemini) 빌드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)