### PR TITLE
feat: reviewer auto_task에 CLAUDE.md 컨텍스트 로드 (#554)

### DIFF
--- a/.dal/reviewer/dal.cue
+++ b/.dal/reviewer/dal.cue
@@ -5,6 +5,8 @@ player:  "codex"
 role:    "member"
 skills:  ["skills/go-review", "skills/security-audit", "skills/docker-ops", "skills/git-workflow", "skills/reviewer-protocol", "skills/inbox-protocol", "skills/history-hygiene", "skills/escalation"]
 hooks:   []
+auto_task:      "1. /workspace/CLAUDE.md 읽어서 프로젝트 컨벤션/규칙 파악. 2. gh pr list --state open --json number,title,headRefName --jq '.[]' | head -5 확인. 3. 새 PR 있으면 gh pr diff <number>로 변경사항 확인. 4. CLAUDE.md 컨벤션 기준 + 보안/Go관용구/에러처리/Docker보안 관점으로 리뷰. 5. 결과를 gh pr review <number> --comment으로 게시."
+auto_interval:  "30m"
 git: {
     user:         "dal-${name}"
     email:        "dal-${name}@dalcenter.local"


### PR DESCRIPTION
## Summary
- reviewer의 `auto_task`에 CLAUDE.md 로드 단계 추가
- wake 시 프로젝트 컨벤션/규칙을 먼저 파악한 후 PR 리뷰 수행
- `auto_interval: 30m` 설정으로 주기적 자동 리뷰

Closes #554

## Test plan
- [ ] `.dal/reviewer/dal.cue`에 `auto_task`, `auto_interval` 필드 존재 확인
- [ ] auto_task 첫 단계가 CLAUDE.md 읽기인지 확인
- [ ] CUE 스키마 유효성 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)