### PR TITLE
feat: ops watcher — 전체 팀 헬스 폴링 + dal 0 자동 wake

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -191,6 +191,11 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// Start queue manager (task expiry + concurrency limits)
 	go d.startQueueManager(ctx)
 
+	// Start ops watcher (poll all teams, auto-wake empty teams)
+	if opsWatcherEnabled() {
+		go d.startOpsWatcher(ctx)
+	}
+
 	if d.bridgeURL != "" {
 		log.Printf("[daemon] matterbridge URL: %s", d.bridgeURL)
 	}

--- a/internal/daemon/ops_watcher.go
+++ b/internal/daemon/ops_watcher.go
@@ -1,0 +1,223 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dalsoop/dalcenter/internal/paths"
+)
+
+const (
+	opsCheckInterval = 2 * time.Minute
+	opsCheckTimeout  = 10 * time.Second
+)
+
+// teamEndpoint holds the team name and its dalcenter API URL.
+type teamEndpoint struct {
+	Name string
+	URL  string
+}
+
+// healthResponse is the JSON shape returned by /api/health.
+type healthResponse struct {
+	Status       string `json:"status"`
+	DalsRunning  int    `json:"dals_running"`
+	RepoCount    int    `json:"repo_count"`
+	LeaderStatus string `json:"leader_status"`
+}
+
+// startOpsWatcher polls all team dalcenter instances and auto-wakes
+// leaders for teams that have zero running dals.
+func (d *Daemon) startOpsWatcher(ctx context.Context) {
+	log.Printf("[ops-watcher] started (interval=%s)", opsCheckInterval)
+
+	ticker := time.NewTicker(opsCheckInterval)
+	defer ticker.Stop()
+
+	client := &http.Client{Timeout: opsCheckTimeout}
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Printf("[ops-watcher] stopped")
+			return
+		case <-ticker.C:
+			d.opsCheck(client)
+		}
+	}
+}
+
+// opsCheck discovers all teams and checks each one's health.
+func (d *Daemon) opsCheck(client *http.Client) {
+	teams := discoverTeams()
+	if len(teams) == 0 {
+		log.Printf("[ops-watcher] no teams discovered — skipping")
+		return
+	}
+
+	for _, team := range teams {
+		if err := d.opsCheckTeam(client, team); err != nil {
+			log.Printf("[ops-watcher] %s: %v", team.Name, err)
+		}
+	}
+}
+
+// opsCheckTeam checks a single team's health and auto-wakes leader if needed.
+func (d *Daemon) opsCheckTeam(client *http.Client, team teamEndpoint) error {
+	health, err := fetchHealth(client, team.URL)
+	if err != nil {
+		return fmt.Errorf("health check failed: %w", err)
+	}
+
+	if health.DalsRunning > 0 {
+		return nil
+	}
+
+	// Zero dals running — check if this team has a leader to wake
+	if health.LeaderStatus == "not_configured" {
+		log.Printf("[ops-watcher] %s: no leader configured — skipping", team.Name)
+		return nil
+	}
+
+	log.Printf("[ops-watcher] %s: 0 dals running, leader_status=%s — attempting wake",
+		team.Name, health.LeaderStatus)
+
+	if err := wakeLeaderRemote(client, team.URL); err != nil {
+		d.postAlert(fmt.Sprintf(":warning: **ops-watcher**: team `%s` has 0 dals and leader wake failed: %v", team.Name, err))
+		return fmt.Errorf("wake leader: %w", err)
+	}
+
+	log.Printf("[ops-watcher] %s: leader wake request sent", team.Name)
+	d.postAlert(fmt.Sprintf(":rocket: **ops-watcher**: team `%s` had 0 dals — leader auto-waked", team.Name))
+	return nil
+}
+
+// fetchHealth calls GET /api/health on a dalcenter instance.
+func fetchHealth(client *http.Client, baseURL string) (*healthResponse, error) {
+	resp, err := client.Get(baseURL + "/api/health")
+	if err != nil {
+		return nil, fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %d", resp.StatusCode)
+	}
+
+	var h healthResponse
+	if err := json.NewDecoder(resp.Body).Decode(&h); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &h, nil
+}
+
+// wakeLeaderRemote sends POST /api/wake/{leader} to a remote dalcenter.
+// It first discovers the leader name from /api/ps or /api/health context,
+// then calls the wake endpoint.
+func wakeLeaderRemote(client *http.Client, baseURL string) error {
+	// Discover leader name by calling GET /api/status
+	leaderName, err := findRemoteLeader(client, baseURL)
+	if err != nil {
+		return fmt.Errorf("find leader: %w", err)
+	}
+
+	token := os.Getenv("DALCENTER_TOKEN")
+	req, err := http.NewRequest("POST", baseURL+"/api/wake/"+leaderName, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("wake returned %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// findRemoteLeader queries a dalcenter's /api/status to find the leader dal name.
+func findRemoteLeader(client *http.Client, baseURL string) (string, error) {
+	resp, err := client.Get(baseURL + "/api/status")
+	if err != nil {
+		return "", fmt.Errorf("request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var statuses []struct {
+		Name string `json:"Name"`
+		Role string `json:"Role"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&statuses); err != nil {
+		return "", fmt.Errorf("decode: %w", err)
+	}
+
+	for _, s := range statuses {
+		if s.Role == "leader" {
+			return s.Name, nil
+		}
+	}
+	return "", fmt.Errorf("no leader found in status response")
+}
+
+// discoverTeams reads /etc/dalcenter/*.env to build a list of team endpoints.
+// Same discovery pattern as the TUI's discoverAddrs.
+func discoverTeams() []teamEndpoint {
+	hostIP := "localhost"
+	commonData, err := os.ReadFile(filepath.Join(paths.ConfigDir(), "common.env"))
+	if err == nil {
+		for _, line := range strings.Split(string(commonData), "\n") {
+			if strings.HasPrefix(line, "DALCENTER_HOST_IP=") {
+				hostIP = strings.TrimPrefix(line, "DALCENTER_HOST_IP=")
+				break
+			}
+		}
+	}
+
+	entries, err := os.ReadDir(paths.ConfigDir())
+	if err != nil {
+		return nil
+	}
+
+	var teams []teamEndpoint
+	for _, e := range entries {
+		if e.Name() == "common.env" || !strings.HasSuffix(e.Name(), ".env") {
+			continue
+		}
+		teamName := strings.TrimSuffix(e.Name(), ".env")
+		data, err := os.ReadFile(filepath.Join(paths.ConfigDir(), e.Name()))
+		if err != nil {
+			continue
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if strings.HasPrefix(line, "DALCENTER_PORT=") {
+				port := strings.TrimPrefix(line, "DALCENTER_PORT=")
+				teams = append(teams, teamEndpoint{
+					Name: teamName,
+					URL:  "http://" + hostIP + ":" + port,
+				})
+				break
+			}
+		}
+	}
+	return teams
+}
+
+// opsWatcherEnabled returns true when the ops watcher env var is set.
+func opsWatcherEnabled() bool {
+	return os.Getenv("DALCENTER_OPS_WATCHER") == "1"
+}
+

--- a/internal/daemon/ops_watcher_test.go
+++ b/internal/daemon/ops_watcher_test.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFetchHealth(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/health" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":        "ok",
+			"dals_running":  2,
+			"repo_count":    3,
+			"leader_status": "running",
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	h, err := fetchHealth(client, srv.URL)
+	if err != nil {
+		t.Fatalf("fetchHealth error: %v", err)
+	}
+	if h.DalsRunning != 2 {
+		t.Fatalf("dals_running = %d, want 2", h.DalsRunning)
+	}
+	if h.LeaderStatus != "running" {
+		t.Fatalf("leader_status = %q, want 'running'", h.LeaderStatus)
+	}
+}
+
+func TestFetchHealth_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", 500)
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	_, err := fetchHealth(client, srv.URL)
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestFindRemoteLeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"Name": "dev", "Role": "member"},
+			{"Name": "dal-leader", "Role": "leader"},
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	name, err := findRemoteLeader(client, srv.URL)
+	if err != nil {
+		t.Fatalf("findRemoteLeader error: %v", err)
+	}
+	if name != "dal-leader" {
+		t.Fatalf("name = %q, want 'dal-leader'", name)
+	}
+}
+
+func TestFindRemoteLeader_NoLeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]any{
+			{"Name": "dev", "Role": "member"},
+		})
+	}))
+	defer srv.Close()
+
+	client := srv.Client()
+	_, err := findRemoteLeader(client, srv.URL)
+	if err == nil {
+		t.Fatal("expected error when no leader in response")
+	}
+}
+
+func TestOpsCheckTeam_HealthyTeam(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":        "ok",
+			"dals_running":  1,
+			"leader_status": "running",
+		})
+	}))
+	defer srv.Close()
+
+	d := &Daemon{containers: map[string]*Container{}}
+	err := d.opsCheckTeam(srv.Client(), teamEndpoint{Name: "test", URL: srv.URL})
+	if err != nil {
+		t.Fatalf("expected nil error for healthy team, got: %v", err)
+	}
+}
+
+func TestOpsCheckTeam_NoLeaderConfigured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"status":        "ok",
+			"dals_running":  0,
+			"leader_status": "not_configured",
+		})
+	}))
+	defer srv.Close()
+
+	d := &Daemon{containers: map[string]*Container{}}
+	err := d.opsCheckTeam(srv.Client(), teamEndpoint{Name: "test", URL: srv.URL})
+	if err != nil {
+		t.Fatalf("expected nil error when leader not configured, got: %v", err)
+	}
+}
+
+func TestOpsCheckTeam_WakeLeader(t *testing.T) {
+	var wakeRequested bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/health":
+			json.NewEncoder(w).Encode(map[string]any{
+				"status":        "ok",
+				"dals_running":  0,
+				"leader_status": "sleeping",
+			})
+		case "/api/status":
+			json.NewEncoder(w).Encode([]map[string]any{
+				{"Name": "dal-leader", "Role": "leader"},
+			})
+		case "/api/wake/dal-leader":
+			wakeRequested = true
+			json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	d := &Daemon{containers: map[string]*Container{}}
+	err := d.opsCheckTeam(srv.Client(), teamEndpoint{Name: "test", URL: srv.URL})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !wakeRequested {
+		t.Fatal("expected wake request to be sent")
+	}
+}
+
+func TestDiscoverTeams(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", dir)
+
+	// Write common.env
+	os.WriteFile(filepath.Join(dir, "common.env"), []byte("DALCENTER_HOST_IP=10.0.0.1\n"), 0644)
+
+	// Write team env files
+	os.WriteFile(filepath.Join(dir, "team-a.env"), []byte("DALCENTER_PORT=11191\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "team-b.env"), []byte("DALCENTER_PORT=11192\n"), 0644)
+
+	teams := discoverTeams()
+	if len(teams) != 2 {
+		t.Fatalf("len(teams) = %d, want 2", len(teams))
+	}
+
+	// Check that host IP was picked up
+	for _, team := range teams {
+		if team.URL == "" {
+			t.Fatalf("team %s has empty URL", team.Name)
+		}
+		if team.URL != "http://10.0.0.1:11191" && team.URL != "http://10.0.0.1:11192" {
+			t.Fatalf("unexpected URL: %s", team.URL)
+		}
+	}
+}
+
+func TestDiscoverTeams_NoConfigDir(t *testing.T) {
+	t.Setenv("DALCENTER_CONFIG_DIR", "/nonexistent")
+	teams := discoverTeams()
+	if len(teams) != 0 {
+		t.Fatalf("expected 0 teams, got %d", len(teams))
+	}
+}
+
+func TestOpsWatcherEnabled(t *testing.T) {
+	t.Setenv("DALCENTER_OPS_WATCHER", "1")
+	if !opsWatcherEnabled() {
+		t.Fatal("expected enabled")
+	}
+
+	t.Setenv("DALCENTER_OPS_WATCHER", "")
+	if opsWatcherEnabled() {
+		t.Fatal("expected disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/daemon/ops_watcher.go` — 2분 간격으로 `/etc/dalcenter/*.env`에서 팀을 디스커버하고 각 팀의 `/api/health` 폴링
- dal이 0개인 팀 감지 시 `/api/status`에서 leader 이름을 찾아 `/api/wake/{leader}` 자동 호출
- `DALCENTER_OPS_WATCHER=1` 환경변수로 활성화 (기본 비활성)
- `daemon.go`에서 goroutine 시작 연결 완료

Closes #610

## Test plan
- [ ] `TestFetchHealth` — health endpoint 정상 파싱
- [ ] `TestFindRemoteLeader` — status 응답에서 leader 추출
- [ ] `TestOpsCheckTeam_WakeLeader` — 0 dal 팀에 wake 요청 전송 확인
- [ ] `TestDiscoverTeams` — env 파일 기반 팀 디스커버리
- [ ] `TestOpsWatcherEnabled` — 환경변수 플래그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)