### PR TITLE
fix: dalcli run bridge stream 엔드포인트 및 gateway 필터링 수정 (#593)

### DIFF
--- a/cmd/dalbridge/main.go
+++ b/cmd/dalbridge/main.go
@@ -143,6 +143,8 @@ func main() {
 			return
 		}
 
+		gatewayFilter := r.URL.Query().Get("gateway")
+
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
@@ -155,7 +157,7 @@ func main() {
 		fmt.Fprintf(w, "data: {\"event\":\"connected\"}\n\n")
 		flusher.Flush()
 
-		log.Printf("[stream] client connected (%d total)", b.clientCount())
+		log.Printf("[stream] client connected (gateway=%q, %d total)", gatewayFilter, b.clientCount())
 		defer func() {
 			log.Printf("[stream] client disconnected (%d remaining)", b.clientCount())
 		}()
@@ -168,6 +170,15 @@ func main() {
 			case data, ok := <-ch:
 				if !ok {
 					return
+				}
+				// gateway 필터링: 파라미터가 있으면 해당 채널만 전달
+				if gatewayFilter != "" {
+					var msg struct {
+						Channel string `json:"channel"`
+					}
+					if json.Unmarshal(data, &msg) == nil && msg.Channel != gatewayFilter {
+						continue
+					}
 				}
 				fmt.Fprintf(w, "data: %s\n\n", data)
 				flusher.Flush()

--- a/internal/bridge/matterbridge.go
+++ b/internal/bridge/matterbridge.go
@@ -148,7 +148,7 @@ func (mb *MatterbridgeBridge) stream() {
 // streamOnce opens a single streaming connection and reads messages until
 // the connection drops or done is closed.
 func (mb *MatterbridgeBridge) streamOnce() error {
-	req, err := http.NewRequest("GET", mb.URL+"/api/stream?gateway="+mb.Gateway, nil)
+	req, err := http.NewRequest("GET", mb.URL+"/stream?gateway="+mb.Gateway, nil)
 	if err != nil {
 		return err
 	}
@@ -202,6 +202,10 @@ func (mb *MatterbridgeBridge) streamOnce() error {
 			continue
 		}
 		if raw.Username == mb.BotUsername {
+			continue
+		}
+		// Client-side gateway filter — defense against server not filtering.
+		if raw.Gateway != "" && raw.Gateway != mb.Gateway {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- **엔드포인트 경로 수정**: `internal/bridge/matterbridge.go`에서 `/api/stream` → `/stream`으로 변경 — dalbridge 서버의 실제 엔드포인트와 일치시킴
- **서버 측 gateway 필터링**: `cmd/dalbridge/main.go`에서 `?gateway=` 쿼리 파라미터 기반 채널 필터링 추가
- **클라이언트 측 방어 필터**: `matterbridge.go`에서 gateway 불일치 메시지 무시하는 방어 로직 추가

Closes #593

## Test plan
- [ ] `dalcli run bridge` 실행 후 stream 메시지 정상 수신 확인
- [ ] gateway 필터링으로 팀별 채널 메시지만 수신되는지 확인
- [ ] `go vet ./...` 통과 확인
- [ ] `go test ./...` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)