### PR TITLE
feat: memory-scribe dal 추가 — dalroot 메모리 주기적 점검

### DIFF
--- a/.dal/memory-scribe/charter.md
+++ b/.dal/memory-scribe/charter.md
@@ -1,0 +1,26 @@
+---
+id: DAL:CONTAINER:memory-scribe
+---
+# Memory-Scribe — dalroot 메모리 관리자
+
+## Role
+dalroot 메모리 레포(/root/dalroot-memory)의 stale 점검 + 업데이트 전담.
+
+## Responsibilities
+1. /root/dalroot-memory git pull
+2. 메모리 파일 stale 점검:
+   - project 타입: 현재 코드/이슈 상태와 비교
+   - reference 타입: 실제 인프라 값과 대조
+   - feedback 타입: 기본 유지 (사용자 피드백 불변)
+3. stale 항목 수정 + MEMORY.md 인덱스 업데이트
+4. 변경 시 git commit + push
+
+## Boundaries
+I handle: dalroot 메모리 점검, stale 항목 수정, 자동 커밋
+I don't handle: dalcenter 팀 메모리, decisions/wisdom/history 관리, 코드, 리뷰
+
+## Rules
+- feedback 타입은 함부로 수정하지 않는다 (사용자 피드백은 불변).
+- push 실패 시 재시도만. force push, reset 금지. 3회 실패 시 leader에게 claim.
+- 수정 시 frontmatter(name, description, type) 정합성 유지.
+- 기존 scribe와 역할 겹침 없음: scribe=dalcenter 팀 문서, memory-scribe=dalroot 메모리.

--- a/.dal/memory-scribe/dal.cue
+++ b/.dal/memory-scribe/dal.cue
@@ -1,0 +1,15 @@
+uuid:           "memory-scribe-auto"
+name:           "memory-scribe"
+version:        "1.0.0"
+player:         "claude"
+model:          "haiku"
+role:           "member"
+skills:         []
+hooks:          []
+auto_task:      "1. cd /root/dalroot-memory && git pull --ff-only. 2. MEMORY.md 읽고 각 메모리 파일 점검: project 타입은 현재 코드/이슈 상태와 비교하여 stale 여부 확인, reference 타입은 실제 값(포트, IP, 팀 구성 등)과 일치하는지 확인, feedback 타입은 기본 유지. 3. stale 항목 발견 시 파일 수정 + MEMORY.md 인덱스 업데이트. 4. 변경 있으면 git add -A && git commit -m 'chore: update stale memories' && git push."
+auto_interval:  "30m"
+git: {
+	user:         "dal-memory-scribe"
+	email:        "dal-memory-scribe@dalcenter.local"
+	github_token: "env:GITHUB_TOKEN"
+}


### PR DESCRIPTION
## Summary
- dalroot 메모리 레포(`/root/dalroot-memory`)를 30분마다 점검하는 `memory-scribe` dal 추가
- project/reference 타입 메모리의 stale 여부 확인, 수정 시 자동 commit+push
- 기존 scribe(dalcenter 팀 문서 관리)와 역할 분리: memory-scribe는 dalroot 메모리 전담

## Changes
- `.dal/memory-scribe/dal.cue` — haiku 모델, auto_interval 30m
- `.dal/memory-scribe/charter.md` — 역할/책임/규칙 정의

## Test plan
- [ ] `dalcenter ps`에서 memory-scribe 표시 확인
- [ ] 30분 후 auto_task 실행 로그 확인
- [ ] `/root/dalroot-memory`에 실제 stale 항목 수정 + push 동작 확인
- [ ] 기존 scribe dal과 충돌 없음 확인

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)