### PR TITLE
docs: dal-control 채널 + 자동화 파이프라인 문서화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,10 +66,13 @@ systemctl restart 'dalcenter@*'
 | doctor | 헬스체크 — 팀/dal 상태 모니터링 |
 | custodian | 자동 커밋 — 정기 정리 작업 |
 | scribe | 메모리 품질 — CLAUDE.md + memory 파일 감사 |
+| scheduled dalroot | 이슈 감시 + 리마인드 — dal-control 채널에 보고 |
 
 ---
 
 ## dal 작업 흐름
+
+### 수동 흐름 (기존)
 
 ```
 이슈 생성 (GitHub)
@@ -78,6 +81,19 @@ systemctl restart 'dalcenter@*'
   → dal이 브랜치 + PR 생성
   → dalroot가 리뷰 후 머지
 ```
+
+### 자동화 파이프라인
+
+```
+사람 (이슈 생성)
+  → scheduled dalroot (감시 + 리마인드)
+  → dal 팀 (구현)
+  → dal-control 채널 (보고)
+  → 사람 (이모지/코멘트로 승인·방향 제시)
+```
+
+scheduled dalroot가 GitHub 이슈를 감시하고, 적절한 dal 팀에 작업을 전달한다.
+결과는 dal-control 채널에 보고되며, 사람이 비동기로 승인/방향을 결정한다.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,6 +112,7 @@ dalcenter sync   # repo-watcher 기다리지 않고 즉시 sync
 ## Mattermost 통신
 
 - 프로젝트당 채널 1개 (serve 시 자동 생성)
+- **dal-control** — 인프라 관제 대시보드 채널. scheduled dalroot가 보고, 사람이 이모지/코멘트로 승인·방향 제시
 - dal별 봇 계정 (wake 시 자동 생성)
 - assign → @mention으로 작업 지시
 - report → [dal-name] 보고


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: scheduled dalroot를 자동화 dal 테이블에 추가, 자동화 파이프라인 흐름(사람→scheduled dalroot→dal 팀→dal-control→사람) 기술
- **architecture.md**: dal-control Mattermost 채널 (인프라 관제 대시보드) 설명 추가

## Context
#618 scheduled dalroot 이슈 관련. 2026-04-01 세션 결과 반영:
- PR #609, #612, #615, PHS#98 머지 완료
- LXC 150 host-ops 팀 신설
- ops-watcher, queue-manager 코드 반영
- QA 검증 8/8 PASS

## Test plan
- [ ] CLAUDE.md 자동화 파이프라인 섹션 정확성 확인
- [ ] architecture.md dal-control 채널 설명 확인
- [ ] 하드코딩된 값 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)