### PR TITLE
fix: MM 팀명 기본값 prelik → dalsoop 수정

### DIFF
--- a/internal/daemon/matterbridge.go
+++ b/internal/daemon/matterbridge.go
@@ -135,7 +135,7 @@ func (d *Daemon) resolveMMChannelID(mmURL, mmToken string) string {
 	// Resolve team ID first
 	mmTeam := os.Getenv("DALCENTER_MM_TEAM")
 	if mmTeam == "" {
-		mmTeam = "prelik"
+		mmTeam = "dalsoop"
 	}
 
 	url := fmt.Sprintf("%s/api/v4/teams/name/%s/channels/name/%s", strings.TrimRight(mmURL, "/"), mmTeam, channelName)

--- a/proxmox-host-setup/dalroot/setup-webhooks.sh
+++ b/proxmox-host-setup/dalroot/setup-webhooks.sh
@@ -9,14 +9,14 @@
 # 환경변수:
 #   MM_URL    — Mattermost URL (default: http://localhost:8065)
 #   MM_TOKEN  — Mattermost admin token (필수)
-#   MM_TEAM   — Team slug (default: prelik)
+#   MM_TEAM   — Team slug (default: dalsoop)
 
 set -euo pipefail
 
 CT_ID="${1:-202}"
 MM_URL="${MM_URL:-http://localhost:8065}"
 MM_TOKEN="${MM_TOKEN:-}"
-MM_TEAM="${MM_TEAM:-prelik}"
+MM_TEAM="${MM_TEAM:-dalsoop}"
 DALBRIDGE_CALLBACK="${DALBRIDGE_CALLBACK:-http://localhost:4280/webhook}"
 
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- Matterbridge가 존재하지 않는 MM 팀 `prelik`에 연결 시도하여 `Team 'prelik' not found in []` 에러 발생
- `internal/daemon/matterbridge.go`와 `proxmox-host-setup/dalroot/setup-webhooks.sh`의 기본 팀명을 `dalsoop`으로 수정

Closes #589

## 호스트 작업 (코드 외)
- [ ] `/etc/dalcenter/proxmox-host-setup.matterbridge.toml`에서 `Team = "prelik"` → `Team = "dalsoop"` 수정
- [ ] `systemctl restart dalcenter@proxmox-host-setup` 재기동
- [ ] `dalroot-tell proxmox-host-setup '@leader 테스트'`로 통신 확인

## Test plan
- [ ] `go vet ./...` 통과
- [ ] `go test ./internal/daemon/...` 통과
- [ ] 호스트에서 TOML 수정 후 서비스 재기동하여 Matterbridge 팀 연결 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)