### PR TITLE
feat: leader 큐 관리 goroutine 구현

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -183,6 +183,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start leader health watcher (auto-recovery)
 	go d.startLeaderWatcher(ctx)
 
+	// Start queue manager (task expiry + concurrency limits)
+	go d.startQueueManager(ctx)
+
 	if d.bridgeURL != "" {
 		log.Printf("[daemon] matterbridge URL: %s", d.bridgeURL)
 	}

--- a/internal/daemon/queue_manager.go
+++ b/internal/daemon/queue_manager.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+const (
+	queueCheckInterval = 60 * time.Second
+	taskExpireTimeout  = 10 * time.Minute
+
+	// maxRunningLeader is the max concurrent running tasks for a leader dal.
+	maxRunningLeader = 1
+	// maxRunningMember is the max concurrent running tasks for a member dal.
+	maxRunningMember = 2
+)
+
+// startQueueManager runs a goroutine that periodically:
+// 1. Expires running tasks that have exceeded taskExpireTimeout.
+// 2. Enforces per-dal concurrency limits based on role.
+func (d *Daemon) startQueueManager(ctx context.Context) {
+	log.Printf("[queue-manager] started (interval=%s, expire=%s, leader=%d, member=%d)",
+		queueCheckInterval, taskExpireTimeout, maxRunningLeader, maxRunningMember)
+
+	ticker := time.NewTicker(queueCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[queue-manager] stopped")
+			return
+		case <-ticker.C:
+			d.expireStaleTasks()
+		}
+	}
+}
+
+// expireStaleTasks finds running tasks older than taskExpireTimeout and marks them failed.
+func (d *Daemon) expireStaleTasks() {
+	now := time.Now().UTC()
+	for _, tr := range d.tasks.List() {
+		if tr.Status != "running" {
+			continue
+		}
+		if now.Sub(tr.StartedAt) <= taskExpireTimeout {
+			continue
+		}
+		expired := d.tasks.Complete(tr.ID, "failed", "", "expired: running longer than "+taskExpireTimeout.String())
+		if expired != nil {
+			log.Printf("[queue-manager] expired task %s (dal=%s, age=%s)", tr.ID, tr.Dal, now.Sub(tr.StartedAt).Truncate(time.Second))
+
+			dispatchWebhook(WebhookEvent{
+				Event:     "task_expired",
+				Dal:       tr.Dal,
+				Task:      truncateStr(tr.Task, 200),
+				Error:     "expired after " + taskExpireTimeout.String(),
+				Timestamp: now.Format(time.RFC3339),
+			})
+		}
+	}
+}
+
+// runningTaskCount returns the number of currently running tasks for a given dal.
+func (d *Daemon) runningTaskCount(dalName string) int {
+	count := 0
+	for _, tr := range d.tasks.List() {
+		if tr.Dal == dalName && tr.Status == "running" {
+			count++
+		}
+	}
+	return count
+}
+
+// maxRunningForDal returns the concurrency limit based on the dal's role.
+func (d *Daemon) maxRunningForDal(dalName string) int {
+	d.mu.RLock()
+	c, ok := d.containers[dalName]
+	d.mu.RUnlock()
+	if !ok {
+		return maxRunningMember // default to member limit
+	}
+	if c.Role == "leader" {
+		return maxRunningLeader
+	}
+	return maxRunningMember
+}
+
+// canAcceptTask checks whether a dal can accept a new task based on concurrency limits.
+func (d *Daemon) canAcceptTask(dalName string) bool {
+	return d.runningTaskCount(dalName) < d.maxRunningForDal(dalName)
+}

--- a/internal/daemon/task.go
+++ b/internal/daemon/task.go
@@ -221,6 +221,14 @@ func (d *Daemon) handleTaskStart(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "dal and task are required", http.StatusBadRequest)
 		return
 	}
+
+	// Enforce per-dal concurrency limit
+	if !d.canAcceptTask(req.Dal) {
+		max := d.maxRunningForDal(req.Dal)
+		http.Error(w, fmt.Sprintf("dal %q has reached max concurrent tasks (%d)", req.Dal, max), http.StatusTooManyRequests)
+		return
+	}
+
 	tr := d.tasks.New(req.Dal, req.Task)
 	respondJSON(w, http.StatusAccepted, map[string]string{
 		"task_id": tr.ID,
@@ -334,6 +342,13 @@ func (d *Daemon) handleTask(w http.ResponseWriter, r *http.Request) {
 	// Role-aware warning: member dals should receive tasks via leader routing
 	if c.Role == "member" {
 		log.Printf("[scope] ⚠️ direct task to member %q — prefer leader routing via dalcli-leader assign", req.Dal)
+	}
+
+	// Enforce per-dal concurrency limit
+	if !d.canAcceptTask(req.Dal) {
+		max := d.maxRunningForDal(req.Dal)
+		http.Error(w, fmt.Sprintf("dal %q has reached max concurrent tasks (%d)", req.Dal, max), http.StatusTooManyRequests)
+		return
 	}
 
 	tr := d.tasks.New(req.Dal, req.Task)


### PR DESCRIPTION
## Summary
- `internal/daemon/queue_manager.go` 신규 생성 — daemon `Run()`에서 goroutine 시작
- 60초 주기로 running 상태가 10분 초과된 task를 자동 expire (failed 처리 + webhook 발송)
- dal당 동시 running task 제한: leader=1, member=2
- `POST /api/task`, `POST /api/task/start` 양쪽 모두 concurrency limit 초과 시 HTTP 429 반환

Closes #611

## Test plan
- [ ] leader dal에 task 1개 실행 중 추가 task 요청 시 429 반환 확인
- [ ] member dal에 task 2개 실행 중 추가 task 요청 시 429 반환 확인
- [ ] running task가 10분 초과 시 자동 expired → failed 전환 확인
- [ ] go vet ./... + go test ./... 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)