### PR TITLE
fix: autoGitWorkflow checkout main이 작업 결과 소실 (#571)

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -885,10 +885,7 @@ func autoGitWorkflow(dalName string) string {
 		return strings.TrimSpace(string(out)), err
 	}
 
-	// 먼저 main으로 복귀 (이전 실행에서 다른 브랜치에 남아있을 수 있음)
-	run("git", "checkout", "main")
-
-	// Check changes
+	// Check changes (현재 브랜치에서 — checkout하면 변경사항이 날아감)
 	statusCmd := exec.Command("git", "status", "--porcelain")
 	statusCmd.Dir = "/workspace"
 	statusOut, err := statusCmd.Output()


### PR DESCRIPTION
## Summary

- `autoGitWorkflow` 시작 시 `git checkout main` 호출이 Claude가 작성한 uncommitted 변경사항을 모두 날리는 버그 수정
- 변경사항 감지를 현재 브랜치에서 먼저 수행하도록 변경하여 working tree 보존

## Root Cause

`cmd/dalcli/cmd_run.go:889`에서 `run("git", "checkout", "main")`이 `git status --porcelain` 전에 호출됨. 이로 인해:
1. Claude가 코드 작성 완료 (uncommitted changes 존재)
2. `autoGitWorkflow` 진입 → `git checkout main` → **변경사항 소실**
3. `git status --porcelain` → 빈 출력 → 빈 문자열 반환 (커밋 skip)

## Fix

`git checkout main` 제거. `git checkout -b <branch>`는 working tree를 보존하므로, 변경사항 감지 후 새 브랜치 생성 시 자연스럽게 작업 결과가 유지됨.

## Related

Closes #571
Blocked: #570, #559, #547, #546

## Test plan

- [ ] dalcli run으로 코드 생성 후 자동 commit/push/PR 생성 확인
- [ ] 변경사항 없을 때 빈 문자열 반환 확인
- [ ] .dal/ only 변경 시 gate1 skip 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)