### PR TITLE
fix: matterbridge 포트를 toml에서 읽도록 수정

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -146,9 +146,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 				mb.Process.Kill()
 				mb.Wait()
 			}()
-			// Auto-set bridgeURL if not explicitly provided
+			// Auto-set bridgeURL from config or default
 			if d.bridgeURL == "" {
-				d.bridgeURL = DefaultBridgeURL
+				if port := parseBridgePort(d.bridgeConf); port != "" {
+					d.bridgeURL = "http://localhost:" + port
+				} else {
+					d.bridgeURL = DefaultBridgeURL
+				}
 			}
 		}
 	}

--- a/internal/daemon/matterbridge.go
+++ b/internal/daemon/matterbridge.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -52,4 +53,23 @@ func matterbridgeAlreadyRunning() bool {
 	}
 	_ = conn.Close()
 	return true
+}
+
+// parseBridgePort reads the API BindAddress port from a matterbridge TOML config.
+func parseBridgePort(confPath string) string {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "BindAddress") {
+			parts := strings.Split(line, ":")
+			if len(parts) >= 2 {
+				port := strings.Trim(parts[len(parts)-1], "\" ")
+				return port
+			}
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
## Bug

각 팀마다 matterbridge 포트가 다른데 (4242~4246), daemon이 항상 기본값 4242를 사용. 결과: 컨테이너가 잘못된 bridge에 연결 → MM 메시지 수신 불가.

## Fix

`parseBridgePort()`로 toml에서 실제 BindAddress 포트를 읽어서 사용.

## Test plan

- [ ] veilkey-selfhosted (port 4243) leader가 MM 메시지 수신 확인
- [ ] dalcenter (port 4242) 기존 동작 유지