### PR TITLE
fix: set bridgeURL when existing matterbridge detected (#574)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -145,7 +145,8 @@ func (d *Daemon) Run(ctx context.Context) error {
 
 	// Start matterbridge as child process
 	if d.bridgeConf != "" {
-		if mb, err := startMatterbridge(ctx, d.bridgeConf); err != nil {
+		mb, err := startMatterbridge(ctx, d.bridgeConf)
+		if err != nil {
 			log.Printf("[daemon] matterbridge start failed: %v (continuing without)", err)
 		} else if mb != nil {
 			defer func() {


### PR DESCRIPTION
## Summary
- `bridge_url`이 wake 시 빈 값으로 컨테이너에 전달되는 버그 수정
- `startMatterbridge`가 기존 프로세스를 감지해 `nil`을 반환하면, `bridgeURL` auto-set 로직이 `mb != nil` 분기 안에 있어서 스킵됨
- `bridgeURL` 설정을 error가 아닌 모든 경우(새 프로세스 시작 + 기존 프로세스 감지)에 실행되도록 이동

## Test plan
- [ ] `bridgeConf`가 설정되고 matterbridge가 이미 실행 중일 때 `d.bridgeURL`이 설정되는지 확인
- [ ] `bridgeConf`가 설정되고 matterbridge를 새로 시작한 경우에도 기존과 동일하게 동작하는지 확인
- [ ] `startMatterbridge`가 에러를 반환하면 `bridgeURL`이 설정되지 않는지 확인

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)