### PR TITLE
feat: dalroot callback notification on task completion

### DIFF
--- a/cmd/dalcenter/cmd_pipeline.go
+++ b/cmd/dalcenter/cmd_pipeline.go
@@ -50,6 +50,7 @@ func newTaskCmd() *cobra.Command {
 	var async bool
 	var poll bool
 	var reason string
+	var callbackPane string
 	cmd := &cobra.Command{
 		Use:   "task <dal> <prompt>",
 		Short: "Execute a task directly in a dal container",
@@ -68,7 +69,7 @@ func newTaskCmd() *cobra.Command {
 			dal := args[0]
 			task := strings.Join(args[1:], " ")
 
-			result, err := client.Task(dal, task, async)
+			result, err := client.Task(dal, task, async, callbackPane)
 			if err != nil {
 				return err
 			}
@@ -103,6 +104,7 @@ func newTaskCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&async, "async", false, "Run task asynchronously")
 	cmd.Flags().BoolVar(&poll, "poll", false, "Wait for async task to complete (implies --async)")
 	cmd.Flags().StringVar(&reason, "reason", "", "사유 (audit trail)")
+	cmd.Flags().StringVar(&callbackPane, "callback-pane", "", "dalroot pane ID for completion notification")
 	return cmd
 }
 

--- a/internal/daemon/client.go
+++ b/internal/daemon/client.go
@@ -328,8 +328,12 @@ type TaskEvent struct {
 }
 
 // Task submits a direct task to a dal container. If async=true, returns immediately with a task ID.
-func (c *Client) Task(dal, task string, async bool) (*TaskResult, error) {
-	body := fmt.Sprintf(`{"dal":%q,"task":%q,"async":%t}`, dal, task, async)
+func (c *Client) Task(dal, task string, async bool, callbackPane ...string) (*TaskResult, error) {
+	pane := ""
+	if len(callbackPane) > 0 {
+		pane = callbackPane[0]
+	}
+	body := fmt.Sprintf(`{"dal":%q,"task":%q,"async":%t,"callback_pane":%q}`, dal, task, async, pane)
 	req, err := http.NewRequest(http.MethodPost, c.baseURL+"/api/task", strings.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -27,7 +27,8 @@ type taskResult struct {
 	GitChanges int    `json:"git_changes,omitempty"` // number of files changed
 	Verified   string `json:"verified,omitempty"`    // "yes", "no_changes", "skipped"
 	// Post-task build/test verification
-	Completion *CompletionResult `json:"completion,omitempty"`
+	Completion    *CompletionResult `json:"completion,omitempty"`
+	CallbackPane  string            `json:"callback_pane,omitempty"`
 }
 
 type taskEvent struct {
@@ -306,7 +307,8 @@ func (d *Daemon) handleTask(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Dal   string `json:"dal"`
 		Task  string `json:"task"`
-		Async bool   `json:"async"`
+		Async        bool   `json:"async"`
+		CallbackPane string `json:"callback_pane,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -331,6 +333,7 @@ func (d *Daemon) handleTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tr := d.tasks.New(req.Dal, req.Task)
+	tr.CallbackPane = req.CallbackPane
 
 	if req.Async {
 		// Run in background, return task ID for polling
@@ -445,6 +448,11 @@ func (d *Daemon) execTaskInContainer(c *Container, tr *taskResult) {
 			Error:     tr.Error,
 			Timestamp: now.Format(time.RFC3339),
 		})
+
+		// Notify dalroot if callback pane was specified
+		if tr.CallbackPane != "" {
+			notifyDalroot(c.DalName, tr, d.serviceRepo)
+		}
 	} else {
 		tr.Status = "done"
 		tr.Output = stdout.String()
@@ -475,6 +483,11 @@ func (d *Daemon) execTaskInContainer(c *Container, tr *taskResult) {
 			OutputSize: len(tr.Output),
 			Timestamp:  now.Format(time.RFC3339),
 		})
+
+		// Notify dalroot if callback pane was specified
+		if tr.CallbackPane != "" {
+			notifyDalroot(c.DalName, tr, d.serviceRepo)
+		}
 	}
 }
 
@@ -503,6 +516,15 @@ func verifyTaskChanges(containerID string, tr *taskResult) {
 				tr.GitChanges++
 			}
 		}
+	}
+}
+
+// notifyDalroot calls notify-dalroot to send a notification to the requesting pane.
+func notifyDalroot(dalName string, tr *taskResult, repo string) {
+	msg := fmt.Sprintf("[%s] task %s: %s", dalName, tr.Status, truncateStr(tr.Task, 80))
+	cmd := exec.Command("notify-dalroot", repo, msg, tr.CallbackPane)
+	if err := cmd.Run(); err != nil {
+		log.Printf("[notify] dalroot notification failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- dalcenter task 완료 시 dalroot에 자동 알림 전송
- `--callback-pane` 플래그로 알림을 받을 tmux pane 지정

## Changes

- `cmd_pipeline.go`: `--callback-pane` CLI 플래그 추가
- `client.go`: `Task()` 메서드에 callbackPane 파라미터 추가
- `task.go`: `notifyDalroot()` 함수 추가, task 성공/실패 시 자동 호출

## How it works

```bash
dalcenter task leader "분석해줘" --callback-pane 6 --async --poll
# task 완료 시 daemon이 자동으로:
# notify-dalroot <repo> "[leader] task done: 분석해줘" "6"
# -> /mnt/host-notifications/dalroot/pane-6/*.json
# -> Claude Code hook이 해당 pane에서 알림 수신
```

## Test plan

- [ ] `--callback-pane` 없으면 기존 동작 유지 (하위 호환)
- [ ] `--callback-pane 6`으로 task 전송 시 완료 후 알림 파일 생성 확인
- [ ] 실패 시에도 알림 전송 확인

Closes #521 (partial - callback notification part)