### PR TITLE
fix: tell이 MM API 직접 호출 (matterbridge self-skip 우회)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -945,9 +945,13 @@ func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 	if dalName == "" {
 		dalName = "dalcenter"
 	}
-	if err := d.bridgePost(req.Message, dalName); err != nil {
-		http.Error(w, fmt.Sprintf("post failed: %v", err), 500)
-		return
+	// Post directly to MM (not via matterbridge) to avoid self-skip
+	if err := d.mmPost(req.Message); err != nil {
+		// Fallback to bridge
+		if err2 := d.bridgePost(req.Message, dalName); err2 != nil {
+			http.Error(w, fmt.Sprintf("post failed: mm=%v bridge=%v", err, err2), 500)
+			return
+		}
 	}
 
 	json.NewEncoder(w).Encode(map[string]string{

--- a/internal/daemon/matterbridge.go
+++ b/internal/daemon/matterbridge.go
@@ -6,6 +6,11 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -72,4 +77,79 @@ func parseBridgePort(confPath string) string {
 		}
 	}
 	return ""
+}
+
+// mmPost posts a message directly to MM API, bypassing matterbridge.
+// This avoids the self-skip issue where matterbridge ignores its own messages.
+func (d *Daemon) mmPost(text string) error {
+	mmURL := os.Getenv("DALCENTER_MM_URL")
+	mmToken := os.Getenv("DALCENTER_MM_TOKEN")
+	if mmURL == "" || mmToken == "" {
+		return fmt.Errorf("DALCENTER_MM_URL or DALCENTER_MM_TOKEN not set")
+	}
+
+	// Resolve channel ID from matterbridge config
+	channelID := d.resolveMMChannelID(mmURL, mmToken)
+	if channelID == "" {
+		return fmt.Errorf("could not resolve MM channel ID")
+	}
+
+	body := fmt.Sprintf(`{"channel_id":%q,"message":%q}`, channelID, text)
+	req, _ := http.NewRequest("POST", strings.TrimRight(mmURL, "/")+"/api/v4/posts", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+mmToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("mm post %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}
+
+// resolveMMChannelID finds the MM channel ID from the matterbridge config.
+func (d *Daemon) resolveMMChannelID(mmURL, mmToken string) string {
+	// Parse channel name from matterbridge config
+	channelName := ""
+	if d.bridgeConf != "" {
+		data, err := os.ReadFile(d.bridgeConf)
+		if err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "channel = ") && !strings.Contains(line, "api") {
+					channelName = strings.Trim(strings.TrimPrefix(line, "channel = "), "\"")
+					break
+				}
+			}
+		}
+	}
+	if channelName == "" {
+		// Fallback: use repo name
+		channelName = filepath.Base(d.serviceRepo)
+	}
+
+	// Resolve team ID first
+	mmTeam := os.Getenv("DALCENTER_MM_TEAM")
+	if mmTeam == "" {
+		mmTeam = "prelik"
+	}
+
+	url := fmt.Sprintf("%s/api/v4/teams/name/%s/channels/name/%s", strings.TrimRight(mmURL, "/"), mmTeam, channelName)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+mmToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	json.NewDecoder(resp.Body).Decode(&result)
+	return result.ID
 }


### PR DESCRIPTION
## Bug

tell → matterbridge API → MM → matterbridge가 자기 봇 메시지로 skip → leader가 못 받음.

## Fix

handleMessage에서 matterbridge API 대신 MM API를 직접 호출 (DALCENTER_MM_TOKEN 사용). matterbridge는 다른 사용자(devops)로 인식 → stream relay → leader 수신.

## Test

devops 토큰으로 MM 직접 포스팅 → leader가 정상 수신 확인됨.

Closes #542