### PR TITLE
fix: dalcenter tell이 호스트에서 DALCENTER_HOST_IP 사용

### DIFF
--- a/cmd/dalcenter/cmd_tell.go
+++ b/cmd/dalcenter/cmd_tell.go
@@ -93,7 +93,11 @@ func resolveRepoURL(repo string) (string, error) {
 			}
 		}
 		if port != "" {
-			return "http://localhost:" + port, nil
+			host := "localhost"
+			if h := readEnvVar(paths.ConfigDir(), "common.env", "DALCENTER_HOST_IP"); h != "" {
+				host = h
+			}
+			return "http://" + host + ":" + port, nil
 		}
 	}
 
@@ -104,4 +108,19 @@ func resolveRepoURL(repo string) (string, error) {
 func currentRepoName() string {
 	wd, _ := os.Getwd()
 	return filepath.Base(wd)
+}
+
+// readEnvVar reads a specific variable from an env file.
+func readEnvVar(dir, file, key string) string {
+	data, err := os.ReadFile(filepath.Join(dir, file))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, key+"=") {
+			return strings.TrimPrefix(line, key+"=")
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Summary

dalcenter tell이 호스트에서 실행될 때 localhost 대신 DALCENTER_HOST_IP (common.env)를 사용하도록 수정.

## Change

`resolveRepoURL`에서 포트 resolve 시 `common.env`의 `DALCENTER_HOST_IP`를 읽어서 사용.

## Test plan

- [ ] 호스트에서 `dalcenter tell dalcenter "테스트"` → LXC IP로 전달
- [ ] LXC 내부에서 `dalcenter tell dalcenter "테스트"` → localhost로 전달 (HOST_IP 없으면 fallback)

Closes #527 (partial)