### PR TITLE
fix: template fallback — .dal/ 직접 경로 탐색

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1138,7 +1138,12 @@ func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]strin
 
 func (d *Daemon) dalCuePath(name string) string {
 	tplRoot := localdal.ResolveTemplateRoot(d.localdalRoot)
-	return fmt.Sprintf("%s/%s/dal.cue", tplRoot, name)
+	path := fmt.Sprintf("%s/%s/dal.cue", tplRoot, name)
+	if _, err := os.Stat(path); err == nil {
+		return path
+	}
+	// Fallback: look directly in .dal/<name>/dal.cue
+	return fmt.Sprintf("%s/%s/dal.cue", d.localdalRoot, name)
 }
 
 // validateMemberLimit checks the leader's max_members setting and rejects

--- a/internal/daemon/docker.go
+++ b/internal/daemon/docker.go
@@ -235,6 +235,10 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr, bridgeURL st
 
 	tplRoot := localdal.ResolveTemplateRoot(localdalRoot)
 	dalDir := filepath.Join(tplRoot, dal.FolderName)
+	if _, err := os.Stat(dalDir); err != nil {
+		// Fallback: look directly in .dal/<name>
+		dalDir = filepath.Join(localdalRoot, dal.FolderName)
+	}
 	home := playerHome(dal.Player)
 	hostHome, _ := os.UserHomeDir()
 
@@ -352,6 +356,13 @@ func dockerRun(localdalRoot, serviceRepo, instanceName, daemonAddr, bridgeURL st
 			continue
 		}
 		skillPath := filepath.Join(tplRoot, skill)
+		if _, err := os.Stat(skillPath); err != nil {
+			skillPath = filepath.Join(localdalRoot, skill)
+		}
+		if _, err := os.Stat(skillPath); err != nil {
+			log.Printf("[docker] skill %s not found, skipping", skill)
+			continue
+		}
 		targetPath := filepath.Join(home, "skills", skillBase)
 		bindMounts = append(bindMounts, mount.Mount{
 			Type:     mount.TypeBind,


### PR DESCRIPTION
## Bug

template 디렉토리 도입 후, template에 정의 안 된 dal(leader 등)이나 skill(go-review 등)을 wake하면 not found 에러.

## Fix

dalCuePath, dockerRun에서 template 경로에 없으면 .dal/ 루트로 fallback.

## Test

- leader wake 성공 (template에 leader 없지만 .dal/leader/에서 찾음)
- skills/go-review 등 template/skills에 없는 스킬 skip 처리