### PR TITLE
fix: bridge_url 미주입 — 기존 matterbridge 감지 시에도 설정

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -150,13 +150,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 				mb.Process.Kill()
 				mb.Wait()
 			}()
-			// Auto-set bridgeURL from config or default
-			if d.bridgeURL == "" {
-				if port := parseBridgePort(d.bridgeConf); port != "" {
-					d.bridgeURL = "http://localhost:" + port
-				} else {
-					d.bridgeURL = DefaultBridgeURL
-				}
+		}
+		// Auto-set bridgeURL from config regardless of child process ownership
+		if d.bridgeURL == "" {
+			if port := parseBridgePort(d.bridgeConf); port != "" {
+				d.bridgeURL = "http://localhost:" + port
+			} else {
+				d.bridgeURL = DefaultBridgeURL
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `startMatterbridge`가 기존 프로세스 감지 시 `nil` 반환 → `bridgeURL` 설정 블록 스킵 → 컨테이너에 `DALCENTER_BRIDGE_URL=""` 주입
- `bridgeConf`가 있으면 프로세스 소유 여부와 무관하게 포트 파싱하여 `bridgeURL` 설정하도록 수정

## Test plan
- [x] `go test ./...` 전체 통과
- [ ] dalcenter 재시작 후 `docker inspect` 로 `DALCENTER_BRIDGE_URL` 값 확인
- [ ] dal wake → bridge 연결 → 메시지 수신 확인

Fixes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)