### PR TITLE
fix: dalbridge stream relay — 메시지 유실 수정

### DIFF
--- a/cmd/dalbridge/main.go
+++ b/cmd/dalbridge/main.go
@@ -16,6 +16,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -35,6 +37,7 @@ type streamMessage struct {
 	Text      string `json:"text"`
 	Username  string `json:"username"`
 	Channel   string `json:"channel"`
+	Gateway   string `json:"gateway,omitempty"`
 	PostID    string `json:"post_id"`
 	Timestamp string `json:"timestamp"`
 }
@@ -100,9 +103,27 @@ func main() {
 		}
 
 		var payload webhookPayload
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			http.Error(w, "invalid json", http.StatusBadRequest)
-			return
+		ct := r.Header.Get("Content-Type")
+		switch {
+		case strings.HasPrefix(ct, "application/json"):
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				http.Error(w, "invalid json", http.StatusBadRequest)
+				return
+			}
+		default:
+			// MM outgoing webhook 기본값: application/x-www-form-urlencoded
+			if err := r.ParseForm(); err != nil {
+				http.Error(w, "invalid form", http.StatusBadRequest)
+				return
+			}
+			payload.Token = r.FormValue("token")
+			payload.ChannelName = r.FormValue("channel_name")
+			payload.UserName = r.FormValue("user_name")
+			payload.Text = r.FormValue("text")
+			payload.PostID = r.FormValue("post_id")
+			if ts := r.FormValue("timestamp"); ts != "" {
+				payload.Timestamp, _ = strconv.ParseInt(ts, 10, 64)
+			}
 		}
 
 		// 토큰 검증 (설정된 경우)
@@ -153,8 +174,8 @@ func main() {
 		ch := b.subscribe()
 		defer b.unsubscribe(ch)
 
-		// 연결 확인 메시지
-		fmt.Fprintf(w, "data: {\"event\":\"connected\"}\n\n")
+		// 연결 확인 메시지 (api_connected: matterbridge 호환)
+		fmt.Fprintf(w, "data: {\"event\":\"api_connected\"}\n\n")
 		flusher.Flush()
 
 		log.Printf("[stream] client connected (gateway=%q, %d total)", gatewayFilter, b.clientCount())
@@ -171,12 +192,12 @@ func main() {
 				if !ok {
 					return
 				}
-				// gateway 필터링: 파라미터가 있으면 해당 채널만 전달
+				// gateway 필터링: 파라미터가 있으면 해당 gateway만 전달
 				if gatewayFilter != "" {
 					var msg struct {
-						Channel string `json:"channel"`
+						Gateway string `json:"gateway"`
 					}
-					if json.Unmarshal(data, &msg) == nil && msg.Channel != gatewayFilter {
+					if json.Unmarshal(data, &msg) == nil && msg.Gateway != gatewayFilter {
 						continue
 					}
 				}
@@ -184,6 +205,46 @@ func main() {
 				flusher.Flush()
 			}
 		}
+	})
+
+	// POST /api/message — dal → stream 메시지 릴레이
+	// dalcli-leader, daemon bridgePost 등에서 사용
+	mux.HandleFunc("/api/message", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var payload struct {
+			Text     string `json:"text"`
+			Username string `json:"username"`
+			Gateway  string `json:"gateway"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+
+		msg := streamMessage{
+			Text:      payload.Text,
+			Username:  payload.Username,
+			Gateway:   payload.Gateway,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}
+
+		data, err := json.Marshal(msg)
+		if err != nil {
+			http.Error(w, "marshal error", http.StatusInternalServerError)
+			return
+		}
+
+		b.broadcast(data)
+		log.Printf("[message] %s@%s: %s (%d clients)",
+			payload.Username, payload.Gateway,
+			truncate(payload.Text, 80), b.clientCount())
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok"}`)
 	})
 
 	// GET /health — 헬스 체크

--- a/internal/bridge/matterbridge.go
+++ b/internal/bridge/matterbridge.go
@@ -182,6 +182,8 @@ func (mb *MatterbridgeBridge) streamOnce() error {
 		if line == "" {
 			continue
 		}
+		// SSE data: 접두사 제거
+		line = strings.TrimPrefix(line, "data: ")
 
 		var raw struct {
 			Text      string `json:"text"`
@@ -197,7 +199,7 @@ func (mb *MatterbridgeBridge) streamOnce() error {
 		}
 
 		// Skip connection events and own messages.
-		if raw.Event == "api_connected" {
+		if raw.Event == "api_connected" || raw.Event == "connected" {
 			log.Printf("[matterbridge] stream connected")
 			continue
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1159,7 +1159,7 @@ func (d *Daemon) agentConfigResponse(name string, c *Container) map[string]strin
 	resp := map[string]string{
 		"dal_name":   c.DalName,
 		"uuid":       c.UUID,
-		"bridge_url": bridgeURLForContainer(d.bridgeURL),
+		"bridge_url": containerBridgeURL(d.dalbridgeURL, d.bridgeURL),
 		"gateway":    gatewayName(d.serviceRepo),
 	}
 

--- a/internal/daemon/daemon_agentconfig_test.go
+++ b/internal/daemon/daemon_agentconfig_test.go
@@ -80,6 +80,30 @@ func TestHandleAgentConfig_DalPrefixRepo(t *testing.T) {
 	}
 }
 
+func TestHandleAgentConfig_DalbridgeURL(t *testing.T) {
+	d := &Daemon{
+		bridgeURL:    "http://old-matterbridge:4242",
+		dalbridgeURL: "http://10.50.0.202:4280",
+		serviceRepo:  "/root/test-repo",
+		containers: map[string]*Container{
+			"dev": {DalName: "dev"},
+		},
+	}
+
+	req := httptest.NewRequest("GET", "/api/agent-config/dev", nil)
+	req.SetPathValue("name", "dev")
+	w := httptest.NewRecorder()
+
+	d.handleAgentConfig(w, req)
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["bridge_url"] != "http://10.50.0.202:4280" {
+		t.Errorf("bridge_url = %q, want dalbridge URL when dalbridgeURL is set", resp["bridge_url"])
+	}
+}
+
 func TestHandleAgentConfig_NoBridge(t *testing.T) {
 	d := &Daemon{
 		containers: map[string]*Container{


### PR DESCRIPTION
## Summary

Closes #628

gateway 격리 도입(a214fec) 후 dalbridge stream이 메시지를 relay하지 않는 버그를 수정.

**근본 원인 6가지:**

- **`/api/message` 엔드포인트 누락** — daemon `bridgePost()`와 dalcli-leader가 `/api/message`로 POST하지만 dalbridge에는 `/webhook`만 존재. dal이 보내는 메시지가 전부 404로 유실됨
- **gateway 필터 필드 불일치** — `/stream?gateway=dal-X`가 `msg.Channel`(MM 채널명)과 비교하므로 항상 불일치 → 필터링된 클라이언트는 모든 메시지 드롭
- **SSE `data: ` 접두사 미제거** — `matterbridge.go`의 `streamOnce()`가 SSE 라인을 그대로 JSON 파싱 시도 → 모든 메시지 파싱 실패로 유실
- **연결 이벤트명 불일치** — dalbridge가 `"connected"` 전송, 클라이언트는 `"api_connected"` 기대
- **`agentConfigResponse` 잘못된 bridge URL** — `bridgeURLForContainer(d.bridgeURL)` (matterbridge URL) 반환, dalbridgeURL 무시
- **form-urlencoded 미지원** — MM outgoing webhook 기본 Content-Type 처리 불가

## Changes

| 파일 | 변경 |
|------|------|
| `cmd/dalbridge/main.go` | `/api/message` 엔드포인트 추가, `streamMessage`에 gateway 필드, gateway 필터 수정, 이벤트명 수정, form-urlencoded 지원 |
| `internal/bridge/matterbridge.go` | SSE `data: ` 접두사 제거, 이벤트 체크 양쪽 호환 |
| `internal/daemon/daemon.go` | `agentConfigResponse`에서 `containerBridgeURL()` 사용 |
| `internal/daemon/daemon_agentconfig_test.go` | dalbridgeURL 우선순위 테스트 추가 |

## Test plan

- [ ] `go vet ./...` + `go test ./...` 통과
- [ ] dalbridge 배포 후 `curl -sN http://10.50.0.202:4280/stream` 으로 메시지 수신 확인
- [ ] dalroot-listener에서 @dalroot 멘션 감지 확인
- [ ] dal 컨테이너에서 gateway 필터링된 메시지 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)