### PR TITLE
feat: dalroot 알림 인프라 코드화 (#572)

### DIFF
--- a/cmd/dalbridge/main.go
+++ b/cmd/dalbridge/main.go
@@ -1,0 +1,195 @@
+// dalbridge — Mattermost outgoing webhook → SSE stream 릴레이
+//
+// matterbridge의 websocket 대신 outgoing webhook을 받아
+// SSE(Server-Sent Events) stream으로 재전송한다.
+// dalroot-listener가 이 stream을 구독하여 멘션을 감지한다.
+//
+// 환경변수:
+//
+//	DALBRIDGE_LISTEN       — 리슨 주소 (default: ":4280")
+//	DALBRIDGE_WEBHOOK_TOKEN — outgoing webhook 검증 토큰 (optional)
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+// webhookPayload is the Mattermost outgoing webhook format.
+type webhookPayload struct {
+	Token       string `json:"token"`
+	ChannelName string `json:"channel_name"`
+	UserName    string `json:"user_name"`
+	Text        string `json:"text"`
+	PostID      string `json:"post_id"`
+	Timestamp   int64  `json:"timestamp"`
+}
+
+// streamMessage is the normalized message sent to SSE clients.
+type streamMessage struct {
+	Text      string `json:"text"`
+	Username  string `json:"username"`
+	Channel   string `json:"channel"`
+	PostID    string `json:"post_id"`
+	Timestamp string `json:"timestamp"`
+}
+
+// broker manages SSE client connections and message broadcasting.
+type broker struct {
+	mu      sync.RWMutex
+	clients map[chan []byte]struct{}
+}
+
+func newBroker() *broker {
+	return &broker{clients: make(map[chan []byte]struct{})}
+}
+
+func (b *broker) subscribe() chan []byte {
+	ch := make(chan []byte, 64)
+	b.mu.Lock()
+	b.clients[ch] = struct{}{}
+	b.mu.Unlock()
+	return ch
+}
+
+func (b *broker) unsubscribe(ch chan []byte) {
+	b.mu.Lock()
+	delete(b.clients, ch)
+	b.mu.Unlock()
+	close(ch)
+}
+
+func (b *broker) broadcast(data []byte) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	for ch := range b.clients {
+		select {
+		case ch <- data:
+		default:
+			// slow client — drop message
+		}
+	}
+}
+
+func (b *broker) clientCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.clients)
+}
+
+func main() {
+	listen := os.Getenv("DALBRIDGE_LISTEN")
+	if listen == "" {
+		listen = ":4280"
+	}
+	webhookToken := os.Getenv("DALBRIDGE_WEBHOOK_TOKEN")
+
+	b := newBroker()
+	mux := http.NewServeMux()
+
+	// POST /webhook — Mattermost outgoing webhook 수신
+	mux.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var payload webhookPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+
+		// 토큰 검증 (설정된 경우)
+		if webhookToken != "" && payload.Token != webhookToken {
+			http.Error(w, "invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		msg := streamMessage{
+			Text:      payload.Text,
+			Username:  payload.UserName,
+			Channel:   payload.ChannelName,
+			PostID:    payload.PostID,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}
+
+		data, err := json.Marshal(msg)
+		if err != nil {
+			http.Error(w, "marshal error", http.StatusInternalServerError)
+			return
+		}
+
+		b.broadcast(data)
+		log.Printf("[webhook] %s@%s: %s (%d clients)",
+			payload.UserName, payload.ChannelName,
+			truncate(payload.Text, 80), b.clientCount())
+
+		// MM outgoing webhook은 응답 본문을 채널에 포스팅하므로 빈 JSON 반환
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, "{}")
+	})
+
+	// GET /stream — SSE stream
+	mux.HandleFunc("/stream", func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		ch := b.subscribe()
+		defer b.unsubscribe(ch)
+
+		// 연결 확인 메시지
+		fmt.Fprintf(w, "data: {\"event\":\"connected\"}\n\n")
+		flusher.Flush()
+
+		log.Printf("[stream] client connected (%d total)", b.clientCount())
+		defer func() {
+			log.Printf("[stream] client disconnected (%d remaining)", b.clientCount())
+		}()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case data, ok := <-ch:
+				if !ok {
+					return
+				}
+				fmt.Fprintf(w, "data: %s\n\n", data)
+				flusher.Flush()
+			}
+		}
+	})
+
+	// GET /health — 헬스 체크
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"status":"ok","clients":%d}`, b.clientCount())
+	})
+
+	log.Printf("[dalbridge] listening on %s", listen)
+	if err := http.ListenAndServe(listen, mux); err != nil {
+		log.Fatalf("[dalbridge] %v", err)
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/proxmox-host-setup/dalroot/README.md
+++ b/proxmox-host-setup/dalroot/README.md
@@ -1,0 +1,77 @@
+# dalroot 알림 인프라
+
+dalroot(호스트 Claude Code)가 Mattermost 메시지를 실시간 수신하기 위한 인프라.
+
+## 아키텍처
+
+```
+Mattermost (#dalcenter, #host, ...)
+    │
+    ▼ outgoing webhook
+CT 202: dalbridge (:4280/webhook)
+    │
+    ▼ SSE stream (:4280/stream)
+Host: dalroot-listener
+    │
+    ▼ file write
+/var/lib/dalroot/inbox/{dalroot-id}/*.msg
+    │
+    ▼ Claude Code hook (UserPromptSubmit)
+dalroot-check-notifications → stdout
+```
+
+## 구성요소
+
+### 호스트 스크립트 (/usr/local/bin/)
+
+| 스크립트 | 설명 |
+|---------|------|
+| `dalroot-id` | tmux pane 역추적으로 `dalroot-{session}-{window}-{pane}` ID 생성 |
+| `dalroot-check-notifications` | inbox에서 unread 알림 읽기 + 삭제 |
+| `dalroot-register` | SessionStart hook — inbox 생성 + MM 등록 |
+| `dalroot-task` | dalcenter task 래퍼 (팀 라우팅 + callback) |
+| `dalroot-listener` | dalbridge SSE stream 구독 → inbox 전달 |
+
+### CT 202 (Mattermost LXC)
+
+| 구성요소 | 설명 |
+|---------|------|
+| `dalbridge` | MM outgoing webhook → SSE stream 릴레이 |
+| outgoing webhooks | 각 팀 채널 → dalbridge:4280 |
+
+### systemd 서비스
+
+| 서비스 | 위치 | 설명 |
+|--------|------|------|
+| `dalroot-listener.service` | Host | listener 데몬 |
+| `dalbridge.service` | CT 202 | dalbridge 데몬 |
+
+## 설치
+
+```bash
+# 전체 설치 (호스트 + CT 202 dalbridge + webhooks)
+./install.sh
+
+# 호스트만
+./install.sh --host
+
+# dalbridge만 (CT ID 지정 가능)
+./install.sh --bridge 202
+
+# webhook만
+MM_TOKEN=<admin-token> ./install.sh --webhooks 202
+```
+
+## Claude Code Hooks
+
+`~/.claude/settings.json`에 추가:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [{"type": "command", "command": "dalroot-register"}],
+    "UserPromptSubmit": [{"type": "command", "command": "dalroot-check-notifications"}],
+    "Notification": [{"type": "command", "command": "dalroot-check-notifications"}]
+  }
+}
+```

--- a/proxmox-host-setup/dalroot/dalbridge.service
+++ b/proxmox-host-setup/dalroot/dalbridge.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=dalbridge — Mattermost outgoing webhook to SSE stream relay
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/dalbridge
+Restart=always
+RestartSec=5
+Environment=DALBRIDGE_LISTEN=:4280
+EnvironmentFile=-/etc/dalbridge.env
+
+[Install]
+WantedBy=multi-user.target

--- a/proxmox-host-setup/dalroot/dalroot-check-notifications
+++ b/proxmox-host-setup/dalroot/dalroot-check-notifications
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dalroot-check-notifications — dalroot-id 기반 inbox에서 unread 알림 읽기
+#
+# Claude Code hook (UserPromptSubmit, Notification)에서 호출된다.
+# inbox 디렉토리에서 미읽은 알림 파일을 읽고 삭제한다.
+
+set -euo pipefail
+
+DALROOT_INBOX_BASE="${DALROOT_INBOX_BASE:-/var/lib/dalroot/inbox}"
+
+# dalroot-id 획득
+DALROOT_ID=$(dalroot-id 2>/dev/null) || DALROOT_ID="dalroot-unknown-0-0"
+INBOX_DIR="${DALROOT_INBOX_BASE}/${DALROOT_ID}"
+
+if [ ! -d "$INBOX_DIR" ]; then
+    exit 0
+fi
+
+# unread 알림 파일 처리 (시간순)
+shopt -s nullglob
+files=("$INBOX_DIR"/*.msg)
+shopt -u nullglob
+
+if [ ${#files[@]} -eq 0 ]; then
+    exit 0
+fi
+
+for f in "${files[@]}"; do
+    cat "$f"
+    echo ""
+    rm -f "$f"
+done

--- a/proxmox-host-setup/dalroot/dalroot-id
+++ b/proxmox-host-setup/dalroot/dalroot-id
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# dalroot-id — Claude Code 프로세스 역추적으로 고유 ID 생성
+# Output: dalroot-{session}-{window}-{pane}
+#
+# Claude Code가 실행 중인 tmux pane을 역추적하여 고유 식별자를 생성한다.
+# 이 ID는 inbox 경로, MM 멘션, task 라우팅에 사용된다.
+
+set -euo pipefail
+
+# 현재 프로세스에서 tmux pane까지 역추적
+find_tmux_pane() {
+    local pid=$$
+    # 최대 20 레벨까지 부모 추적
+    for _ in $(seq 1 20); do
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+        [ -z "$pid" ] || [ "$pid" = "1" ] && break
+
+        # tmux pane 환경변수 확인
+        local env_file="/proc/$pid/environ"
+        if [ -r "$env_file" ]; then
+            local tmux_pane
+            tmux_pane=$(tr '\0' '\n' < "$env_file" | grep '^TMUX_PANE=' | head -1 | cut -d= -f2-)
+            if [ -n "$tmux_pane" ]; then
+                echo "$tmux_pane"
+                return 0
+            fi
+        fi
+    done
+    return 1
+}
+
+# tmux pane ID에서 session, window, pane 번호 추출
+resolve_tmux_ids() {
+    local pane_id="$1"
+    # tmux list-panes로 session:window.pane 형식 조회
+    tmux list-panes -a -F '#{pane_id} #{session_name} #{window_index} #{pane_index}' 2>/dev/null \
+        | grep "^${pane_id} " | head -1 | awk '{print $2, $3, $4}'
+}
+
+main() {
+    local tmux_pane
+    tmux_pane=$(find_tmux_pane) || {
+        # tmux 밖이면 PID 기반 fallback
+        echo "dalroot-nontmux-$$-0"
+        exit 0
+    }
+
+    local ids
+    ids=$(resolve_tmux_ids "$tmux_pane")
+    if [ -z "$ids" ]; then
+        echo "dalroot-unknown-0-0"
+        exit 0
+    fi
+
+    local session window pane
+    read -r session window pane <<< "$ids"
+    echo "dalroot-${session}-${window}-${pane}"
+}
+
+main

--- a/proxmox-host-setup/dalroot/dalroot-listener
+++ b/proxmox-host-setup/dalroot/dalroot-listener
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# dalroot-listener — dalbridge stream에서 @dalroot-N-N-N 멘션 감지 → inbox 전달
+#
+# CT 202의 dalbridge SSE stream을 구독하고,
+# @dalroot-{session}-{window}-{pane} 패턴 멘션을 감지하면
+# 해당 dalroot의 inbox에 알림 파일을 생성한다.
+#
+# systemd 서비스로 실행: dalroot-listener.service
+
+set -euo pipefail
+
+DALROOT_INBOX_BASE="${DALROOT_INBOX_BASE:-/var/lib/dalroot/inbox}"
+DALBRIDGE_URL="${DALBRIDGE_URL:-http://10.50.0.202:4280/stream}"
+RECONNECT_DELAY=5
+
+log() { echo "[dalroot-listener] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+deliver_to_inbox() {
+    local dalroot_id="$1"
+    local message="$2"
+    local inbox_dir="${DALROOT_INBOX_BASE}/${dalroot_id}"
+
+    if [ ! -d "$inbox_dir" ]; then
+        log "inbox not found for ${dalroot_id}, skipping"
+        return
+    fi
+
+    local timestamp
+    timestamp=$(date '+%s%N')
+    echo "$message" > "${inbox_dir}/${timestamp}.msg"
+    log "delivered to ${dalroot_id}"
+}
+
+process_line() {
+    local line="$1"
+
+    # JSON 파싱 (jq 사용)
+    local text username channel
+    text=$(echo "$line" | jq -r '.text // empty' 2>/dev/null) || return
+    username=$(echo "$line" | jq -r '.username // empty' 2>/dev/null) || return
+    channel=$(echo "$line" | jq -r '.channel // empty' 2>/dev/null) || return
+
+    [ -z "$text" ] && return
+
+    # @dalroot-{session}-{window}-{pane} 멘션 패턴 감지
+    local mentions
+    mentions=$(echo "$text" | grep -oP '@dalroot-\S+' || true)
+
+    if [ -z "$mentions" ]; then
+        # @dalroot (세션 미지정) — 모든 활성 inbox에 전달
+        if echo "$text" | grep -qP '@dalroot\b'; then
+            for inbox_dir in "${DALROOT_INBOX_BASE}"/dalroot-*/; do
+                [ -d "$inbox_dir" ] || continue
+                local id
+                id=$(basename "$inbox_dir")
+                deliver_to_inbox "$id" "[${channel}] ${username}: ${text}"
+            done
+        fi
+        return
+    fi
+
+    # 특정 dalroot 인스턴스에 전달
+    for mention in $mentions; do
+        local dalroot_id="${mention#@}"
+        deliver_to_inbox "$dalroot_id" "[${channel}] ${username}: ${text}"
+    done
+}
+
+main() {
+    log "starting (bridge: ${DALBRIDGE_URL})"
+    mkdir -p "$DALROOT_INBOX_BASE"
+
+    while true; do
+        log "connecting to dalbridge..."
+        # curl SSE stream — 각 줄이 JSON 메시지
+        curl -sN "$DALBRIDGE_URL" 2>/dev/null | while IFS= read -r line; do
+            [ -z "$line" ] && continue
+            # SSE data: 접두사 제거
+            line="${line#data: }"
+            process_line "$line"
+        done
+
+        log "disconnected, reconnecting in ${RECONNECT_DELAY}s..."
+        sleep "$RECONNECT_DELAY"
+    done
+}
+
+main

--- a/proxmox-host-setup/dalroot/dalroot-listener.service
+++ b/proxmox-host-setup/dalroot/dalroot-listener.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=dalroot notification listener — dalbridge SSE stream subscriber
+After=network.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/dalroot-listener
+Restart=always
+RestartSec=5
+Environment=DALROOT_INBOX_BASE=/var/lib/dalroot/inbox
+Environment=DALBRIDGE_URL=http://10.50.0.202:4280/stream
+
+[Install]
+WantedBy=multi-user.target

--- a/proxmox-host-setup/dalroot/dalroot-register
+++ b/proxmox-host-setup/dalroot/dalroot-register
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# dalroot-register — SessionStart hook: inbox 생성 + MM 온라인 등록
+#
+# Claude Code SessionStart 이벤트에서 호출된다.
+# 1. dalroot-id 기반 inbox 디렉토리 생성
+# 2. Mattermost에 온라인 상태 등록 (dalcenter API 경유)
+
+set -euo pipefail
+
+DALROOT_INBOX_BASE="${DALROOT_INBOX_BASE:-/var/lib/dalroot/inbox}"
+DALCENTER_CT="${DALCENTER_CT:-105}"
+DALCENTER_MM_CHANNEL="${DALCENTER_MM_CHANNEL:-host}"
+
+# dalroot-id 획득
+DALROOT_ID=$(dalroot-id 2>/dev/null) || {
+    echo "[dalroot-register] failed to get dalroot-id" >&2
+    exit 1
+}
+
+# 1. inbox 디렉토리 생성
+INBOX_DIR="${DALROOT_INBOX_BASE}/${DALROOT_ID}"
+mkdir -p "$INBOX_DIR"
+
+# 2. Mattermost 온라인 등록
+# dalcenter API를 통해 호스트 채널에 등록 메시지 전송
+if command -v pct >/dev/null 2>&1; then
+    pct exec "$DALCENTER_CT" -- dalcenter tell dalcenter \
+        "[register] ${DALROOT_ID} online" 2>/dev/null || true
+fi
+
+echo "[dalroot-register] ${DALROOT_ID} registered (inbox: ${INBOX_DIR})"

--- a/proxmox-host-setup/dalroot/dalroot-task
+++ b/proxmox-host-setup/dalroot/dalroot-task
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# dalroot-task — dalcenter task 래퍼 (팀 라우팅 + dalroot-id)
+#
+# Usage: dalroot-task <team> <task-description>
+# Example: dalroot-task dalcenter "이슈 현황 보고해"
+#
+# dalcenter task API를 호출하되, 콜백 pane을 dalroot-id로 설정하여
+# 완료 알림이 올바른 inbox로 라우팅되도록 한다.
+
+set -euo pipefail
+
+DALCENTER_CT="${DALCENTER_CT:-105}"
+
+if [ $# -lt 2 ]; then
+    echo "Usage: dalroot-task <team> <task-description>" >&2
+    exit 1
+fi
+
+TEAM="$1"
+shift
+TASK="$*"
+
+# dalroot-id 획득
+DALROOT_ID=$(dalroot-id 2>/dev/null) || DALROOT_ID="dalroot-unknown-0-0"
+
+# dalcenter API로 해당 팀의 포트 조회
+get_team_port() {
+    local team="$1"
+    case "$team" in
+        dalcenter)              echo 11192 ;;
+        veilkey-v2)             echo 11193 ;;
+        veilkey-selfhosted)     echo 11190 ;;
+        bridge-of-gaya-script)  echo 11191 ;;
+        dal-qa-team)            echo 11194 ;;
+        *)
+            echo "[dalroot-task] unknown team: $team" >&2
+            return 1
+            ;;
+    esac
+}
+
+PORT=$(get_team_port "$TEAM") || exit 1
+
+# task 실행 (callback_pane으로 dalroot-id 전달)
+if command -v pct >/dev/null 2>&1; then
+    pct exec "$DALCENTER_CT" -- \
+        curl -s -X POST "http://localhost:${PORT}/api/task" \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $(cat /etc/dalcenter/token 2>/dev/null || echo '')" \
+        -d "{\"task\":\"${TASK}\",\"callback_pane\":\"${DALROOT_ID}\"}"
+else
+    echo "[dalroot-task] pct not available" >&2
+    exit 1
+fi

--- a/proxmox-host-setup/dalroot/install.sh
+++ b/proxmox-host-setup/dalroot/install.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# install.sh — dalroot 알림 인프라 설치 자동화
+#
+# Proxmox 호스트에서 실행:
+#   ./install.sh [--host] [--bridge CT_ID]
+#
+# --host:  호스트에 dalroot 스크립트 + listener 설치
+# --bridge CT_ID: CT에 dalbridge 설치 (default: 202)
+# 인자 없으면 둘 다 설치
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DALCENTER_REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[install]${NC} $*"; }
+warn() { echo -e "${YELLOW}[install]${NC} $*"; }
+err()  { echo -e "${RED}[install]${NC} $*" >&2; }
+
+# ─── 호스트 설치 ───────────────────────────────────────────────────
+
+install_host() {
+    log "Installing dalroot scripts to /usr/local/bin/..."
+
+    local scripts=(dalroot-id dalroot-check-notifications dalroot-register dalroot-task dalroot-listener)
+    for s in "${scripts[@]}"; do
+        cp "$SCRIPT_DIR/$s" "/usr/local/bin/$s"
+        chmod +x "/usr/local/bin/$s"
+        log "  installed $s"
+    done
+
+    # inbox 디렉토리 생성
+    mkdir -p /var/lib/dalroot/inbox
+    log "  created /var/lib/dalroot/inbox"
+
+    # systemd 서비스 설치
+    log "Installing dalroot-listener.service..."
+    cp "$SCRIPT_DIR/dalroot-listener.service" /etc/systemd/system/
+    systemctl daemon-reload
+    systemctl enable dalroot-listener.service
+    systemctl restart dalroot-listener.service
+    log "  dalroot-listener.service enabled and started"
+
+    # Claude Code hooks 설정 안내
+    warn ""
+    warn "Claude Code settings.json에 다음 hooks를 추가하세요:"
+    warn ""
+    warn '  "hooks": {'
+    warn '    "SessionStart": [{"type": "command", "command": "dalroot-register"}],'
+    warn '    "UserPromptSubmit": [{"type": "command", "command": "dalroot-check-notifications"}],'
+    warn '    "Notification": [{"type": "command", "command": "dalroot-check-notifications"}]'
+    warn '  }'
+    warn ""
+}
+
+# ─── dalbridge 설치 (CT 내부) ──────────────────────────────────────
+
+install_bridge() {
+    local ct_id="${1:-202}"
+
+    log "Building dalbridge..."
+    (cd "$DALCENTER_REPO" && GOOS=linux GOARCH=amd64 go build -o dist/dalbridge ./cmd/dalbridge/)
+    log "  built dist/dalbridge"
+
+    log "Installing dalbridge to CT ${ct_id}..."
+    pct push "$ct_id" "$DALCENTER_REPO/dist/dalbridge" /usr/local/bin/dalbridge
+    pct exec "$ct_id" -- chmod +x /usr/local/bin/dalbridge
+
+    # systemd 서비스 설치
+    pct push "$ct_id" "$SCRIPT_DIR/dalbridge.service" /etc/systemd/system/dalbridge.service
+    pct exec "$ct_id" -- systemctl daemon-reload
+    pct exec "$ct_id" -- systemctl enable dalbridge.service
+    pct exec "$ct_id" -- systemctl restart dalbridge.service
+    log "  dalbridge.service enabled and started on CT ${ct_id}"
+}
+
+# ─── Outgoing Webhook 생성 ─────────────────────────────────────────
+
+setup_webhooks() {
+    local ct_id="${1:-202}"
+
+    log "Setting up outgoing webhooks..."
+    if [ ! -f "$SCRIPT_DIR/setup-webhooks.sh" ]; then
+        warn "setup-webhooks.sh not found, skipping webhook setup"
+        return
+    fi
+    bash "$SCRIPT_DIR/setup-webhooks.sh" "$ct_id"
+}
+
+# ─── main ──────────────────────────────────────────────────────────
+
+usage() {
+    echo "Usage: $0 [--host] [--bridge [CT_ID]] [--webhooks [CT_ID]]"
+    echo ""
+    echo "Options:"
+    echo "  --host              Install dalroot scripts + listener on host"
+    echo "  --bridge [CT_ID]    Install dalbridge on CT (default: 202)"
+    echo "  --webhooks [CT_ID]  Create MM outgoing webhooks (default: 202)"
+    echo ""
+    echo "No arguments: install everything (host + bridge CT 202 + webhooks)"
+}
+
+main() {
+    if [ $# -eq 0 ]; then
+        install_host
+        install_bridge 202
+        setup_webhooks 202
+        log "All done!"
+        exit 0
+    fi
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --host)
+                install_host
+                shift
+                ;;
+            --bridge)
+                local ct="${2:-202}"
+                [[ "$ct" == --* ]] && ct="202" || shift
+                install_bridge "$ct"
+                shift
+                ;;
+            --webhooks)
+                local ct="${2:-202}"
+                [[ "$ct" == --* ]] && ct="202" || shift
+                setup_webhooks "$ct"
+                shift
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                err "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+
+    log "Done!"
+}
+
+main "$@"

--- a/proxmox-host-setup/dalroot/setup-webhooks.sh
+++ b/proxmox-host-setup/dalroot/setup-webhooks.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# setup-webhooks.sh — Mattermost outgoing webhook 자동 생성
+#
+# CT 내부의 Mattermost API를 사용하여 각 팀 채널에
+# dalbridge로 메시지를 전달하는 outgoing webhook을 생성한다.
+#
+# Usage: ./setup-webhooks.sh [CT_ID]
+#
+# 환경변수:
+#   MM_URL    — Mattermost URL (default: http://localhost:8065)
+#   MM_TOKEN  — Mattermost admin token (필수)
+#   MM_TEAM   — Team slug (default: prelik)
+
+set -euo pipefail
+
+CT_ID="${1:-202}"
+MM_URL="${MM_URL:-http://localhost:8065}"
+MM_TOKEN="${MM_TOKEN:-}"
+MM_TEAM="${MM_TEAM:-prelik}"
+DALBRIDGE_CALLBACK="${DALBRIDGE_CALLBACK:-http://localhost:4280/webhook}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[webhooks]${NC} $*"; }
+err() { echo -e "${RED}[webhooks]${NC} $*" >&2; }
+
+# MM API 호출 (CT 내부에서 실행)
+mm_api() {
+    local method="$1" path="$2"
+    shift 2
+    pct exec "$CT_ID" -- curl -s -X "$method" \
+        "${MM_URL}${path}" \
+        -H "Authorization: Bearer ${MM_TOKEN}" \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+# 팀 ID 조회
+get_team_id() {
+    mm_api GET "/api/v4/teams/name/${MM_TEAM}" | jq -r '.id'
+}
+
+# 채널 ID 조회
+get_channel_id() {
+    local team_id="$1" channel_name="$2"
+    mm_api GET "/api/v4/teams/${team_id}/channels/name/${channel_name}" | jq -r '.id // empty'
+}
+
+# 기존 webhook 목록 조회
+list_webhooks() {
+    local team_id="$1"
+    mm_api GET "/api/v4/hooks/outgoing?team_id=${team_id}&per_page=200"
+}
+
+# outgoing webhook 생성
+create_webhook() {
+    local team_id="$1"
+    local channel_id="$2"
+    local channel_name="$3"
+    local display_name="dalbridge-${channel_name}"
+
+    # 이미 존재하는지 확인
+    local existing
+    existing=$(list_webhooks "$team_id" | jq -r --arg name "$display_name" '.[] | select(.display_name == $name) | .id')
+    if [ -n "$existing" ]; then
+        log "webhook already exists for ${channel_name} (id: ${existing}), skipping"
+        return
+    fi
+
+    local payload
+    payload=$(jq -n \
+        --arg team_id "$team_id" \
+        --arg channel_id "$channel_id" \
+        --arg display_name "$display_name" \
+        --arg callback "$DALBRIDGE_CALLBACK" \
+        --arg desc "dalbridge relay for #${channel_name}" \
+        '{
+            team_id: $team_id,
+            channel_id: $channel_id,
+            display_name: $display_name,
+            description: $desc,
+            callback_urls: [$callback],
+            content_type: "application/json",
+            trigger_when: 0
+        }')
+
+    local result
+    result=$(mm_api POST "/api/v4/hooks/outgoing" -d "$payload")
+    local webhook_id
+    webhook_id=$(echo "$result" | jq -r '.id // empty')
+
+    if [ -n "$webhook_id" ]; then
+        log "created webhook for #${channel_name} (id: ${webhook_id})"
+    else
+        err "failed to create webhook for #${channel_name}: $(echo "$result" | jq -r '.message // .error // "unknown error"')"
+    fi
+}
+
+main() {
+    if [ -z "$MM_TOKEN" ]; then
+        err "MM_TOKEN is required. Set it to a Mattermost admin token."
+        err "  export MM_TOKEN=<your-admin-token>"
+        exit 1
+    fi
+
+    log "Setting up outgoing webhooks (CT: ${CT_ID}, team: ${MM_TEAM})"
+
+    local team_id
+    team_id=$(get_team_id)
+    if [ -z "$team_id" ] || [ "$team_id" = "null" ]; then
+        err "Team '${MM_TEAM}' not found"
+        exit 1
+    fi
+    log "Team ID: ${team_id}"
+
+    # 각 팀 채널에 webhook 생성
+    local channels=(dalcenter veilkey-v2 veilkey-selfhosted bridge-of-gaya-script dal-qa-team host)
+    for ch in "${channels[@]}"; do
+        local channel_id
+        channel_id=$(get_channel_id "$team_id" "$ch")
+        if [ -z "$channel_id" ]; then
+            warn "channel #${ch} not found, skipping"
+            continue
+        fi
+        create_webhook "$team_id" "$channel_id" "$ch"
+    done
+
+    log "Webhook setup complete"
+}
+
+main


### PR DESCRIPTION
## Summary
- dalroot 알림 인프라를 수동 설치에서 레포 코드화로 전환
- `cmd/dalbridge/`: MM outgoing webhook → SSE stream 릴레이 (Go, 표준 라이브러리만 사용)
- `proxmox-host-setup/dalroot/`: 호스트 스크립트 5종 + systemd 서비스 + 설치 자동화
- `setup-webhooks.sh`: 각 팀 채널별 MM outgoing webhook 자동 생성

## 변경 내역

### cmd/dalbridge/main.go
- Mattermost outgoing webhook POST `/webhook` 수신
- SSE stream GET `/stream` 릴레이
- 헬스체크 GET `/health`
- broker 패턴으로 다중 클라이언트 지원

### proxmox-host-setup/dalroot/
| 파일 | 설명 |
|------|------|
| `dalroot-id` | tmux pane 역추적으로 `dalroot-{session}-{window}-{pane}` ID 생성 |
| `dalroot-check-notifications` | inbox에서 unread 알림 읽기 (Claude Code hook) |
| `dalroot-register` | SessionStart hook — inbox 생성 + MM 등록 |
| `dalroot-task` | dalcenter task 래퍼 (팀 라우팅 + callback) |
| `dalroot-listener` | dalbridge SSE stream 구독 → 멘션 감지 → inbox 전달 |
| `install.sh` | 호스트 + CT dalbridge 설치 자동화 |
| `setup-webhooks.sh` | MM outgoing webhook 채널별 자동 생성 |
| `dalroot-listener.service` | listener systemd 서비스 |
| `dalbridge.service` | dalbridge systemd 서비스 |

## Test plan
- [ ] `go vet ./cmd/dalbridge/` 통과 확인
- [ ] `go build ./cmd/dalbridge/` 빌드 확인
- [ ] 호스트에서 `./install.sh --host` 실행 — 스크립트 설치 확인
- [ ] CT 202에서 `./install.sh --bridge` 실행 — dalbridge 설치 확인
- [ ] dalbridge `/health` 엔드포인트 응답 확인
- [ ] MM outgoing webhook → dalbridge → SSE stream 메시지 흐름 검증
- [ ] dalroot-listener가 멘션 감지 후 inbox에 파일 생성하는지 확인

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)