### PR TITLE
fix: entrypoint에서 dalcli run 재시도 (bridge race condition)

### DIFF
--- a/dockerfiles/entrypoint.sh
+++ b/dockerfiles/entrypoint.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 # Dal container entrypoint.
-# 1. Wait for dalcli to be injected (dalcenter copies it after container start)
-# 2. Try to start agent loop (dalcli run)
-# 3. If agent loop fails or exits, fall back to sleep infinity
+# 1. Wait for dalcli to be injected
+# 2. Start agent loop with retry
+# 3. Fall back to sleep infinity after max retries
 
 set -e
 
-# Wait for dalcli binary (injected by dalcenter after docker run)
 MAX_WAIT=30
 for i in $(seq 1 $MAX_WAIT); do
     if [ -x /usr/local/bin/dalcli ]; then
@@ -15,17 +14,25 @@ for i in $(seq 1 $MAX_WAIT); do
     sleep 1
 done
 
-# Give dalcenter daemon time to register this container
 sleep 3
 
-# Try agent loop, fall back to sleep
-if [ -x /usr/local/bin/dalcli ]; then
-    echo "[entrypoint] starting dalcli run..."
-    dalcli run 2>&1 || {
-        echo "[entrypoint] dalcli run exited ($?), falling back to sleep"
-        exec sleep infinity
-    }
-else
+if [ ! -x /usr/local/bin/dalcli ]; then
     echo "[entrypoint] dalcli not found after ${MAX_WAIT}s, sleeping"
     exec sleep infinity
 fi
+
+# Retry dalcli run up to 5 times with backoff
+MAX_RETRY=5
+for attempt in $(seq 1 $MAX_RETRY); do
+    echo "[entrypoint] starting dalcli run (attempt ${attempt}/${MAX_RETRY})..."
+    dalcli run 2>&1 && exit 0
+    EXIT_CODE=$?
+    if [ $attempt -lt $MAX_RETRY ]; then
+        WAIT=$((attempt * 5))
+        echo "[entrypoint] dalcli run exited (${EXIT_CODE}), retrying in ${WAIT}s..."
+        sleep $WAIT
+    fi
+done
+
+echo "[entrypoint] dalcli run failed after ${MAX_RETRY} attempts, sleeping"
+exec sleep infinity


### PR DESCRIPTION
## Problem

컨테이너 시작 시 matterbridge가 아직 준비되지 않으면 bridge_url이 비어서 dalcli run이 즉시 실패 → sleep infinity로 빠짐. leader가 MM 메시지를 수신하지 못하는 원인.

## Fix

entrypoint에서 dalcli run 실패 시 최대 5회 재시도 (5s 간격 backoff). matterbridge 시작 대기 시간을 확보.

## Related

- #532 중복 wake 버그 (entrypoint 실패로 인한 재wake 시도)

## Test plan

- [ ] daemon + matterbridge 시작 후 컨테이너 wake → dalcli run 성공
- [ ] matterbridge 지연 시 재시도로 복구 확인