### PR TITLE
feat: CCW git clone 설치 및 프로젝트 specs 추가

### DIFF
--- a/.ccw/specs/architecture-constraints.md
+++ b/.ccw/specs/architecture-constraints.md
@@ -1,0 +1,17 @@
+---
+keywords: architecture, design, structure
+category: planning
+---
+# Architecture
+
+## dalcenter
+- cmd/dalcenter/ — CLI 엔트리포인트
+- cmd/dalcli/ — dal agent CLI
+- cmd/dalcli-leader/ — leader 전용 CLI
+- internal/daemon/ — 데몬 로직
+- internal/bridge/ — matterbridge 연동
+- internal/localdal/ — 로컬 dal 관리
+
+## Docker
+- dockerfiles/ — claude/codex 이미지
+- 각 dal은 독립 Docker 컨테이너로 실행

--- a/.ccw/specs/coding-conventions.md
+++ b/.ccw/specs/coding-conventions.md
@@ -1,0 +1,22 @@
+---
+keywords: code, convention, style, review
+category: general
+---
+# Coding Conventions
+
+## Go
+- go vet + go build 통과 필수
+- go test ./... 통과 후 PR
+- 에러 핸들링: if err != nil 패턴
+- 패키지명은 소문자 단일 단어
+
+## Git
+- 브랜치: issue-{N}/{dal-name} 또는 fix/{description}
+- PR에 Closes #{N} 포함
+- 커밋 메시지: feat/fix/refactor 접두사
+
+## CCW
+- 작업 시작: ccw session start
+- 작업 종료: ccw session end
+- 코드 분석: ccw tool read_file, edit_file
+- 리뷰: ccw cli --tool codex --mode review

--- a/.ccw/specs/project.yaml
+++ b/.ccw/specs/project.yaml
@@ -1,0 +1,20 @@
+name: dalcenter
+description: Dal lifecycle manager — multi-agent orchestration framework
+language: go
+conventions:
+  - All Go code must pass go vet and go build
+  - Test with go test ./... before PR
+  - Branch naming: issue-{N}/{dal-name} or fix/{description}
+  - PR must reference issue number with Closes #{N}
+  - Commit messages in Korean or English, imperative mood
+  - Use CCW tools for code analysis and review
+workflow:
+  - dalops: infrastructure, CLI commands, deployment
+  - dal: documentation, templates, feature implementation
+  - reviewer: PR review, build verification, approve/request-changes
+tools:
+  - ccw tool list — available tools
+  - ccw cli --tool claude — Claude Code execution
+  - ccw spec load — load project conventions
+  - ccw session start — start work session
+  - ccw session end — end with summary

--- a/dockerfiles/claude.Dockerfile
+++ b/dockerfiles/claude.Dockerfile
@@ -26,8 +26,12 @@ RUN mkdir -p .claude/skills .claude/hooks
 # Git credential helper — uses GH_TOKEN env var for HTTPS push
 RUN git config --global credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
 
-# CCW — JSON-driven multi-agent workflow orchestration
-RUN npm install -g claude-code-workflow && ccw install -m Global || true
+# CCW — JSON-driven multi-agent workflow orchestration (git clone build)
+RUN git clone --depth 1 https://github.com/catlog22/Claude-Code-Workflow.git /opt/ccw && \
+    cd /opt/ccw && npm install --ignore-scripts && npx tsc && \
+    printf '#!/bin/sh\nnode /opt/ccw/dist/index.js "$@"\n' > /usr/local/bin/ccw && \
+    chmod +x /usr/local/bin/ccw && \
+    ccw install -m Global || true
 
 ENV DAL_ROLE=member
 ENV DAL_PLAYER=claude


### PR DESCRIPTION
## Summary
- `dockerfiles/claude.Dockerfile`: CCW 설치를 `npm install -g` → git clone `/opt/ccw` + `npx tsc` 빌드 + `/usr/local/bin/ccw` 래퍼 스크립트 방식으로 변경
- `.ccw/specs/`: 프로젝트 컨벤션 파일 3개 추가 (project.yaml, coding-conventions.md, architecture-constraints.md)

## Test plan
- [ ] Docker 이미지 빌드 확인 (`docker build -f dockerfiles/claude.Dockerfile .`)
- [ ] 컨테이너 내 `ccw --version` 동작 확인
- [ ] `ccw spec load` 로 specs 파일 로드 확인

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)