### PR TITLE
fix: gateway 기반 stream 격리 (#590)

### DIFF
--- a/internal/bridge/matterbridge.go
+++ b/internal/bridge/matterbridge.go
@@ -148,7 +148,7 @@ func (mb *MatterbridgeBridge) stream() {
 // streamOnce opens a single streaming connection and reads messages until
 // the connection drops or done is closed.
 func (mb *MatterbridgeBridge) streamOnce() error {
-	req, err := http.NewRequest("GET", mb.URL+"/api/stream", nil)
+	req, err := http.NewRequest("GET", mb.URL+"/api/stream?gateway="+mb.Gateway, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -983,7 +983,7 @@ func (d *Daemon) bridgePost(text, username string) error {
 	if d.bridgeURL == "" {
 		return fmt.Errorf("bridge URL not configured")
 	}
-	body := fmt.Sprintf(`{"text":%q,"username":%q,"gateway":"dal-team"}`, text, username)
+	body := fmt.Sprintf(`{"text":%q,"username":%q,"gateway":%q}`, text, username, "dal-"+filepath.Base(d.serviceRepo))
 	req, _ := http.NewRequest("POST", d.bridgeURL+"/api/message", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -1128,7 +1128,7 @@ func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]strin
 		"dal_name":   c.DalName,
 		"uuid":       c.UUID,
 		"bridge_url": bridgeURLForContainer(d.bridgeURL),
-		"gateway":    "dal-team",
+		"gateway":    "dal-" + filepath.Base(d.serviceRepo),
 	}
 
 	// Inject team member names so leader can mention them correctly

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -9,6 +9,7 @@ import (
 func TestHandleAgentConfig_Found(t *testing.T) {
 	d := &Daemon{
 		bridgeURL: "http://bridge:4242",
+		serviceRepo: "/root/test-repo",
 		containers: map[string]*Container{
 			"story-checker": {
 				DalName: "story-checker",
@@ -35,7 +36,7 @@ func TestHandleAgentConfig_Found(t *testing.T) {
 	if resp["bridge_url"] != "http://bridge:4242" {
 		t.Errorf("bridge_url = %q", resp["bridge_url"])
 	}
-	if resp["gateway"] != "dal-team" {
+	if resp["gateway"] != "dal-test-repo" {
 		t.Errorf("gateway = %q", resp["gateway"])
 	}
 }


### PR DESCRIPTION
## Bug

dalbridge가 모든 채널 메시지를 모든 팀에 broadcast → 5개 팀 leader가 전부 응답.

## Fix

- daemon: gateway를 `dal-{repo_name}`으로 변경 (기존 `dal-team` 고정)
- matterbridge.go: stream URL에 `?gateway=` 파라미터 추가
- dalbridge: gateway 필터 기반으로 해당 클라이언트에만 전달

## Test

dalcenter에 ping → dalcenter leader만 pong 1개 응답 확인.

Closes #590