### PR TITLE
feat: writing-style 팀 포트 매핑 추가 (#616)

### DIFF
--- a/.dal/dalroot/charter.md
+++ b/.dal/dalroot/charter.md
@@ -48,6 +48,7 @@ pct exec $CT -- dalcenter tell bridge-of-gaya-script "스크립트 검증해"
 | veilkey-selfhosted | 11190 | 6 | dalcenter@veilkey-selfhosted |
 | bridge-of-gaya-script | 11191 | 6 | dalcenter@bridge-of-gaya-script |
 | dal-qa-team | 11194 | 3 | dalcenter@dal-qa-team |
+| writing-style | 11196 | 3 | dalcenter@writing-style |
 
 ### dal 관리 명령
 

--- a/.dal/skills/dal-lifecycle/SKILL.md
+++ b/.dal/skills/dal-lifecycle/SKILL.md
@@ -15,6 +15,7 @@ id: DAL:SKILL:life0001
 | veilkey-v2 | 11193 | dalcenter@veilkey-v2 |
 | dal-qa-team | 11194 | dalcenter@dal-qa-team |
 | emotion-ai | 11195 | 수동 (nsenter) |
+| writing-style | 11196 | dalcenter@writing-style |
 
 ## Wake / Sleep
 

--- a/proxmox-host-setup/dalroot/dalroot-task
+++ b/proxmox-host-setup/dalroot/dalroot-task
@@ -32,6 +32,7 @@ get_team_port() {
         veilkey-selfhosted)     echo 11190 ;;
         bridge-of-gaya-script)  echo 11191 ;;
         dal-qa-team)            echo 11194 ;;
+        writing-style)          echo 11196 ;;
         *)
             echo "[dalroot-task] unknown team: $team" >&2
             return 1


### PR DESCRIPTION
## Summary
- dalsoop/writing-style 레포 생성 완료 (private, Rust)
- .dal/ 팀 구성: leader(opus), writer(sonnet), editor(sonnet)
- 스킬 3종: user-tone, anti-ai-tone, doc-structure
- dalcenter 레포에 포트 매핑(11196) 추가: dalroot-task, dal-lifecycle, dalroot charter

## 변경 내역
- `proxmox-host-setup/dalroot/dalroot-task` — writing-style → 11196
- `.dal/skills/dal-lifecycle/SKILL.md` — 포트 테이블 추가
- `.dal/dalroot/charter.md` — 관리 대상 레포 테이블 추가

## Test plan
- [ ] dalroot-task writing-style 호출 시 11196 반환 확인
- [ ] dalcenter register로 writing-style 서비스 등록 테스트
- [ ] writing-style 레포에서 dalcenter wake leader 동작 확인

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)