### PR TITLE
feat: leader lifecycle management — health check, auto-recovery, member limits

### DIFF
--- a/cmd/dalcenter/cmd_localdal.go
+++ b/cmd/dalcenter/cmd_localdal.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"syscall"
 	"text/tabwriter"
 
@@ -260,6 +261,16 @@ func newPsCmd() *cobra.Command {
 				fmt.Println("no awake dals")
 				return nil
 			}
+			// Sort: leader first, then by name
+			sort.Slice(containers, func(i, j int) bool {
+				if containers[i].Role == "leader" && containers[j].Role != "leader" {
+					return true
+				}
+				if containers[i].Role != "leader" && containers[j].Role == "leader" {
+					return false
+				}
+				return containers[i].DalName < containers[j].DalName
+			})
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tCONTAINER")
 			for _, c := range containers {

--- a/cmd/dalcli-leader/main.go
+++ b/cmd/dalcli-leader/main.go
@@ -28,16 +28,18 @@ func main() {
 }
 
 func wakeCmd() *cobra.Command {
-	return &cobra.Command{
+	var issueID string
+	cmd := &cobra.Command{
 		Use:   "wake <dal>",
 		Short: "Wake a team member",
+		Long:  "Wake a team member. Use --issue to create an issue branch.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := daemon.NewClient()
 			if err != nil {
 				return err
 			}
-			result, err := client.Wake(args[0])
+			result, err := client.WakeWithIssue(args[0], issueID)
 			if err != nil {
 				return err
 			}
@@ -46,9 +48,14 @@ func wakeCmd() *cobra.Command {
 				return fmt.Errorf("unexpected response: missing container_id")
 			}
 			fmt.Printf("wake: %s → %s\n", args[0], cid)
+			if issueID != "" {
+				fmt.Printf("issue: %s\n", issueID)
+			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&issueID, "issue", "", "Issue ID for branch creation (e.g. 489)")
+	return cmd
 }
 
 func sleepCmd() *cobra.Command {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -164,6 +164,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start peer health watcher (dalcenter HA)
 	go d.startPeerWatcher(ctx)
 
+	// Start leader health watcher (auto-recovery)
+	go d.startLeaderWatcher(ctx)
+
 	if d.bridgeURL != "" {
 		log.Printf("[daemon] matterbridge URL: %s", d.bridgeURL)
 	}
@@ -243,15 +246,35 @@ func (d *Daemon) Run(ctx context.Context) error {
 func (d *Daemon) handleHealth(w http.ResponseWriter, r *http.Request) {
 	d.mu.RLock()
 	dalsRunning := len(d.containers)
+	// Find leader status
+	leaderStatus := "not_configured"
+	for _, c := range d.containers {
+		if c.Role == "leader" {
+			leaderStatus = c.Status
+			break
+		}
+	}
 	d.mu.RUnlock()
+
+	// If no leader is running but one is defined, mark as sleeping
+	if leaderStatus == "not_configured" {
+		dals, _ := localdal.ListDals(d.localdalRoot)
+		for _, dal := range dals {
+			if dal.Role == "leader" {
+				leaderStatus = "sleeping"
+				break
+			}
+		}
+	}
 
 	dals, _ := localdal.ListDals(d.localdalRoot)
 
 	respondJSON(w, http.StatusOK, map[string]any{
-		"status":       "ok",
-		"uptime":       time.Since(d.startTime).Truncate(time.Second).String(),
-		"dals_running": dalsRunning,
-		"repo_count":   len(dals),
+		"status":        "ok",
+		"uptime":        time.Since(d.startTime).Truncate(time.Second).String(),
+		"dals_running":  dalsRunning,
+		"repo_count":    len(dals),
+		"leader_status": leaderStatus,
 	})
 }
 
@@ -360,6 +383,14 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, fmt.Sprintf("dal %q not found: %v", name, err), 404)
 		return
+	}
+
+	// Validate member count limit: find the leader's max_members setting
+	if dal.Role == "member" || dal.Role == "ops" {
+		if err := d.validateMemberLimit(name); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
 	}
 
 	// Prepare issue workspace if --issue is provided
@@ -1091,4 +1122,43 @@ func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]strin
 func (d *Daemon) dalCuePath(name string) string {
 	tplRoot := localdal.ResolveTemplateRoot(d.localdalRoot)
 	return fmt.Sprintf("%s/%s/dal.cue", tplRoot, name)
+}
+
+// validateMemberLimit checks the leader's max_members setting and rejects
+// wake requests that would exceed the limit.
+func (d *Daemon) validateMemberLimit(name string) error {
+	// Find leader profile to read max_members
+	dals, err := localdal.ListDals(d.localdalRoot)
+	if err != nil {
+		return nil // cannot validate, allow
+	}
+
+	var maxMembers int
+	for _, dal := range dals {
+		if dal.Role == "leader" && dal.MaxMembers > 0 {
+			maxMembers = dal.MaxMembers
+			break
+		}
+	}
+	if maxMembers == 0 {
+		return nil // no limit configured
+	}
+
+	// Count currently running member containers (excluding the one being waked if it's a re-wake)
+	d.mu.RLock()
+	var memberCount int
+	for n, c := range d.containers {
+		if c.Role == "member" || c.Role == "ops" {
+			if n != name { // don't count self if re-waking
+				memberCount++
+			}
+		}
+	}
+	d.mu.RUnlock()
+
+	if memberCount >= maxMembers {
+		return fmt.Errorf("member limit reached: %d/%d members running (max_members=%d in leader config)",
+			memberCount, maxMembers, maxMembers)
+	}
+	return nil
 }

--- a/internal/daemon/leader_watcher.go
+++ b/internal/daemon/leader_watcher.go
@@ -1,0 +1,237 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	sdkcontainer "github.com/docker/go-sdk/container"
+
+	"github.com/dalsoop/dalcenter/internal/localdal"
+)
+
+const (
+	leaderCheckInterval   = 30 * time.Second
+	leaderCheckTimeout    = 10 * time.Second
+	leaderFailThreshold   = 3
+	leaderMaxRestartRetry = 3
+)
+
+// leaderHealth tracks the health state of the leader container.
+type leaderHealth struct {
+	Status           string    `json:"status"`    // "healthy", "unhealthy", "recovering", "dead"
+	ConsecutiveFails int       `json:"consecutive_fails"`
+	LastCheckAt      time.Time `json:"last_check_at,omitempty"`
+	RestartCount     int       `json:"restart_count"`
+}
+
+// startLeaderWatcher periodically checks the leader container health.
+// If the leader is unresponsive, it attempts auto-recovery.
+// On recovery failure, it escalates to dalroot via the escalation system.
+func (d *Daemon) startLeaderWatcher(ctx context.Context) {
+	log.Printf("[leader-watcher] started (interval=%s, threshold=%d)", leaderCheckInterval, leaderFailThreshold)
+
+	ticker := time.NewTicker(leaderCheckInterval)
+	defer ticker.Stop()
+
+	health := &leaderHealth{Status: "healthy"}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[leader-watcher] stopped")
+			return
+		case <-ticker.C:
+			d.checkLeaderHealth(ctx, health)
+		}
+	}
+}
+
+// checkLeaderHealth inspects the leader container and triggers recovery if needed.
+func (d *Daemon) checkLeaderHealth(ctx context.Context, health *leaderHealth) {
+	health.LastCheckAt = time.Now()
+
+	leaderName, containerID := d.findLeader()
+	if leaderName == "" {
+		// No leader registered — nothing to watch
+		health.Status = "healthy"
+		health.ConsecutiveFails = 0
+		return
+	}
+
+	running, err := isContainerRunning(ctx, containerID)
+	if err != nil {
+		log.Printf("[leader-watcher] inspect error for %s: %v", leaderName, err)
+		health.ConsecutiveFails++
+	} else if !running {
+		health.ConsecutiveFails++
+		log.Printf("[leader-watcher] leader %s not running (%d/%d)",
+			leaderName, health.ConsecutiveFails, leaderFailThreshold)
+	} else {
+		// Leader is healthy
+		if health.Status != "healthy" {
+			log.Printf("[leader-watcher] leader %s recovered", leaderName)
+		}
+		health.Status = "healthy"
+		health.ConsecutiveFails = 0
+		health.RestartCount = 0
+		return
+	}
+
+	if health.ConsecutiveFails < leaderFailThreshold {
+		health.Status = "unhealthy"
+		return
+	}
+
+	// Threshold reached — attempt recovery
+	health.Status = "recovering"
+	log.Printf("[leader-watcher] leader %s failed %d checks — attempting restart",
+		leaderName, health.ConsecutiveFails)
+
+	if health.RestartCount >= leaderMaxRestartRetry {
+		health.Status = "dead"
+		log.Printf("[leader-watcher] leader %s restart retries exhausted — escalating to dalroot", leaderName)
+		d.escalateLeaderFailure(leaderName)
+		// Reset to allow future retry cycles
+		health.RestartCount = 0
+		health.ConsecutiveFails = 0
+		return
+	}
+
+	if err := d.restartLeader(leaderName); err != nil {
+		health.RestartCount++
+		log.Printf("[leader-watcher] leader restart failed (%d/%d): %v",
+			health.RestartCount, leaderMaxRestartRetry, err)
+	} else {
+		health.Status = "healthy"
+		health.ConsecutiveFails = 0
+		health.RestartCount++
+		d.notifyLeaderRestarted(leaderName)
+		log.Printf("[leader-watcher] leader %s restarted successfully", leaderName)
+	}
+}
+
+// findLeader returns the name and container ID of the leader dal, if any.
+func (d *Daemon) findLeader() (name, containerID string) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	for n, c := range d.containers {
+		if c.Role == "leader" {
+			return n, c.ContainerID
+		}
+	}
+	return "", ""
+}
+
+// isContainerRunning checks if a Docker container is in running state.
+func isContainerRunning(ctx context.Context, containerID string) (bool, error) {
+	cli, err := getDockerClient()
+	if err != nil {
+		return false, fmt.Errorf("docker client: %w", err)
+	}
+
+	ctr, err := sdkcontainer.FromID(ctx, cli, containerID)
+	if err != nil {
+		return false, fmt.Errorf("container from ID: %w", err)
+	}
+
+	info, err := ctr.Inspect(ctx)
+	if err != nil {
+		return false, fmt.Errorf("inspect: %w", err)
+	}
+
+	return info.Container.State.Running, nil
+}
+
+// restartLeader performs a clean restart of the leader container.
+func (d *Daemon) restartLeader(name string) error {
+	d.mu.RLock()
+	c, ok := d.containers[name]
+	d.mu.RUnlock()
+	if !ok {
+		return fmt.Errorf("leader %q not in containers map", name)
+	}
+
+	// Stop existing container
+	if err := dockerStop(c.ContainerID); err != nil {
+		log.Printf("[leader-watcher] stop failed for %s: %v (continuing with fresh wake)", name, err)
+	}
+
+	d.mu.Lock()
+	delete(d.containers, name)
+	d.mu.Unlock()
+
+	// Fresh wake
+	dal, err := d.readDalProfile(name)
+	if err != nil {
+		return fmt.Errorf("read dal.cue for %s: %w", name, err)
+	}
+
+	containerID, _, err := dockerRun(d.localdalRoot, d.serviceRepo, name, d.addr, d.bridgeURL, dal)
+	if err != nil {
+		return fmt.Errorf("wake %s: %w", name, err)
+	}
+
+	ws := dal.Workspace
+	if ws == "" {
+		ws = "shared"
+	}
+	d.mu.Lock()
+	d.containers[name] = &Container{
+		DalName:     name,
+		UUID:        dal.UUID,
+		Player:      dal.Player,
+		Role:        dal.Role,
+		ContainerID: containerID,
+		Status:      "running",
+		Workspace:   ws,
+		Skills:      len(dal.Skills),
+		LastSeenAt:  time.Now().UTC(),
+	}
+	d.mu.Unlock()
+
+	d.registry.Set(dal.UUID, RegistryEntry{
+		Name:        name,
+		Repo:        d.serviceRepo,
+		ContainerID: containerID,
+		Status:      "running",
+	})
+
+	return nil
+}
+
+// readDalProfile reads the dal.cue for a given dal name.
+func (d *Daemon) readDalProfile(name string) (*localdal.DalProfile, error) {
+	return localdal.ReadDalCue(d.dalCuePath(name), name)
+}
+
+// notifyLeaderRestarted posts a recovery notice to the team channel.
+func (d *Daemon) notifyLeaderRestarted(name string) {
+	msg := fmt.Sprintf(":arrows_counterclockwise: **leader 재시작됨** — `%s` 자동 복구 완료", name)
+	d.postAlert(msg)
+
+	dispatchWebhook(WebhookEvent{
+		Event:     "leader_restarted",
+		Dal:       name,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// escalateLeaderFailure sends an escalation when leader recovery fails.
+func (d *Daemon) escalateLeaderFailure(name string) {
+	msg := fmt.Sprintf(":rotating_light: **leader 복구 실패** — `%s` %d회 재시작 시도 후 실패. dalroot 확인 필요.",
+		name, leaderMaxRestartRetry)
+	d.postAlert(msg)
+
+	d.escalations.Add(name, "leader-health-check", "leader_unrecoverable",
+		fmt.Sprintf("leader %s failed health checks and %d restart attempts", name, leaderMaxRestartRetry))
+
+	dispatchWebhook(WebhookEvent{
+		Event:     "escalation",
+		Dal:       name,
+		Task:      "leader-health-check",
+		Error:     "leader unrecoverable after restart retries",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+}

--- a/internal/daemon/leader_watcher_test.go
+++ b/internal/daemon/leader_watcher_test.go
@@ -1,0 +1,82 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestFindLeader(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"leader": {DalName: "leader", Role: "leader", ContainerID: "abc123", Status: "running"},
+			"dev":    {DalName: "dev", Role: "member", ContainerID: "def456", Status: "running"},
+		},
+	}
+
+	name, cid := d.findLeader()
+	if name != "leader" {
+		t.Fatalf("findLeader name = %q, want 'leader'", name)
+	}
+	if cid != "abc123" {
+		t.Fatalf("findLeader containerID = %q, want 'abc123'", cid)
+	}
+}
+
+func TestFindLeader_NoLeader(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{
+			"dev": {DalName: "dev", Role: "member", ContainerID: "def456", Status: "running"},
+		},
+	}
+
+	name, cid := d.findLeader()
+	if name != "" {
+		t.Fatalf("findLeader name = %q, want empty", name)
+	}
+	if cid != "" {
+		t.Fatalf("findLeader containerID = %q, want empty", cid)
+	}
+}
+
+func TestValidateMemberLimit_NoLeader(t *testing.T) {
+	// No localdalRoot configured, so ListDals will fail → allow
+	d := &Daemon{
+		localdalRoot: "/nonexistent",
+		containers:   map[string]*Container{},
+	}
+
+	err := d.validateMemberLimit("dev")
+	if err != nil {
+		t.Fatalf("expected nil error when no leader config, got: %v", err)
+	}
+}
+
+func TestValidateMemberLimit_UnderLimit(t *testing.T) {
+	// validateMemberLimit reads ListDals to find the leader's max_members.
+	// Without a real dal.cue, ListDals returns empty → no limit → allow.
+	d := &Daemon{
+		localdalRoot: "/nonexistent",
+		containers: map[string]*Container{
+			"dev": {DalName: "dev", Role: "member", Status: "running"},
+		},
+	}
+
+	err := d.validateMemberLimit("dev-2")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+}
+
+func TestCheckLeaderHealth_NoLeaderRegistered(t *testing.T) {
+	d := &Daemon{
+		containers: map[string]*Container{},
+	}
+	health := &leaderHealth{Status: "healthy"}
+	d.checkLeaderHealth(nil, health)
+
+	if health.Status != "healthy" {
+		t.Fatalf("status = %q, want 'healthy' when no leader registered", health.Status)
+	}
+	if health.ConsecutiveFails != 0 {
+		t.Fatalf("consecutiveFails = %d, want 0", health.ConsecutiveFails)
+	}
+}

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -71,6 +71,8 @@ type DalProfile struct {
 	Branch BranchConfig
 	// Setup config (ready-to-code environment)
 	Setup SetupConfig
+	// Team management (leader only)
+	MaxMembers int // max concurrent member containers (0 = unlimited)
 }
 
 // Init initializes a localdal repository at the given path.
@@ -523,6 +525,11 @@ func ReadDalCue(path, folderName string) (*DalProfile, error) {
 	if p.Setup.Timeout == "" {
 		p.Setup.Timeout = "5m"
 	}
+	// Team management
+	if v := val.LookupPath(cue.ParsePath("max_members")); v.Exists() {
+		n, _ := v.Int64()
+		p.MaxMembers = int(n)
+	}
 	return p, nil
 }
 
@@ -752,6 +759,7 @@ const defaultSpec = `// dal.spec.cue — localdal schema
 	workspace?:      string
 	branch?:         #BranchConfig
 	setup?:          #SetupConfig
+	max_members?:    int & >=0
 	git?: {
 		user?:         string
 		email?:        string


### PR DESCRIPTION
## Summary
- Leader 컨테이너 상태 감시 (30초 주기, 3회 실패 임계값) 및 자동 복구
- 복구 실패 시 dalroot 에스컬레이션 + MM 채널 알림
- `dalcli-leader wake --issue <N>` 지원 (이슈 브랜치 생성)
- `max_members` 설정으로 동시 member 수 제한
- `/api/health`에 `leader_status` 필드 추가
- `dalcenter ps` 출력에서 leader 우선 표시

## Changes
- **`internal/daemon/leader_watcher.go`** — leader health check watcher (30s interval, auto-restart, escalation)
- **`internal/daemon/leader_watcher_test.go`** — unit tests for findLeader, validateMemberLimit, checkLeaderHealth
- **`internal/daemon/daemon.go`** — wire leader watcher, add validateMemberLimit, enhance handleHealth
- **`internal/localdal/localdal.go`** — add MaxMembers field + CUE schema
- **`cmd/dalcli-leader/main.go`** — add --issue flag to wake command
- **`cmd/dalcenter/cmd_localdal.go`** — sort ps output (leader first)

## Test plan
- [ ] `go test ./internal/daemon/...` passes
- [ ] `go build ./...` succeeds
- [ ] `dalcli-leader wake dev --issue 489` creates container with issue branch
- [ ] Leader container killed → auto-restart within 90s + MM alert
- [ ] 3x restart failure → dalroot escalation notice
- [ ] `max_members: 2` in leader dal.cue → 3rd wake returns 403

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)