### PR TITLE
fix: gateway 이름 dal- 접두어 중복 방지 (#593)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -983,7 +983,7 @@ func (d *Daemon) bridgePost(text, username string) error {
 	if d.bridgeURL == "" {
 		return fmt.Errorf("bridge URL not configured")
 	}
-	body := fmt.Sprintf(`{"text":%q,"username":%q,"gateway":%q}`, text, username, "dal-"+filepath.Base(d.serviceRepo))
+	body := fmt.Sprintf(`{"text":%q,"username":%q,"gateway":%q}`, text, username, gatewayName(d.serviceRepo))
 	req, _ := http.NewRequest("POST", d.bridgeURL+"/api/message", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
@@ -996,6 +996,16 @@ func (d *Daemon) bridgePost(text, username string) error {
 		return fmt.Errorf("bridge %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil
+}
+
+// gatewayName returns the matterbridge gateway name for a service repo path.
+// It ensures exactly one "dal-" prefix even if the repo basename already starts with "dal-".
+func gatewayName(serviceRepo string) string {
+	base := filepath.Base(serviceRepo)
+	if strings.HasPrefix(base, "dal-") {
+		return base
+	}
+	return "dal-" + base
 }
 
 // reconcile discovers existing dal-* containers and restores daemon state.
@@ -1128,7 +1138,7 @@ func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]strin
 		"dal_name":   c.DalName,
 		"uuid":       c.UUID,
 		"bridge_url": bridgeURLForContainer(d.bridgeURL),
-		"gateway":    "dal-" + filepath.Base(d.serviceRepo),
+		"gateway":    gatewayName(d.serviceRepo),
 	}
 
 	// Inject team member names so leader can mention them correctly

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -57,6 +57,29 @@ func TestHandleAgentConfig_NotFound(t *testing.T) {
 	}
 }
 
+func TestHandleAgentConfig_DalPrefixRepo(t *testing.T) {
+	d := &Daemon{
+		bridgeURL:   "http://bridge:4242",
+		serviceRepo: "/root/dal-proxmox-host-setup",
+		containers: map[string]*Container{
+			"dev": {DalName: "dev"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/agent-config/dev", nil)
+	req.SetPathValue("name", "dev")
+	w := httptest.NewRecorder()
+
+	d.handleAgentConfig(w, req)
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["gateway"] != "dal-proxmox-host-setup" {
+		t.Errorf("gateway = %q, want %q (should not double dal- prefix)", resp["gateway"], "dal-proxmox-host-setup")
+	}
+}
+
 func TestHandleAgentConfig_NoBridge(t *testing.T) {
 	d := &Daemon{
 		containers: map[string]*Container{


### PR DESCRIPTION
## Summary
- PHS leader 컨테이너 메시지 수신 불응답 버그 수정 (#593)
- `serviceRepo`가 이미 `dal-`로 시작하는 경우 (`dal-proxmox-host-setup`) gateway 이름이 `dal-dal-proxmox-host-setup`으로 이중 접두어가 붙는 문제
- `gatewayName()` 헬퍼 함수 도입으로 정확히 한 번만 `dal-` 접두어 적용

## Changes
- `internal/daemon/daemon.go`: `gatewayName()` 함수 추가, `bridgePost`와 `agentConfigResponse`에서 사용
- `internal/daemon/daemon_agentconfig_test.go`: `dal-` 접두어 리포에 대한 테스트 추가

## Test plan
- [ ] `TestHandleAgentConfig_DalPrefixRepo` 통과 확인
- [ ] PHS leader 컨테이너에서 메시지 수신 정상 동작 확인

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)