### PR TITLE
feat: member dal은 항상 clone mode로 강제

### DIFF
--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -274,7 +274,7 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr, bridgeURL st
 	})
 
 	// Mount service repo as workspace (shared mode) or leave empty for clone mode
-	isCloneMode := dal.Workspace == "clone"
+	isCloneMode := dal.Workspace == "clone" || dal.Role == "member"
 	if serviceRepo != "" && !isCloneMode {
 		bindMounts = append(bindMounts, mount.Mount{
 			Type:   mount.TypeBind,


### PR DESCRIPTION
## Summary

member role의 dal은 workspace 설정과 무관하게 항상 clone mode(독립 git clone)로 실행되도록 강제.

## Change

```go
// before
isCloneMode := dal.Workspace == "clone"

// after
isCloneMode := dal.Workspace == "clone" || dal.Role == "member"
```

## Why

- member dal들이 같은 bind mount를 공유하면 동시 작업 시 파일 충돌 발생
- 각 member가 독립된 workspace를 가져야 안전하게 병렬 작업 가능
- leader는 shared를 유지 (routing/관리 역할이라 코드 수정 안 함)

## Test plan

- [ ] member wake 시 bind mount 대신 git clone 확인
- [ ] leader wake 시 기존 shared mode 유지 확인
- [ ] `--issue` 플래그와 조합 시 독립 브랜치 생성 확인