### PR TITLE
feat: extend dalcenter tell with --issue and --direct bridge mode

### DIFF
--- a/cmd/dalcenter/cmd_tell.go
+++ b/cmd/dalcenter/cmd_tell.go
@@ -15,55 +15,168 @@ import (
 )
 
 func newTellCmd() *cobra.Command {
-	return &cobra.Command{
-		Use:   "tell <repo> <message>",
-		Short: "Send a message to another dalcenter instance",
-		Args:  cobra.MinimumNArgs(2),
+	var issueNum int
+	var direct bool
+
+	cmd := &cobra.Command{
+		Use:   "tell <team> <message>",
+		Short: "Send a message to a team's dalcenter or matterbridge",
+		Long: `Send a message to another dalcenter instance or directly to its matterbridge.
+
+By default, messages are routed through the target dalcenter's /api/message endpoint.
+Use --direct to send directly to the team's matterbridge API (bypassing dalcenter).
+Use --issue to include a GitHub issue reference in the message.`,
+		Args: cobra.MinimumNArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			repo := args[0]
+			team := args[0]
 			message := strings.Join(args[1:], " ")
 
-			targetURL, err := resolveRepoURL(repo)
-			if err != nil {
-				return fmt.Errorf("resolve repo URL: %w", err)
+			if issueNum > 0 {
+				message = fmt.Sprintf("[issue #%d] %s", issueNum, message)
 			}
 
-			from := currentRepoName()
-
-			body := fmt.Sprintf(`{"from":%q,"message":%q}`, from, message)
-			req, err := http.NewRequest(http.MethodPost, targetURL+"/api/message", strings.NewReader(body))
-			if err != nil {
-				return fmt.Errorf("create request: %w", err)
+			if direct {
+				return sendViaBridge(team, message)
 			}
-			req.Header.Set("Content-Type", "application/json")
-
-			if token := os.Getenv("DALCENTER_TOKEN"); token != "" {
-				req.Header.Set("Authorization", "Bearer "+token)
-			}
-
-			client := &http.Client{Timeout: 30 * time.Second}
-			resp, err := client.Do(req)
-			if err != nil {
-				return fmt.Errorf("send message: %w", err)
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode >= 400 {
-				b, _ := io.ReadAll(resp.Body)
-				return fmt.Errorf("message failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(b)))
-			}
-
-			var result struct {
-				PostID string `json:"post_id"`
-			}
-			if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-				return fmt.Errorf("decode response: %w", err)
-			}
-
-			fmt.Printf("[tell] message sent to %s (post_id=%s)\n", repo, result.PostID)
-			return nil
+			return sendViaDalcenter(team, message)
 		},
 	}
+
+	cmd.Flags().IntVar(&issueNum, "issue", 0, "Attach GitHub issue number to the message")
+	cmd.Flags().BoolVar(&direct, "direct", false, "Send directly to matterbridge (bypass dalcenter)")
+
+	return cmd
+}
+
+// sendViaDalcenter sends a message through the target dalcenter's /api/message endpoint.
+func sendViaDalcenter(team, message string) error {
+	targetURL, err := resolveRepoURL(team)
+	if err != nil {
+		return fmt.Errorf("resolve repo URL: %w", err)
+	}
+
+	from := currentRepoName()
+
+	body := fmt.Sprintf(`{"from":%q,"message":%q}`, from, message)
+	req, err := http.NewRequest(http.MethodPost, targetURL+"/api/message", strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if token := os.Getenv("DALCENTER_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send message: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("message failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	var result struct {
+		PostID string `json:"post_id"`
+		Status string `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+
+	if result.PostID != "" {
+		fmt.Printf("[tell] message sent to %s (post_id=%s)\n", team, result.PostID)
+	} else {
+		fmt.Printf("[tell] message sent to %s (status=%s)\n", team, result.Status)
+	}
+	return nil
+}
+
+// sendViaBridge sends a message directly to a team's matterbridge API.
+func sendViaBridge(team, message string) error {
+	bridgeURL, err := resolveBridgeURL(team)
+	if err != nil {
+		return fmt.Errorf("resolve bridge URL: %w", err)
+	}
+
+	gateway := resolveBridgeGateway(team)
+	from := currentRepoName()
+
+	payload := struct {
+		Text     string `json:"text"`
+		Username string `json:"username"`
+		Gateway  string `json:"gateway"`
+	}{
+		Text:     message,
+		Username: from,
+		Gateway:  gateway,
+	}
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequest(http.MethodPost, bridgeURL+"/api/message", strings.NewReader(string(body)))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	if token := os.Getenv("MATTERBRIDGE_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send to bridge: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("bridge send failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(b)))
+	}
+
+	fmt.Printf("[tell] message sent to %s via bridge (gateway=%s)\n", team, gateway)
+	return nil
+}
+
+// resolveBridgeURL looks up the matterbridge URL for a team.
+// Priority: 1) DALCENTER_BRIDGE_URLS env  2) <team>.env DALCENTER_BRIDGE_URL  3) default port
+func resolveBridgeURL(team string) (string, error) {
+	// 1. Explicit env var: DALCENTER_BRIDGE_URLS=team1=http://host:4242,team2=http://host:4243
+	if urls := os.Getenv("DALCENTER_BRIDGE_URLS"); urls != "" {
+		for _, entry := range strings.Split(urls, ",") {
+			entry = strings.TrimSpace(entry)
+			parts := strings.SplitN(entry, "=", 2)
+			if len(parts) == 2 && parts[0] == team {
+				return strings.TrimRight(parts[1], "/"), nil
+			}
+		}
+	}
+
+	// 2. Team env file: DALCENTER_BRIDGE_URL in /etc/dalcenter/<team>.env
+	if url := readEnvVar(paths.ConfigDir(), team+".env", "DALCENTER_BRIDGE_URL"); url != "" {
+		return strings.TrimRight(url, "/"), nil
+	}
+
+	// 3. Default: use DALCENTER_HOST_IP (or localhost) with default bridge port
+	host := "localhost"
+	if h := readEnvVar(paths.ConfigDir(), "common.env", "DALCENTER_HOST_IP"); h != "" {
+		host = h
+	}
+	return "http://" + host + ":4242", nil
+}
+
+// resolveBridgeGateway returns the matterbridge gateway name for a team.
+// Reads from <team>.env DALCENTER_BRIDGE_GATEWAY, defaults to "dal-team".
+func resolveBridgeGateway(team string) string {
+	if gw := readEnvVar(paths.ConfigDir(), team+".env", "DALCENTER_BRIDGE_GATEWAY"); gw != "" {
+		return gw
+	}
+	return "dal-team"
 }
 
 // resolveRepoURL looks up the dalcenter URL for a given repo name.

--- a/cmd/dalcenter/cmd_tell_test.go
+++ b/cmd/dalcenter/cmd_tell_test.go
@@ -1,0 +1,218 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSendViaDalcenter(t *testing.T) {
+	var received struct {
+		From    string `json:"from"`
+		Message string `json:"message"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/message" {
+			t.Errorf("path = %s, want /api/message", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		json.NewDecoder(r.Body).Decode(&received)
+		json.NewEncoder(w).Encode(map[string]string{"status": "sent"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_URLS", "myteam="+srv.URL)
+
+	err := sendViaDalcenter("myteam", "hello leader")
+	if err != nil {
+		t.Fatalf("sendViaDalcenter: %v", err)
+	}
+	if received.Message != "hello leader" {
+		t.Errorf("message = %q, want %q", received.Message, "hello leader")
+	}
+}
+
+func TestSendViaDalcenterWithAuth(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		json.NewEncoder(w).Encode(map[string]string{"status": "sent"})
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_URLS", "team1="+srv.URL)
+	t.Setenv("DALCENTER_TOKEN", "secret123")
+
+	err := sendViaDalcenter("team1", "msg")
+	if err != nil {
+		t.Fatalf("sendViaDalcenter: %v", err)
+	}
+	if gotAuth != "Bearer secret123" {
+		t.Errorf("auth = %q, want %q", gotAuth, "Bearer secret123")
+	}
+}
+
+func TestSendViaBridge(t *testing.T) {
+	var received struct {
+		Text     string `json:"text"`
+		Username string `json:"username"`
+		Gateway  string `json:"gateway"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/message" {
+			t.Errorf("path = %s, want /api/message", r.URL.Path)
+		}
+		json.NewDecoder(r.Body).Decode(&received)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_BRIDGE_URLS", "teamA="+srv.URL)
+
+	err := sendViaBridge("teamA", "direct message")
+	if err != nil {
+		t.Fatalf("sendViaBridge: %v", err)
+	}
+	if received.Text != "direct message" {
+		t.Errorf("text = %q, want %q", received.Text, "direct message")
+	}
+	if received.Gateway != "dal-team" {
+		t.Errorf("gateway = %q, want %q", received.Gateway, "dal-team")
+	}
+}
+
+func TestSendViaBridgeWithToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_BRIDGE_URLS", "teamB="+srv.URL)
+	t.Setenv("MATTERBRIDGE_TOKEN", "bridge-secret")
+
+	err := sendViaBridge("teamB", "msg")
+	if err != nil {
+		t.Fatalf("sendViaBridge: %v", err)
+	}
+	if gotAuth != "Bearer bridge-secret" {
+		t.Errorf("auth = %q, want %q", gotAuth, "Bearer bridge-secret")
+	}
+}
+
+func TestResolveBridgeURL_FromEnvVar(t *testing.T) {
+	t.Setenv("DALCENTER_BRIDGE_URLS", "team1=http://10.0.0.1:4242,team2=http://10.0.0.1:4243")
+
+	url, err := resolveBridgeURL("team2")
+	if err != nil {
+		t.Fatalf("resolveBridgeURL: %v", err)
+	}
+	if url != "http://10.0.0.1:4243" {
+		t.Errorf("url = %q, want %q", url, "http://10.0.0.1:4243")
+	}
+}
+
+func TestResolveBridgeURL_FromEnvFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", tmpDir)
+	t.Setenv("DALCENTER_BRIDGE_URLS", "") // ensure env var is empty
+
+	envContent := "DALCENTER_BRIDGE_URL=http://192.168.1.10:4243\n"
+	os.WriteFile(filepath.Join(tmpDir, "teamX.env"), []byte(envContent), 0644)
+
+	url, err := resolveBridgeURL("teamX")
+	if err != nil {
+		t.Fatalf("resolveBridgeURL: %v", err)
+	}
+	if url != "http://192.168.1.10:4243" {
+		t.Errorf("url = %q, want %q", url, "http://192.168.1.10:4243")
+	}
+}
+
+func TestResolveBridgeURL_DefaultFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", tmpDir)
+	t.Setenv("DALCENTER_BRIDGE_URLS", "")
+
+	// Write common.env with host IP
+	os.WriteFile(filepath.Join(tmpDir, "common.env"), []byte("DALCENTER_HOST_IP=10.0.0.5\n"), 0644)
+
+	url, err := resolveBridgeURL("unknown-team")
+	if err != nil {
+		t.Fatalf("resolveBridgeURL: %v", err)
+	}
+	if url != "http://10.0.0.5:4242" {
+		t.Errorf("url = %q, want %q", url, "http://10.0.0.5:4242")
+	}
+}
+
+func TestResolveBridgeGateway_Default(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", tmpDir)
+
+	gw := resolveBridgeGateway("anyteam")
+	if gw != "dal-team" {
+		t.Errorf("gateway = %q, want %q", gw, "dal-team")
+	}
+}
+
+func TestResolveBridgeGateway_FromEnvFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", tmpDir)
+
+	envContent := "DALCENTER_BRIDGE_GATEWAY=custom-gateway\n"
+	os.WriteFile(filepath.Join(tmpDir, "team1.env"), []byte(envContent), 0644)
+
+	gw := resolveBridgeGateway("team1")
+	if gw != "custom-gateway" {
+		t.Errorf("gateway = %q, want %q", gw, "custom-gateway")
+	}
+}
+
+func TestSendViaDalcenter_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", 500)
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_URLS", "errteam="+srv.URL)
+
+	err := sendViaDalcenter("errteam", "msg")
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestSendViaBridge_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", 401)
+	}))
+	defer srv.Close()
+
+	t.Setenv("DALCENTER_BRIDGE_URLS", "errteam="+srv.URL)
+
+	err := sendViaBridge("errteam", "msg")
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+}
+
+func TestNewTellCmd_IssueFlag(t *testing.T) {
+	cmd := newTellCmd()
+
+	// Verify flags exist
+	f := cmd.Flags().Lookup("issue")
+	if f == nil {
+		t.Fatal("--issue flag not found")
+	}
+	f = cmd.Flags().Lookup("direct")
+	if f == nil {
+		t.Fatal("--direct flag not found")
+	}
+}


### PR DESCRIPTION
## Summary
- `--issue <num>` 플래그 추가: 메시지에 `[issue #N]` 접두사 자동 포함
- `--direct` 플래그 추가: dalcenter를 거치지 않고 팀의 matterbridge API로 직접 전송
- 팀별 bridge URL/gateway 자동 해석 (DALCENTER_BRIDGE_URLS env → team.env → common.env fallback)

## Usage
```bash
# 기존 방식 (dalcenter API 경유)
dalcenter tell myteam "메시지"

# 이슈 참조 포함
dalcenter tell myteam --issue 524 "이슈 확인 바람"

# 직접 matterbridge 전송
dalcenter tell myteam --direct "긴급 메시지"
```

## Bridge URL Resolution (--direct)
1. `DALCENTER_BRIDGE_URLS` env: `team1=http://host:4242,team2=http://host:4243`
2. `/etc/dalcenter/<team>.env` → `DALCENTER_BRIDGE_URL`
3. Fallback: `DALCENTER_HOST_IP:4242`

## Test plan
- [ ] `TestSendViaDalcenter` — dalcenter API 경유 메시지 전송
- [ ] `TestSendViaBridge` — matterbridge 직접 전송
- [ ] `TestResolveBridgeURL_*` — env var, env file, fallback 해석
- [ ] `TestResolveBridgeGateway_*` — gateway 해석
- [ ] `TestSendVia*_ServerError` — 에러 핸들링

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)