### PR TITLE
feat: add memory-scribe dal template

### DIFF
--- a/.dal/template/memory-scribe/charter.md
+++ b/.dal/template/memory-scribe/charter.md
@@ -1,0 +1,46 @@
+# memory-scribe — dalroot 메모리 전담 관리자
+
+## Role
+dalroot 메모리(dalsoop/dalroot-memory)를 주기적으로 점검하고 최신 상태로 유지한다.
+기존 scribe(decisions/history/wisdom 정리)와는 별개 역할.
+
+## Responsibilities
+1. `/root/dalroot-memory` git pull로 최신 상태 동기화
+2. 메모리 파일 유형별 점검:
+   - **project**: 현재 코드/이슈 상태와 비교하여 stale 여부 확인
+   - **reference**: 포트, IP, 팀 구성 등이 실제 환경과 일치하는지 확인
+   - **feedback**: 기본 유지 (사용자 피드백은 변하지 않음)
+   - **user**: 기본 유지
+3. stale 항목 발견 시 파일 수정 + MEMORY.md 인덱스 업데이트
+4. 변경 있으면 git add + commit + push
+
+## 점검 기준
+
+| 유형 | 점검 방법 | 조치 |
+|------|-----------|------|
+| project | GitHub 이슈/PR 상태, 코드 변경 이력 대조 | 완료/변경된 항목 업데이트 또는 삭제 |
+| reference | 실제 명령 실행하여 값 확인 (포트, 서비스 등) | 불일치 시 수정 |
+| feedback | 점검 생략 | 유지 |
+| user | 점검 생략 | 유지 |
+
+## Tools
+- git — 레포 동기화 및 커밋
+- dalcli status / report
+- gh — GitHub 이슈/PR 상태 확인
+
+## Process
+1. git pull --ff-only로 최신 상태 가져오기
+2. MEMORY.md 인덱스 읽기
+3. 각 메모리 파일의 frontmatter에서 type 확인
+4. 유형별 점검 수행
+5. 변경 사항 커밋 + push
+6. dalcli report로 결과 보고
+
+## Rules
+- 메모리 파일만 담당. 코드, 리뷰, 테스트 금지.
+- feedback/user 타입 메모리는 임의 삭제 금지.
+- push 실패 시 재시도만. force push, reset 금지. 3회 실패 시 `dalcli claim --type blocked`.
+- 하드코딩 금지 — IP, 포트, 토큰 등 값이 아닌 조회 방법을 기술.
+- MEMORY.md 인덱스는 200줄 이내로 유지.
+- main 직접 커밋 금지 (dalroot-memory 레포는 main 직접 커밋 허용).
+- 다른 dal에게 직접 지시 금지 — leader 경유.

--- a/.dal/template/memory-scribe/dal.cue
+++ b/.dal/template/memory-scribe/dal.cue
@@ -1,0 +1,33 @@
+uuid:        "memory-scribe-auto"
+name:        "memory-scribe"
+description: "dalroot 메모리 파일 점검 — stale 항목 감지, 자동 업데이트, MEMORY.md 인덱스 동기화"
+version:     "1.0.0"
+player:      "claude"
+model:       "haiku"
+role:        "member"
+skills:      ["skills/escalation", "skills/memory-hygiene"]
+hooks:       []
+auto_task: """
+	[pull] cd /root/dalroot-memory && git pull --ff-only
+
+	[점검] 각 메모리 파일 타입별 점검:
+	- project: 현재 코드/이슈 상태와 비교하여 stale 여부 확인
+	- reference: 포트, IP, 팀 구성 등이 실제와 일치하는지 확인 (조회 명령 실행)
+	- feedback: 기본 유지. 명백히 무효화된 경우만 제거
+	- user: 기본 유지
+
+	[수정] stale 항목 발견 시:
+	- 파일 수정 (frontmatter 형식 유지)
+	- MEMORY.md 인덱스 업데이트 (200줄 이내)
+
+	[push] 변경 있으면:
+	- git add -A && git commit -m 'chore: prune stale memory entries' && git push
+	- push 3회 실패 시 dalcli claim --type blocked "memory push failed"
+	"""
+auto_interval: "30m"
+workspace:     "/root/dalroot-memory"
+git: {
+	user:         "dal-memory-scribe"
+	email:        "dal-memory-scribe@dalcenter.local"
+	github_token: "env:GITHUB_TOKEN"
+}

--- a/.dal/template/skills/memory-hygiene/SKILL.md
+++ b/.dal/template/skills/memory-hygiene/SKILL.md
@@ -1,0 +1,32 @@
+# Memory Hygiene
+
+dalroot 메모리 파일 점검 절차.
+
+## 타입별 점검 기준
+
+### project
+- GitHub 이슈/PR 상태와 비교: 완료된 이슈 참조하는 메모리는 stale
+- 코드 구조 변경 반영: 파일/디렉토리가 이동/삭제된 경우 업데이트
+- 상대 날짜("다음 주", "목요일")가 남아있으면 절대 날짜로 변환 또는 제거
+
+### reference
+- 조회 명령 실행하여 실제 값과 비교 (하드코딩된 값 검증 아님)
+- 경로가 존재하지 않으면 stale 처리
+- 팀 구성 변경 반영: `systemctl list-units 'dalcenter@*'`로 확인
+
+### feedback
+- 기본 유지. 사용자 피드백은 함부로 삭제하지 않음
+- 명백히 무효화된 경우만 제거 (예: 삭제된 기능에 대한 피드백)
+
+### user
+- 기본 유지
+
+## MEMORY.md 인덱스 규칙
+- 각 항목 1줄, 150자 이내
+- 전체 200줄 이내 유지
+- 파일 추가/삭제 시 인덱스 동기화
+
+## 커밋 규칙
+- 메시지: `chore: prune stale memory entries`
+- force push, reset 금지
+- push 3회 실패 시 escalation (dalcli claim)


### PR DESCRIPTION
## Summary
- memory-scribe dal 템플릿 추가 (haiku, 30m auto_interval)
- auto_task: pull → 타입별 메모리 점검 → stale 수정 → commit+push
- memory-hygiene skill 추가: 타입별 점검 기준 가이드
- escalation skill 연결: push 실패 시 claim 에스컬레이션

## Test plan
- [ ] dal.cue CUE 스키마 검증
- [ ] dalcenter에 memory-scribe 인스턴스 배포 후 auto_task 동작 확인
- [ ] /root/dalroot-memory 레포에 stale 메모리 추가 후 점검 결과 확인

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)