### PR TITLE
feat: dal.cue에 description 필드 추가

### DIFF
--- a/.dal/dal.spec.cue
+++ b/.dal/dal.spec.cue
@@ -29,6 +29,7 @@
 	workspace?:      string
 	branch?:         #BranchConfig
 	setup?:          #SetupConfig
+	description?:    string
 	job?:            string // JOB UUID 참조
 	git?: {
 		user?:         string

--- a/.dal/template/dal/dal.cue
+++ b/.dal/template/dal/dal.cue
@@ -1,5 +1,6 @@
 uuid:    "99ab0934-07fb-423f-84e6-1ce8aef91919"
 name:    "dal"
+description: "문서 관리자 — inbox 병합, history 압축, 자동 커밋"
 version: "1.0.0"
 player:  "claude"
 model:   "haiku"

--- a/.dal/template/dalops/dal.cue
+++ b/.dal/template/dalops/dal.cue
@@ -1,5 +1,6 @@
 uuid:    "c9380496-8203-44e4-9025-6e624e95cb67"
 name:    "dalops"
+description: "CCW 기반 오케스트레이터 — 코드 구현, 리뷰, 테스트 워크플로우"
 version: "1.0.0"
 player:  "claude"
 role:    "ops"

--- a/cmd/dalcli/main.go
+++ b/cmd/dalcli/main.go
@@ -81,7 +81,7 @@ func psCmd() *cobra.Command {
 				return nil
 			}
 			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tIDLE\tLAST SEEN")
+			fmt.Fprintln(w, "NAME\tPLAYER\tROLE\tSTATUS\tIDLE\tLAST SEEN\tDESCRIPTION")
 			for _, c := range containers {
 				idle := c.IdleFor
 				if idle == "" {
@@ -91,7 +91,11 @@ func psCmd() *cobra.Command {
 				if !c.LastSeenAt.IsZero() {
 					lastSeen = c.LastSeenAt.Local().Format("2006-01-02 15:04:05")
 				}
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status, idle, lastSeen)
+				desc := c.Description
+				if desc == "" {
+					desc = "-"
+				}
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", c.DalName, c.Player, c.Role, c.Status, idle, lastSeen, desc)
 			}
 			w.Flush()
 			return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -58,6 +58,7 @@ type Container struct {
 	UUID        string    `json:"uuid"`
 	Player      string    `json:"player"`
 	Role        string    `json:"role"`
+	Description string    `json:"description,omitempty"`
 	ContainerID string    `json:"container_id"`
 	Status      string    `json:"status"`    // "running", "stopped"
 	Workspace   string    `json:"workspace"` // "shared" or "clone"
@@ -393,6 +394,7 @@ func (d *Daemon) handleStatusOne(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"uuid":         dal.UUID,
 		"name":         dal.Name,
+		"description":  dal.Description,
 		"player":       dal.Player,
 		"role":         dal.Role,
 		"skills":       dal.Skills,
@@ -465,6 +467,7 @@ func (d *Daemon) handleWake(w http.ResponseWriter, r *http.Request) {
 		UUID:        dal.UUID,
 		Player:      dal.Player,
 		Role:        dal.Role,
+		Description: dal.Description,
 		ContainerID: containerID,
 		Status:      "running",
 		Workspace:   ws,
@@ -681,6 +684,7 @@ func (d *Daemon) runSync() (synced, restarted []string) {
 				UUID:        dal.UUID,
 				Player:      dal.Player,
 				Role:        dal.Role,
+				Description: dal.Description,
 				ContainerID: newID,
 				Status:      "running",
 				Skills:      len(dal.Skills),
@@ -1064,6 +1068,7 @@ func (d *Daemon) reconcile() {
 				UUID:        dal.UUID,
 				Player:      dal.Player,
 				Role:        dal.Role,
+				Description: dal.Description,
 				ContainerID: c.ID,
 				Status:      "running",
 				Skills:      len(dal.Skills),

--- a/internal/daemon/leader_watcher.go
+++ b/internal/daemon/leader_watcher.go
@@ -183,6 +183,7 @@ func (d *Daemon) restartLeader(name string) error {
 		UUID:        dal.UUID,
 		Player:      dal.Player,
 		Role:        dal.Role,
+		Description: dal.Description,
 		ContainerID: containerID,
 		Status:      "running",
 		Workspace:   ws,

--- a/internal/localdal/localdal.go
+++ b/internal/localdal/localdal.go
@@ -46,6 +46,7 @@ type SetupConfig struct {
 type DalProfile struct {
 	UUID           string
 	Name           string
+	Description    string
 	Version        string
 	Player         string
 	FallbackPlayer string // fallback player when primary fails (empty = auto-detect)
@@ -427,6 +428,9 @@ func ReadDalCue(path, folderName string) (*DalProfile, error) {
 	if p.Name == "" {
 		p.Name = folderName
 	}
+	if v := val.LookupPath(cue.ParsePath("description")); v.Exists() {
+		p.Description, _ = v.String()
+	}
 	if v := val.LookupPath(cue.ParsePath("version")); v.Exists() {
 		p.Version, _ = v.String()
 	}
@@ -759,6 +763,7 @@ const defaultSpec = `// dal.spec.cue — localdal schema
 	workspace?:      string
 	branch?:         #BranchConfig
 	setup?:          #SetupConfig
+	description?:    string
 	max_members?:    int & >=0
 	git?: {
 		user?:         string


### PR DESCRIPTION
## Summary
- `#DalProfile` CUE 스키마 및 Go 구조체에 `description?: string` optional 필드 추가
- `/api/status`, `/api/status/{name}`, `/api/ps` JSON 응답에 description 포함
- `dalcli ps` 출력에 DESCRIPTION 컬럼 추가 (빈 값은 `-` 표시)
- `.dal/template/dal/dal.cue`, `.dal/template/dalops/dal.cue`에 description 값 추가

## Test plan
- [ ] `go build ./...` 성공
- [ ] `go vet ./...` 성공
- [ ] `dalcli ps` 실행 시 DESCRIPTION 컬럼 표시 확인
- [ ] `/api/status` 응답에 description 필드 포함 확인

Closes #604

🤖 Generated with [Claude Code](https://claude.com/claude-code)