### PR TITLE
feat: dalops + dal 역할 단순화 (CCW 기반)

### DIFF
--- a/internal/localdal/init_test.go
+++ b/internal/localdal/init_test.go
@@ -72,7 +72,7 @@ func TestInit_Idempotent(t *testing.T) {
 	}
 }
 
-func TestInit_CreatesScribeDal(t *testing.T) {
+func TestInit_CreatesDalDocManager(t *testing.T) {
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, ".dal")
 	os.MkdirAll(root, 0755)
@@ -82,19 +82,19 @@ func TestInit_CreatesScribeDal(t *testing.T) {
 	}
 
 	tpl := ResolveTemplateRoot(root)
-	cue := filepath.Join(tpl, "scribe", "dal.cue")
+	cue := filepath.Join(tpl, "dal", "dal.cue")
 	if _, err := os.Stat(cue); err != nil {
-		t.Fatal("scribe/dal.cue not created")
+		t.Fatal("dal/dal.cue not created")
 	}
 
-	instr := filepath.Join(tpl, "scribe", "charter.md")
+	instr := filepath.Join(tpl, "dal", "charter.md")
 	if _, err := os.Stat(instr); err != nil {
-		t.Fatal("scribe/charter.md not created")
+		t.Fatal("dal/charter.md not created")
 	}
 
 	data, _ := os.ReadFile(cue)
-	if !strings.Contains(string(data), "scribe") {
-		t.Error("dal.cue should contain scribe")
+	if !strings.Contains(string(data), "dal") {
+		t.Error("dal.cue should contain dal")
 	}
 }
 
@@ -197,12 +197,10 @@ func TestInit_FullStructure(t *testing.T) {
 		"decisions.md",
 		"decisions-archive.md",
 		"wisdom.md",
-		"scribe/dal.cue",
-		"scribe/charter.md",
-		"leader/dal.cue",
-		"leader/charter.md",
-		"dev/dal.cue",
-		"dev/charter.md",
+		"dalops/dal.cue",
+		"dalops/charter.md",
+		"dal/dal.cue",
+		"dal/charter.md",
 		"skills/inbox-protocol/SKILL.md",
 		"skills/history-hygiene/SKILL.md",
 		"skills/escalation/SKILL.md",
@@ -224,7 +222,7 @@ func TestInit_FullStructure(t *testing.T) {
 	}
 }
 
-func TestInit_CreatesLeaderDal(t *testing.T) {
+func TestInit_CreatesDalopsDal(t *testing.T) {
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, ".dal")
 	os.MkdirAll(root, 0755)
@@ -234,78 +232,48 @@ func TestInit_CreatesLeaderDal(t *testing.T) {
 	}
 
 	tpl := ResolveTemplateRoot(root)
-	cueFile := filepath.Join(tpl, "leader", "dal.cue")
+	cueFile := filepath.Join(tpl, "dalops", "dal.cue")
 	data, err := os.ReadFile(cueFile)
 	if err != nil {
-		t.Fatal("leader/dal.cue not created")
+		t.Fatal("dalops/dal.cue not created")
 	}
 	content := string(data)
 
-	checks := []string{"leader", "role:", "\"leader\"", "dal-leader", "GITHUB_TOKEN"}
+	checks := []string{"dalops", "\"ops\"", "dal-ops", "GITHUB_TOKEN"}
 	for _, check := range checks {
 		if !strings.Contains(content, check) {
-			t.Errorf("leader dal.cue missing: %q", check)
+			t.Errorf("dalops dal.cue missing: %q", check)
 		}
 	}
 
-	charter := filepath.Join(tpl, "leader", "charter.md")
+	charter := filepath.Join(tpl, "dalops", "charter.md")
 	if _, err := os.Stat(charter); err != nil {
-		t.Fatal("leader/charter.md not created")
+		t.Fatal("dalops/charter.md not created")
 	}
 }
 
-func TestInit_CreatesDevDal(t *testing.T) {
-	tmp := t.TempDir()
-	root := filepath.Join(tmp, ".dal")
-	os.MkdirAll(root, 0755)
-
-	if err := Init(root); err != nil {
-		t.Fatal(err)
-	}
-
-	tpl := ResolveTemplateRoot(root)
-	cueFile := filepath.Join(tpl, "dev", "dal.cue")
-	data, err := os.ReadFile(cueFile)
-	if err != nil {
-		t.Fatal("dev/dal.cue not created")
-	}
-	content := string(data)
-
-	checks := []string{"dev", "\"member\"", "dal-dev", "GITHUB_TOKEN"}
-	for _, check := range checks {
-		if !strings.Contains(content, check) {
-			t.Errorf("dev dal.cue missing: %q", check)
-		}
-	}
-
-	charter := filepath.Join(tpl, "dev", "charter.md")
-	if _, err := os.Stat(charter); err != nil {
-		t.Fatal("dev/charter.md not created")
-	}
-}
-
-func TestInit_LeaderDevIdempotent(t *testing.T) {
+func TestInit_DalopsDalIdempotent(t *testing.T) {
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, ".dal")
 	os.MkdirAll(root, 0755)
 
 	Init(root)
 
-	// Modify leader charter
+	// Modify dalops charter
 	tpl := ResolveTemplateRoot(root)
-	path := filepath.Join(tpl, "leader", "charter.md")
-	os.WriteFile(path, []byte("custom leader"), 0644)
+	path := filepath.Join(tpl, "dalops", "charter.md")
+	os.WriteFile(path, []byte("custom dalops"), 0644)
 
 	// Re-init should not overwrite
 	Init(root)
 
 	data, _ := os.ReadFile(path)
-	if string(data) != "custom leader" {
-		t.Error("Init() overwrote existing leader/charter.md")
+	if string(data) != "custom dalops" {
+		t.Error("Init() overwrote existing dalops/charter.md")
 	}
 }
 
-func TestInit_LeaderDevHaveUUIDs(t *testing.T) {
+func TestInit_DalopsDalHaveUUIDs(t *testing.T) {
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, ".dal")
 	os.MkdirAll(root, 0755)
@@ -313,33 +281,32 @@ func TestInit_LeaderDevHaveUUIDs(t *testing.T) {
 	Init(root)
 
 	tpl := ResolveTemplateRoot(root)
-	for _, name := range []string{"leader", "dev"} {
+	for _, name := range []string{"dalops", "dal"} {
 		data, _ := os.ReadFile(filepath.Join(tpl, name, "dal.cue"))
 		content := string(data)
 		if !strings.Contains(content, "uuid:") {
 			t.Errorf("%s/dal.cue missing uuid field", name)
 		}
-		// UUID should be non-empty (not just "uuid:")
 		if strings.Contains(content, `uuid:    ""`) {
 			t.Errorf("%s/dal.cue has empty uuid", name)
 		}
 	}
 }
 
-func TestInit_ScribeDalCueContent(t *testing.T) {
+func TestInit_DalDocManagerCueContent(t *testing.T) {
 	tmp := t.TempDir()
 	root := filepath.Join(tmp, ".dal")
 	os.MkdirAll(root, 0755)
 	Init(root)
 
 	tpl := ResolveTemplateRoot(root)
-	data, _ := os.ReadFile(filepath.Join(tpl, "scribe", "dal.cue"))
+	data, _ := os.ReadFile(filepath.Join(tpl, "dal", "dal.cue"))
 	content := string(data)
 
-	checks := []string{"scribe", "haiku", "auto_task", "30m", "dal-scribe", "GITHUB_TOKEN"}
+	checks := []string{"dal", "haiku", "auto_task", "30m", "dal-docs", "GITHUB_TOKEN"}
 	for _, check := range checks {
 		if !strings.Contains(content, check) {
-			t.Errorf("scribe dal.cue missing: %q", check)
+			t.Errorf("dal dal.cue missing: %q", check)
 		}
 	}
 }

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -127,49 +127,35 @@ func Init(root string) error {
 		}
 	}
 
-	// Auto-create scribe dal
-	scribeDir := filepath.Join(root, "scribe")
-	if _, err := os.Stat(scribeDir); err != nil {
-		if err := os.MkdirAll(scribeDir, 0755); err != nil {
-			return fmt.Errorf("create scribe dir: %w", err)
+	// Auto-create dalops (operations — CCW-based orchestration)
+	dalopsDir := filepath.Join(root, "dalops")
+	if _, err := os.Stat(dalopsDir); err != nil {
+		if err := os.MkdirAll(dalopsDir, 0755); err != nil {
+			return fmt.Errorf("create dalops dir: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(scribeDir, "dal.cue"), []byte(defaultScribeCue), 0644); err != nil {
-			return fmt.Errorf("write scribe dal.cue: %w", err)
+		dalopsUUID := generateUUID()
+		dalopsCue := fmt.Sprintf(defaultDalopsCueTemplate, dalopsUUID)
+		if err := os.WriteFile(filepath.Join(dalopsDir, "dal.cue"), []byte(dalopsCue), 0644); err != nil {
+			return fmt.Errorf("write dalops dal.cue: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(scribeDir, "charter.md"), []byte(defaultScribeInstructions), 0644); err != nil {
-			return fmt.Errorf("write scribe charter.md: %w", err)
-		}
-	}
-
-	// Auto-create leader dal
-	leaderDir := filepath.Join(root, "leader")
-	if _, err := os.Stat(leaderDir); err != nil {
-		if err := os.MkdirAll(leaderDir, 0755); err != nil {
-			return fmt.Errorf("create leader dir: %w", err)
-		}
-		leaderUUID := generateUUID()
-		leaderCue := fmt.Sprintf(defaultLeaderCueTemplate, leaderUUID)
-		if err := os.WriteFile(filepath.Join(leaderDir, "dal.cue"), []byte(leaderCue), 0644); err != nil {
-			return fmt.Errorf("write leader dal.cue: %w", err)
-		}
-		if err := os.WriteFile(filepath.Join(leaderDir, "charter.md"), []byte(defaultLeaderCharter), 0644); err != nil {
-			return fmt.Errorf("write leader charter.md: %w", err)
+		if err := os.WriteFile(filepath.Join(dalopsDir, "charter.md"), []byte(defaultDalopsCharter), 0644); err != nil {
+			return fmt.Errorf("write dalops charter.md: %w", err)
 		}
 	}
 
-	// Auto-create dev dal
-	devDir := filepath.Join(root, "dev")
-	if _, err := os.Stat(devDir); err != nil {
-		if err := os.MkdirAll(devDir, 0755); err != nil {
-			return fmt.Errorf("create dev dir: %w", err)
+	// Auto-create dal (document manager)
+	dalDir := filepath.Join(root, "dal")
+	if _, err := os.Stat(dalDir); err != nil {
+		if err := os.MkdirAll(dalDir, 0755); err != nil {
+			return fmt.Errorf("create dal dir: %w", err)
 		}
-		devUUID := generateUUID()
-		devCue := fmt.Sprintf(defaultDevCueTemplate, devUUID)
-		if err := os.WriteFile(filepath.Join(devDir, "dal.cue"), []byte(devCue), 0644); err != nil {
-			return fmt.Errorf("write dev dal.cue: %w", err)
+		dalUUID := generateUUID()
+		dalCue := fmt.Sprintf(defaultDalCueTemplate, dalUUID)
+		if err := os.WriteFile(filepath.Join(dalDir, "dal.cue"), []byte(dalCue), 0644); err != nil {
+			return fmt.Errorf("write dal dal.cue: %w", err)
 		}
-		if err := os.WriteFile(filepath.Join(devDir, "charter.md"), []byte(defaultDevCharter), 0644); err != nil {
-			return fmt.Errorf("write dev charter.md: %w", err)
+		if err := os.WriteFile(filepath.Join(dalDir, "charter.md"), []byte(defaultDalCharter), 0644); err != nil {
+			return fmt.Errorf("write dal charter.md: %w", err)
 		}
 	}
 
@@ -643,10 +629,103 @@ const defaultDevCharter = `# Dev Dal
 - 기존 코드 패턴 준수
 `
 
+// defaultDalopsCueTemplate has one %s placeholder for the UUID.
+const defaultDalopsCueTemplate = `uuid:    %q
+name:    "dalops"
+version: "1.0.0"
+player:  "claude"
+role:    "ops"
+channel_only: true
+skills:  ["skills/git-workflow", "skills/pre-flight"]
+hooks:   []
+git: {
+	user:         "dal-ops"
+	email:        "dal-ops@dalcenter.local"
+	github_token: "env:GITHUB_TOKEN"
+}
+`
+
+const defaultDalopsCharter = `# dalops — 운영자
+
+## Role
+CCW 기반 오케스트레이터. 코드 구현, 리뷰, 테스트를 워크플로우로 실행한다.
+
+## Tools
+- ccw cli --tool codex --mode review — Codex 코드 리뷰
+- ccw cli --tool codex --mode analysis — Codex 분석
+- ccw cli --tool gemini — Gemini 분석
+- quorum verify — 보안/시크릿/의존성 검사
+- dalcli status / ps / report
+
+## Workflows
+- workflow-lite-plan — 단일 모듈 기능 구현
+- workflow-tdd-plan — 테스트 주도 개발
+- workflow-multi-cli-plan — 멀티 CLI 협업 분석/리뷰
+- workflow-test-fix — 테스트 생성 및 수정 루프
+
+## Process
+1. 이슈/작업 수신
+2. CCW 워크플로우 선택 및 실행
+3. codex 리뷰 통과 확인
+4. quorum verify (보안 검사)
+5. 브랜치 → PR 생성
+6. dalcli report로 결과 보고
+
+## Rules
+- main 직접 커밋 금지
+- PR 생성 전 반드시 테스트 통과
+- ccw session으로 작업 컨텍스트 유지
+`
+
+// defaultDalCueTemplate has one %s placeholder for the UUID.
+const defaultDalCueTemplate = `uuid:    %q
+name:    "dal"
+version: "1.0.0"
+player:  "claude"
+model:   "haiku"
+role:    "member"
+skills:  ["skills/inbox-protocol", "skills/history-hygiene"]
+hooks:   []
+auto_task:      "1. /workspace/decisions/inbox/ → decisions.md 병합 (중복 제거 후 삭제). 2. /workspace/history-buffer/ → .dal/{name}/history.md 병합. 3. /workspace/wisdom-inbox/ → wisdom.md 병합. 4. history.md 12KB 초과 시 압축. 5. decisions.md 50KB 초과 시 30일+ 아카이브. 6. README.md, CLAUDE.md 갱신 필요 시 ccw tool update_module_claude로 자동 생성. 7. 변경 시 git add + commit + push."
+auto_interval:  "30m"
+git: {
+	user:         "dal-docs"
+	email:        "dal-docs@dalcenter.local"
+	github_token: "env:GITHUB_TOKEN"
+}
+`
+
+const defaultDalCharter = `# dal — 문서 관리자
+
+## Role
+팀 공유 기억의 유일한 writer + committer. 백그라운드 자동 실행.
+
+## Responsibilities
+1. decisions/inbox/ → decisions.md 병합 (중복 제거: By + What 기준)
+2. wisdom-inbox/ → wisdom.md 병합
+3. history-buffer/{name}.md → .dal/{name}/history.md 병합
+4. history.md 12KB 초과 시 Core Context 압축
+5. decisions.md 50KB 초과 시 30일+ 항목 → decisions-archive.md
+6. README.md / CLAUDE.md 갱신 (ccw tool update_module_claude)
+7. 변경 시 git add + commit + push
+
+## Tools
+- ccw tool update_module_claude — 모듈 문서 자동 생성
+- ccw tool detect_changed_modules — 변경 모듈 탐지
+- ccw memory — 컨텍스트 메모리 관리
+- dalcli status / report
+
+## Rules
+- push 실패 시 재시도만. force push, reset 금지.
+- 병합 후 inbox 파일 삭제.
+- history에는 최종 결과만. 중간 상태 금지.
+- 코드, 리뷰, 테스트 금지 — 문서만 담당.
+`
+
 const defaultSpec = `// dal.spec.cue — localdal schema
 
 #Player: "claude" | "codex" | "gemini"
-#Role:   "leader" | "member"
+#Role:   "leader" | "member" | "ops"
 
 #BranchConfig: {
 	base?: string | *"main"

--- a/internal/localdal/localdal_test.go
+++ b/internal/localdal/localdal_test.go
@@ -78,9 +78,9 @@ func TestCreateAndListDal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Init() auto-creates scribe + leader + dev = 3, plus reviewer = 4
-	if len(dals) != 4 {
-		t.Fatalf("got %d dals, want 4 (scribe + leader + dev + reviewer)", len(dals))
+	// Init() auto-creates dalops + dal = 2, plus reviewer = 3
+	if len(dals) != 3 {
+		t.Fatalf("got %d dals, want 3 (dalops + dal + reviewer)", len(dals))
 	}
 	names := make(map[string]bool)
 	for _, d := range dals {
@@ -94,8 +94,8 @@ func TestCreateAndListDal(t *testing.T) {
 func TestCreateDalDuplicate(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
-	// dev is auto-created by Init(), so creating it again should fail
-	if _, err := CreateDal(root, "dev", "claude"); err == nil {
+	// dalops is auto-created by Init(), so creating it again should fail
+	if _, err := CreateDal(root, "dalops", "claude"); err == nil {
 		t.Fatal("expected error for duplicate")
 	}
 }
@@ -104,8 +104,8 @@ func TestDeleteDal(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
 
-	// dev is auto-created by Init()
-	if err := DeleteDal(root, "dev"); err != nil {
+	// dal is auto-created by Init()
+	if err := DeleteDal(root, "dal"); err != nil {
 		t.Fatal(err)
 	}
 	dals, _ := ListDals(root)
@@ -113,8 +113,8 @@ func TestDeleteDal(t *testing.T) {
 	for _, d := range dals {
 		names[d.Name] = true
 	}
-	if names["dev"] {
-		t.Fatal("dev dal should be deleted")
+	if names["dal"] {
+		t.Fatal("dal should be deleted")
 	}
 }
 

--- a/internal/localdal/validate.go
+++ b/internal/localdal/validate.go
@@ -48,9 +48,9 @@ func Validate(root string) []string {
 			}
 		}
 		switch d.Role {
-		case "leader", "member":
+		case "leader", "member", "ops":
 		default:
-			errors = append(errors, fmt.Sprintf("%s: invalid role %q (must be leader or member)", d.FolderName, d.Role))
+			errors = append(errors, fmt.Sprintf("%s: invalid role %q (must be leader, member, or ops)", d.FolderName, d.Role))
 		}
 		if d.Role == "leader" {
 			leaderCount++
@@ -79,11 +79,9 @@ func Validate(root string) []string {
 		}
 	}
 
-	// Exactly one leader
-	if leaderCount == 0 {
-		errors = append(errors, "no leader dal found (exactly 1 required)")
-	} else if leaderCount > 1 {
-		errors = append(errors, fmt.Sprintf("found %d leaders (exactly 1 required)", leaderCount))
+	// At most one leader (ops-only teams don't require a leader)
+	if leaderCount > 1 {
+		errors = append(errors, fmt.Sprintf("found %d leaders (at most 1 allowed)", leaderCount))
 	}
 
 	return errors

--- a/internal/localdal/validate_test.go
+++ b/internal/localdal/validate_test.go
@@ -34,22 +34,14 @@ func TestValidateValid(t *testing.T) {
 	_ = p
 }
 
-func TestValidateNoLeader(t *testing.T) {
+func TestValidateOpsOnlyTeamValid(t *testing.T) {
 	root := t.TempDir()
 	Init(root)
 
-	// Init() auto-creates leader, so remove it to test the validation
-	DeleteDal(root, "leader")
-
+	// ops-only team (no leader) should be valid
 	errors := Validate(root)
-	found := false
-	for _, e := range errors {
-		if e == "no leader dal found (exactly 1 required)" {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected 'no leader' error, got: %v", errors)
+	if len(errors) != 0 {
+		t.Fatalf("expected 0 errors for ops-only team, got: %v", errors)
 	}
 }
 


### PR DESCRIPTION
## Summary
- leader/dev/scribe 3개 역할 → **dalops** + **dal** 2개로 단순화
- dalops: CCW 워크플로우 기반 오케스트레이터 (구현/리뷰/테스트)
- dal: 문서 관리자 (decisions/wisdom/history + ccw tool로 문서 자동 생성)
- role에 `"ops"` 추가, "exactly 1 leader" 제약 → "at most 1 leader"로 완화
- 전체 9 패키지 테스트 통과

## 변경된 파일
- `internal/localdal/localdal.go` — Init() dalops+dal 생성, 새 템플릿 상수
- `internal/localdal/validate.go` — ops role 허용, leader 제약 완화
- `internal/localdal/*_test.go` — 새 구조에 맞게 테스트 업데이트

## 배경
- 기존 leader/reviewer/member/scribe 역할 오케스트레이션이 복잡하고 안정적이지 않음
- CCW(Claude Code Workflow)가 codex/gemini를 직접 호출해서 리뷰/분석을 처리
- 컨테이너 수: 레포당 8개 → 2개로 축소 가능

## Test plan
- [x] `go test ./...` 전체 9 패키지 PASS
- [ ] `dalcenter init --repo` 로 새 .dal/ 구조 생성 확인
- [ ] dalops 컨테이너에서 CCW 워크플로우 실행 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)