### PR TITLE
feat: dalcenter GitHub issue polling and auto-dispatch to leader

### DIFF
--- a/cmd/dalcenter/cmd_localdal.go
+++ b/cmd/dalcenter/cmd_localdal.go
@@ -27,7 +27,7 @@ func localdalRoot() string {
 // --- serve ---
 
 func newServeCmd() *cobra.Command {
-	var addr, serviceRepo, bridgeURL, bridgeConf string
+	var addr, serviceRepo, bridgeURL, bridgeConf, githubRepo string
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run dalcenter daemon (HTTP API + Docker management)",
@@ -39,7 +39,7 @@ func newServeCmd() *cobra.Command {
 					root = repoRoot
 				}
 			}
-			d := daemon.New(addr, root, serviceRepo, bridgeURL, bridgeConf)
+			d := daemon.New(addr, root, serviceRepo, bridgeURL, bridgeConf, githubRepo)
 
 			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 			defer cancel()
@@ -51,6 +51,7 @@ func newServeCmd() *cobra.Command {
 	cmd.Flags().StringVar(&serviceRepo, "repo", os.Getenv("DALCENTER_REPO"), "Service repository path")
 	cmd.Flags().StringVar(&bridgeURL, "bridge-url", os.Getenv("DALCENTER_BRIDGE_URL"), "Matterbridge API URL (auto-set if --bridge-conf provided)")
 	cmd.Flags().StringVar(&bridgeConf, "bridge-conf", os.Getenv("DALCENTER_BRIDGE_CONF"), "Matterbridge config path (starts as child process)")
+	cmd.Flags().StringVar(&githubRepo, "github-repo", os.Getenv("DALCENTER_GITHUB_REPO"), "GitHub repo for issue polling (e.g., owner/repo)")
 	return cmd
 }
 

--- a/internal/daemon/claim_test.go
+++ b/internal/daemon/claim_test.go
@@ -77,7 +77,7 @@ func TestClaimStore_FilterByStatus(t *testing.T) {
 }
 
 func TestHandleClaim_Post(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	body := `{"dal":"dev","type":"bug","title":"cargo missing","detail":"command not found"}`
 	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -93,7 +93,7 @@ func TestHandleClaim_Post(t *testing.T) {
 }
 
 func TestHandleClaims_Empty(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	req := httptest.NewRequest("GET", "/api/claims", nil)
 	w := httptest.NewRecorder()
 	d.handleClaims(w, req)
@@ -103,7 +103,7 @@ func TestHandleClaims_Empty(t *testing.T) {
 }
 
 func TestHandleClaim_MissingFields(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	body := `{"dal":"","title":""}`
 	req := httptest.NewRequest("POST", "/api/claim", strings.NewReader(body))
 	w := httptest.NewRecorder()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -33,6 +33,7 @@ type Daemon struct {
 	serviceRepo  string // service repo path to mount as /workspace
 	bridgeURL    string // matterbridge API URL
 	bridgeConf   string // matterbridge config path (child process)
+	githubRepo   string // GitHub repo for issue polling (e.g., "owner/repo")
 	apiToken     string                // Bearer token for write endpoints (empty = no auth)
 	containers   map[string]*Container // dal name -> container
 	mu           sync.RWMutex
@@ -44,6 +45,7 @@ type Daemon struct {
 	tasks        *taskStore
 	feedback     *feedbackStore
 	costs        *costStore
+	issues       *issueStore
 	registry     *Registry
 	startTime    time.Time
 }
@@ -63,7 +65,7 @@ type Container struct {
 }
 
 // New creates a daemon.
-func New(addr, localdalRoot, serviceRepo, bridgeURL, bridgeConf string) *Daemon {
+func New(addr, localdalRoot, serviceRepo, bridgeURL, bridgeConf, githubRepo string) *Daemon {
 	token := os.Getenv("DALCENTER_TOKEN")
 	if token != "" {
 		log.Println("[daemon] API token auth enabled for write endpoints")
@@ -77,6 +79,7 @@ func New(addr, localdalRoot, serviceRepo, bridgeURL, bridgeConf string) *Daemon 
 		serviceRepo:  serviceRepo,
 		bridgeURL:    strings.TrimRight(bridgeURL, "/"),
 		bridgeConf:   bridgeConf,
+		githubRepo:   githubRepo,
 		apiToken:     token,
 		containers:   make(map[string]*Container),
 		escalations:  newEscalationStoreWithFile(filepath.Join(dataDir(serviceRepo), "escalations.json")),
@@ -84,6 +87,7 @@ func New(addr, localdalRoot, serviceRepo, bridgeURL, bridgeConf string) *Daemon 
 		tasks:        newTaskStoreWithFile(filepath.Join(dataDir(serviceRepo), "tasks.json")),
 		feedback:     newFeedbackStoreWithFile(filepath.Join(dataDir(serviceRepo), "feedback.json")),
 		costs:        newCostStoreWithFile(filepath.Join(dataDir(serviceRepo), "costs.json"), orchestrationLogDir(serviceRepo)),
+		issues:       newIssueStore(filepath.Join(dataDir(serviceRepo), "issues_seen.json")),
 		registry:     newRegistry(serviceRepo),
 		credSyncLast: newCredentialSyncMap(),
 		startTime:    time.Now(),
@@ -168,6 +172,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start peer health watcher (dalcenter HA)
 	go d.startPeerWatcher(ctx)
 
+	// Start GitHub issue watcher
+	go d.startIssueWatcher(ctx, d.githubRepo, defaultIssuePollInterval)
+
 	// Start leader health watcher (auto-recovery)
 	go d.startLeaderWatcher(ctx)
 
@@ -222,6 +229,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/escalate", d.requireAuth(d.handleEscalate))
 	mux.HandleFunc("GET /api/escalations", d.handleEscalations)
 	mux.HandleFunc("POST /api/escalations/{id}/resolve", d.requireAuth(d.handleResolveEscalation))
+	// GitHub issue tracking
+	mux.HandleFunc("GET /api/issues", d.handleIssues)
 	// A2A protocol endpoints
 	mux.HandleFunc("GET /api/provider-status", d.handleProviderStatus)
 	mux.HandleFunc("POST /api/provider-trip", d.handleProviderTrip)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -43,7 +43,7 @@ hooks:   []
 `), 0644)
 	os.WriteFile(filepath.Join(devDir, "charter.md"), []byte("# Dev\n"), 0644)
 
-	d := New(":0", root, "", "", "")
+	d := New(":0", root, "", "", "", "")
 	return d, root
 }
 

--- a/internal/daemon/issue_watcher.go
+++ b/internal/daemon/issue_watcher.go
@@ -1,0 +1,316 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultIssuePollInterval = 5 * time.Minute
+	maxTrackedIssues         = 200
+)
+
+// ghIssue represents a GitHub issue from `gh issue list --json`.
+type ghIssue struct {
+	Number    int       `json:"number"`
+	Title     string    `json:"title"`
+	Body      string    `json:"body"`
+	State     string    `json:"state"`
+	Labels    []ghLabel `json:"labels"`
+	CreatedAt time.Time `json:"createdAt"`
+	Author    ghAuthor  `json:"author"`
+	URL       string    `json:"url"`
+}
+
+type ghLabel struct {
+	Name string `json:"name"`
+}
+
+type ghAuthor struct {
+	Login string `json:"login"`
+}
+
+// trackedIssue records a dispatched issue and its processing state.
+type trackedIssue struct {
+	Number     int       `json:"number"`
+	Title      string    `json:"title"`
+	URL        string    `json:"url"`
+	Author     string    `json:"author"`
+	Labels     []string  `json:"labels,omitempty"`
+	DetectedAt time.Time `json:"detected_at"`
+	TaskID     string    `json:"task_id,omitempty"` // task ID dispatched to leader
+	Status     string    `json:"status"`            // "dispatched", "skipped", "error"
+	Error      string    `json:"error,omitempty"`
+}
+
+// issueStore tracks which issues have been seen and dispatched.
+type issueStore struct {
+	mu       sync.RWMutex
+	issues   map[int]*trackedIssue // issue number -> tracked issue
+	filePath string
+}
+
+func newIssueStore(path string) *issueStore {
+	s := &issueStore{issues: make(map[int]*trackedIssue), filePath: path}
+	var items []*trackedIssue
+	if err := loadJSON(path, &items); err == nil {
+		for _, issue := range items {
+			s.issues[issue.Number] = issue
+		}
+	}
+	return s
+}
+
+func (s *issueStore) Seen(number int) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.issues[number]
+	return ok
+}
+
+func (s *issueStore) Track(issue *trackedIssue) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.issues[issue.Number] = issue
+	s.save()
+}
+
+func (s *issueStore) List() []*trackedIssue {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]*trackedIssue, 0, len(s.issues))
+	for _, issue := range s.issues {
+		result = append(result, issue)
+	}
+	return result
+}
+
+func (s *issueStore) save() {
+	if s.filePath == "" {
+		return
+	}
+	items := make([]*trackedIssue, 0, len(s.issues))
+	for _, issue := range s.issues {
+		items = append(items, issue)
+	}
+	// Evict oldest if over limit
+	if len(items) > maxTrackedIssues {
+		oldest := items[0]
+		for _, item := range items[1:] {
+			if item.DetectedAt.Before(oldest.DetectedAt) {
+				oldest = item
+			}
+		}
+		delete(s.issues, oldest.Number)
+		items = make([]*trackedIssue, 0, len(s.issues))
+		for _, issue := range s.issues {
+			items = append(items, issue)
+		}
+	}
+	persistJSON(s.filePath, items, nil)
+}
+
+// startIssueWatcher periodically polls GitHub issues and dispatches new ones to the leader.
+func (d *Daemon) startIssueWatcher(ctx context.Context, repo string, interval time.Duration) {
+	if repo == "" {
+		log.Printf("[issue-watcher] DALCENTER_GITHUB_REPO not set, skipping")
+		return
+	}
+
+	// Verify gh CLI is available
+	if _, err := exec.LookPath("gh"); err != nil {
+		log.Printf("[issue-watcher] gh CLI not found, skipping: %v", err)
+		return
+	}
+
+	if interval <= 0 {
+		interval = defaultIssuePollInterval
+	}
+
+	log.Printf("[issue-watcher] started (interval=%s, repo=%s)", interval, repo)
+
+	// Initial poll after short delay to let daemon finish startup
+	initialDelay := 30 * time.Second
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(initialDelay):
+	}
+
+	d.pollGitHubIssues(repo)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[issue-watcher] stopped")
+			return
+		case <-ticker.C:
+			d.pollGitHubIssues(repo)
+		}
+	}
+}
+
+// pollGitHubIssues fetches open issues and dispatches new ones to the leader.
+func (d *Daemon) pollGitHubIssues(repo string) {
+	issues, err := fetchGitHubIssues(repo)
+	if err != nil {
+		log.Printf("[issue-watcher] fetch failed: %v", err)
+		return
+	}
+
+	var newCount int
+	for _, issue := range issues {
+		if d.issues.Seen(issue.Number) {
+			continue
+		}
+
+		// Skip pull requests (gh issue list may include them)
+		if isPullRequest(issue) {
+			continue
+		}
+
+		newCount++
+		tracked := &trackedIssue{
+			Number:     issue.Number,
+			Title:      issue.Title,
+			URL:        issue.URL,
+			Author:     issue.Author.Login,
+			DetectedAt: time.Now().UTC(),
+		}
+		for _, l := range issue.Labels {
+			tracked.Labels = append(tracked.Labels, l.Name)
+		}
+
+		// Dispatch to leader
+		taskID, err := d.dispatchIssueToLeader(issue)
+		if err != nil {
+			log.Printf("[issue-watcher] dispatch #%d failed: %v", issue.Number, err)
+			tracked.Status = "error"
+			tracked.Error = err.Error()
+		} else {
+			tracked.Status = "dispatched"
+			tracked.TaskID = taskID
+			log.Printf("[issue-watcher] dispatched #%d → leader (task=%s)", issue.Number, taskID)
+		}
+
+		d.issues.Track(tracked)
+	}
+
+	if newCount > 0 {
+		log.Printf("[issue-watcher] poll: %d new issues dispatched", newCount)
+	}
+}
+
+// fetchGitHubIssues calls `gh issue list` to get open issues.
+func fetchGitHubIssues(repo string) ([]ghIssue, error) {
+	cmd := exec.Command("gh", "issue", "list",
+		"--repo", repo,
+		"--state", "open",
+		"--limit", "30",
+		"--json", "number,title,body,state,labels,createdAt,author,url",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue list: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("gh issue list: %w", err)
+	}
+
+	var issues []ghIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse issues: %w", err)
+	}
+	return issues, nil
+}
+
+// isPullRequest checks if a gh issue is actually a PR (gh may include PRs).
+func isPullRequest(issue ghIssue) bool {
+	return strings.Contains(issue.URL, "/pull/")
+}
+
+// dispatchIssueToLeader sends a task to the running leader container.
+func (d *Daemon) dispatchIssueToLeader(issue ghIssue) (string, error) {
+	// Find leader container
+	d.mu.RLock()
+	var leader *Container
+	for _, c := range d.containers {
+		if c.Role == "leader" && c.Status == "running" {
+			leader = c
+			break
+		}
+	}
+	d.mu.RUnlock()
+
+	if leader == nil {
+		return "", fmt.Errorf("no running leader container")
+	}
+
+	// Build task prompt for leader
+	labels := make([]string, 0, len(issue.Labels))
+	for _, l := range issue.Labels {
+		labels = append(labels, l.Name)
+	}
+
+	body := issue.Body
+	if len(body) > 2000 {
+		body = body[:2000] + "\n...(truncated)"
+	}
+
+	prompt := fmt.Sprintf(`새 GitHub 이슈가 등록되었습니다. 분석하고 적절한 member에게 작업을 할당하세요.
+
+## Issue #%d: %s
+- Author: %s
+- Labels: %s
+- URL: %s
+
+### Body
+%s
+
+## 지시사항
+1. 이슈를 분석하여 작업 범위를 파악하세요
+2. 적절한 member dal에게 assign하세요 (dalcli wake <member> --issue %d)
+3. member가 깨어나면 dalcli assign <member> "이슈 #%d 작업 지시 내용"으로 작업을 전달하세요
+4. 작업 완료 후 PR이 올라오면 dalroot에게 알려주세요`,
+		issue.Number, issue.Title,
+		issue.Author.Login,
+		strings.Join(labels, ", "),
+		issue.URL,
+		body,
+		issue.Number, issue.Number,
+	)
+
+	// Dispatch as async task to leader
+	tr := d.tasks.New(leader.DalName, prompt)
+	go d.execTaskInContainer(leader, tr)
+
+	// Dispatch webhook notification
+	dispatchWebhook(WebhookEvent{
+		Event:     "issue_detected",
+		Dal:       leader.DalName,
+		Task:      fmt.Sprintf("Issue #%d: %s", issue.Number, issue.Title),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+
+	return tr.ID, nil
+}
+
+// handleIssues returns tracked GitHub issues.
+// GET /api/issues
+func (d *Daemon) handleIssues(w http.ResponseWriter, r *http.Request) {
+	issues := d.issues.List()
+	respondJSON(w, http.StatusOK, map[string]any{
+		"issues": issues,
+		"total":  len(issues),
+	})
+}

--- a/internal/daemon/issue_watcher_test.go
+++ b/internal/daemon/issue_watcher_test.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIssueStoreSeen(t *testing.T) {
+	s := &issueStore{issues: make(map[int]*trackedIssue)}
+
+	if s.Seen(1) {
+		t.Error("expected issue 1 not seen")
+	}
+
+	s.Track(&trackedIssue{Number: 1, Title: "test", Status: "dispatched", DetectedAt: time.Now()})
+
+	if !s.Seen(1) {
+		t.Error("expected issue 1 seen after Track")
+	}
+	if s.Seen(2) {
+		t.Error("expected issue 2 not seen")
+	}
+}
+
+func TestIssueStoreList(t *testing.T) {
+	s := &issueStore{issues: make(map[int]*trackedIssue)}
+	s.Track(&trackedIssue{Number: 1, Title: "first", Status: "dispatched", DetectedAt: time.Now()})
+	s.Track(&trackedIssue{Number: 2, Title: "second", Status: "error", DetectedAt: time.Now()})
+
+	list := s.List()
+	if len(list) != 2 {
+		t.Fatalf("expected 2 issues, got %d", len(list))
+	}
+}
+
+func TestIssueStorePersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "issues_seen.json")
+
+	// Create store and add issues
+	s := newIssueStore(path)
+	s.Track(&trackedIssue{Number: 10, Title: "persisted", Status: "dispatched", DetectedAt: time.Now()})
+
+	// Verify file was written
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file to exist: %v", err)
+	}
+
+	// Load from file
+	s2 := newIssueStore(path)
+	if !s2.Seen(10) {
+		t.Error("expected issue 10 to be persisted and loaded")
+	}
+	if s2.Seen(99) {
+		t.Error("expected issue 99 not seen")
+	}
+}
+
+func TestIsPullRequest(t *testing.T) {
+	tests := []struct {
+		url  string
+		want bool
+	}{
+		{"https://github.com/owner/repo/issues/1", false},
+		{"https://github.com/owner/repo/pull/2", true},
+		{"https://github.com/owner/repo/issues/3", false},
+	}
+	for _, tt := range tests {
+		issue := ghIssue{URL: tt.url}
+		if got := isPullRequest(issue); got != tt.want {
+			t.Errorf("isPullRequest(%q) = %v, want %v", tt.url, got, tt.want)
+		}
+	}
+}

--- a/internal/daemon/task_test.go
+++ b/internal/daemon/task_test.go
@@ -83,7 +83,7 @@ func TestTaskStore_Eviction(t *testing.T) {
 }
 
 func TestHandleTask_NoDal(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	body := `{"dal":"nonexistent","task":"hello"}`
 	req := httptest.NewRequest("POST", "/api/task", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -94,7 +94,7 @@ func TestHandleTask_NoDal(t *testing.T) {
 }
 
 func TestHandleTask_MissingFields(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	body := `{"dal":"","task":""}`
 	req := httptest.NewRequest("POST", "/api/task", strings.NewReader(body))
 	w := httptest.NewRecorder()
@@ -105,7 +105,7 @@ func TestHandleTask_MissingFields(t *testing.T) {
 }
 
 func TestHandleTaskList_Empty(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	req := httptest.NewRequest("GET", "/api/tasks", nil)
 	w := httptest.NewRecorder()
 	d.handleTaskList(w, req)
@@ -118,7 +118,7 @@ func TestHandleTaskList_Empty(t *testing.T) {
 }
 
 func TestHandleTaskStatus_NotFound(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	req := httptest.NewRequest("GET", "/api/task/task-9999", nil)
 	req.SetPathValue("id", "task-9999")
 	w := httptest.NewRecorder()
@@ -129,7 +129,7 @@ func TestHandleTaskStatus_NotFound(t *testing.T) {
 }
 
 func TestHandleTaskStartAndFinish(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 
 	startReq := httptest.NewRequest("POST", "/api/task/start", strings.NewReader(`{"dal":"leader","task":"triage issue"}`))
 	startW := httptest.NewRecorder()
@@ -175,7 +175,7 @@ func TestHandleTaskStartAndFinish(t *testing.T) {
 }
 
 func TestHandleTaskEvent(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	tr := d.tasks.New("leader", "triage issue")
 
 	req := httptest.NewRequest("POST", "/api/task/"+tr.ID+"/event", strings.NewReader(`{"kind":"self_repair","message":"Retrying after fix"}`))
@@ -196,7 +196,7 @@ func TestHandleTaskEvent(t *testing.T) {
 }
 
 func TestHandleTaskMetadata(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	tr := d.tasks.New("leader", "triage issue")
 
 	req := httptest.NewRequest("POST", "/api/task/"+tr.ID+"/metadata", strings.NewReader(`{"git_diff":"M README.md","git_changes":1,"verified":"yes","completion":{"build_ok":true,"test_ok":false,"duration":"1.2s"}}`))
@@ -276,7 +276,7 @@ func TestTaskResult_WithChanges(t *testing.T) {
 }
 
 func TestMessageFallback_NoMM(t *testing.T) {
-	d := New(":0", "/tmp/test", t.TempDir(), "", "")
+	d := New(":0", "/tmp/test", t.TempDir(), "", "", "")
 	// No MM configured, no running dals → should return 503
 	body := `{"from":"host","message":"test"}`
 	req := httptest.NewRequest("POST", "/api/message", strings.NewReader(body))


### PR DESCRIPTION
## Summary
- dalcenter 데몬이 GitHub 이슈를 주기적으로 polling (5분 간격, `gh` CLI 사용)
- 새 이슈 감지 시 leader container에 async task로 자동 전달
- leader가 이슈 분석 → member assign → 브랜치 생성 → 작업 시작 플로우

## Changes
- `internal/daemon/issue_watcher.go`: GitHub 이슈 polling watcher + issueStore (seen 추적)
- `internal/daemon/daemon.go`: `githubRepo` 필드, `issues` store, watcher 시작, `/api/issues` 엔드포인트
- `cmd/dalcenter/cmd_localdal.go`: `--github-repo` / `DALCENTER_GITHUB_REPO` 플래그
- `internal/daemon/issue_watcher_test.go`: issueStore 및 isPullRequest 테스트

## Configuration
```bash
# 환경변수 또는 serve 플래그
DALCENTER_GITHUB_REPO=dalsoop/dalcenter dalcenter serve
# 또는
dalcenter serve --github-repo dalsoop/dalcenter
```

## Flow
```
dalroot: gh issue create "기능 X 구현"
  → dalcenter daemon: 새 이슈 감지 (5분 polling)
  → leader: 이슈 분석, member assign, wake --issue N
  → member: clone workspace, 브랜치 생성, 구현, PR
  → webhook: "issue_detected" 이벤트 발송
```

## Test plan
- [x] `go build ./...` 통과
- [x] `go test ./internal/daemon/` 전체 통과
- [ ] 실제 환경에서 `DALCENTER_GITHUB_REPO` 설정 후 이슈 polling 확인
- [ ] leader container 실행 중 새 이슈 생성 → 자동 task dispatch 확인

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)