### PR TITLE
feat: 팀별 MM 봇 토큰 중복 감지 + check-tokens CLI

### DIFF
--- a/cmd/dalcenter/cmd_check_tokens.go
+++ b/cmd/dalcenter/cmd_check_tokens.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dalsoop/dalcenter/internal/daemon"
+	"github.com/spf13/cobra"
+)
+
+func newCheckTokensCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check-tokens",
+		Short: "Check for shared MM bot tokens across teams (self-message bug)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dupes := daemon.CheckBridgeTokens()
+			if dupes == nil {
+				fmt.Println("OK: all teams use unique MM bot tokens (or no bridge configs found)")
+				return nil
+			}
+
+			fmt.Fprintf(os.Stderr, "WARNING: shared MM bot tokens detected!\n\n")
+			fmt.Fprintf(os.Stderr, "When teams share a bot token, matterbridge treats messages from\n")
+			fmt.Fprintf(os.Stderr, "other teams as self-messages and drops them silently.\n\n")
+
+			for token, teams := range dupes {
+				masked := token
+				if len(masked) > 8 {
+					masked = masked[:4] + "..." + masked[len(masked)-4:]
+				}
+				fmt.Fprintf(os.Stderr, "  Token %s shared by: %v\n", masked, teams)
+			}
+
+			fmt.Fprintf(os.Stderr, "\nFix: assign a unique bot account+token per team in each\n")
+			fmt.Fprintf(os.Stderr, "     /etc/dalcenter/<team>.matterbridge.toml\n")
+			return fmt.Errorf("duplicate bridge tokens found")
+		},
+	}
+}

--- a/cmd/dalcenter/main.go
+++ b/cmd/dalcenter/main.go
@@ -36,6 +36,7 @@ func main() {
 		newVersionCmd(),
 		newTuiCmd(),
 		newPipelineCmd(),
+		newCheckTokensCmd(),
 	)
 
 	if err := root.Execute(); err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -172,6 +172,17 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 	}
 
+	// Check for shared bridge tokens across teams (self-message bug)
+	if dupes := CheckBridgeTokens(); dupes != nil {
+		for token, teams := range dupes {
+			masked := token
+			if len(masked) > 8 {
+				masked = masked[:4] + "..." + masked[len(masked)-4:]
+			}
+			log.Printf("[daemon] WARNING: teams %v share the same MM bot token (%s) — self-message filtering will fail. See issue #578", teams, masked)
+		}
+	}
+
 	// Start credential watcher
 	go startCredentialWatcher(ctx, d)
 

--- a/internal/daemon/matterbridge.go
+++ b/internal/daemon/matterbridge.go
@@ -2,17 +2,19 @@ package daemon
 
 import (
 	"context"
-	"log"
-	"net"
-	"os"
-	"os/exec"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
+	"net"
 	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/dalsoop/dalcenter/internal/paths"
 )
 
 // startMatterbridge starts matterbridge as a child process.
@@ -109,6 +111,107 @@ func (d *Daemon) mmPost(text string) error {
 		return fmt.Errorf("mm post %d: %s", resp.StatusCode, string(respBody))
 	}
 	return nil
+}
+
+// parseBridgeToken reads the MM bot Token from a matterbridge TOML config.
+// It looks for lines like: Token = "xxx" under [mattermost.*] sections.
+func parseBridgeToken(confPath string) string {
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Token") && strings.Contains(line, "=") {
+			// Extract value: Token = "xxx" or Token="xxx"
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				val := strings.TrimSpace(parts[1])
+				val = strings.Trim(val, "\"")
+				if val != "" {
+					return val
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// bridgeTokenEntry holds team name and its bridge token for duplicate detection.
+type bridgeTokenEntry struct {
+	Team    string
+	Token   string
+	ConfPath string
+}
+
+// CheckBridgeTokens scans /etc/dalcenter/*.env for DALCENTER_BRIDGE_CONF paths,
+// extracts the MM bot token from each, and returns duplicate groups.
+// Returns nil if no duplicates found.
+func CheckBridgeTokens() map[string][]string {
+	configDir := paths.ConfigDir()
+	entries, err := os.ReadDir(configDir)
+	if err != nil {
+		return nil
+	}
+
+	var tokens []bridgeTokenEntry
+	for _, e := range entries {
+		if e.Name() == "common.env" || !strings.HasSuffix(e.Name(), ".env") {
+			continue
+		}
+		teamName := strings.TrimSuffix(e.Name(), ".env")
+		data, err := os.ReadFile(filepath.Join(configDir, e.Name()))
+		if err != nil {
+			continue
+		}
+
+		// Look for DALCENTER_BRIDGE_CONF in the env file
+		confPath := ""
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "DALCENTER_BRIDGE_CONF=") {
+				confPath = strings.TrimPrefix(line, "DALCENTER_BRIDGE_CONF=")
+				break
+			}
+		}
+		if confPath == "" {
+			// Try default path: /etc/dalcenter/<team>.matterbridge.toml
+			defaultConf := filepath.Join(configDir, teamName+".matterbridge.toml")
+			if _, err := os.Stat(defaultConf); err == nil {
+				confPath = defaultConf
+			}
+		}
+		if confPath == "" {
+			continue
+		}
+
+		token := parseBridgeToken(confPath)
+		if token != "" {
+			tokens = append(tokens, bridgeTokenEntry{
+				Team:     teamName,
+				Token:    token,
+				ConfPath: confPath,
+			})
+		}
+	}
+
+	// Group by token to find duplicates
+	groups := make(map[string][]string)
+	for _, t := range tokens {
+		groups[t.Token] = append(groups[t.Token], t.Team)
+	}
+
+	// Filter to only duplicates
+	dupes := make(map[string][]string)
+	for token, teams := range groups {
+		if len(teams) > 1 {
+			dupes[token] = teams
+		}
+	}
+	if len(dupes) == 0 {
+		return nil
+	}
+	return dupes
 }
 
 // resolveMMChannelID finds the MM channel ID from the matterbridge config.

--- a/internal/daemon/matterbridge_token_test.go
+++ b/internal/daemon/matterbridge_token_test.go
@@ -1,0 +1,168 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseBridgeToken_Basic(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "team.matterbridge.toml")
+	content := `[mattermost.mybot]
+Server = "https://mm.example.com"
+Token = "abc123token456"
+Team = "dalsoop"
+
+[api]
+BindAddress = ":4242"
+`
+	if err := os.WriteFile(conf, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseBridgeToken(conf)
+	if got != "abc123token456" {
+		t.Errorf("parseBridgeToken = %q, want %q", got, "abc123token456")
+	}
+}
+
+func TestParseBridgeToken_NoToken(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "empty.toml")
+	if err := os.WriteFile(conf, []byte("[api]\nBindAddress = \":4242\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseBridgeToken(conf)
+	if got != "" {
+		t.Errorf("parseBridgeToken = %q, want empty", got)
+	}
+}
+
+func TestParseBridgeToken_FileNotFound(t *testing.T) {
+	got := parseBridgeToken("/nonexistent/path.toml")
+	if got != "" {
+		t.Errorf("parseBridgeToken = %q, want empty", got)
+	}
+}
+
+func TestParseBridgeToken_NoSpaces(t *testing.T) {
+	dir := t.TempDir()
+	conf := filepath.Join(dir, "nospace.toml")
+	content := `[mattermost.bot]
+Token="tokenvalue"
+`
+	if err := os.WriteFile(conf, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := parseBridgeToken(conf)
+	if got != "tokenvalue" {
+		t.Errorf("parseBridgeToken = %q, want %q", got, "tokenvalue")
+	}
+}
+
+func TestCheckBridgeTokens_NoDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", dir)
+
+	// Create two teams with unique tokens
+	writeTeamConfig(t, dir, "team-a", "token-aaa")
+	writeTeamConfig(t, dir, "team-b", "token-bbb")
+
+	dupes := CheckBridgeTokens()
+	if dupes != nil {
+		t.Errorf("expected no duplicates, got %v", dupes)
+	}
+}
+
+func TestCheckBridgeTokens_WithDuplicates(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", dir)
+
+	// Create two teams sharing the same token
+	writeTeamConfig(t, dir, "team-a", "shared-token")
+	writeTeamConfig(t, dir, "team-b", "shared-token")
+	writeTeamConfig(t, dir, "team-c", "unique-token")
+
+	dupes := CheckBridgeTokens()
+	if dupes == nil {
+		t.Fatal("expected duplicates, got nil")
+	}
+
+	teams, ok := dupes["shared-token"]
+	if !ok {
+		t.Fatal("expected shared-token in duplicates")
+	}
+	if len(teams) != 2 {
+		t.Errorf("expected 2 teams sharing token, got %d", len(teams))
+	}
+
+	// unique-token should not appear
+	if _, ok := dupes["unique-token"]; ok {
+		t.Error("unique-token should not be in duplicates")
+	}
+}
+
+func TestCheckBridgeTokens_NoConfigDir(t *testing.T) {
+	t.Setenv("DALCENTER_CONFIG_DIR", "/nonexistent")
+	dupes := CheckBridgeTokens()
+	if dupes != nil {
+		t.Errorf("expected nil for missing config dir, got %v", dupes)
+	}
+}
+
+func TestCheckBridgeTokens_SkipsCommonEnv(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", dir)
+
+	// common.env should be skipped
+	if err := os.WriteFile(filepath.Join(dir, "common.env"), []byte("DALCENTER_HOST_IP=10.0.0.1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeTeamConfig(t, dir, "team-a", "token-a")
+
+	dupes := CheckBridgeTokens()
+	if dupes != nil {
+		t.Errorf("expected no duplicates, got %v", dupes)
+	}
+}
+
+func TestCheckBridgeTokens_DefaultTomlPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DALCENTER_CONFIG_DIR", dir)
+
+	// Team env without DALCENTER_BRIDGE_CONF — should fall back to <team>.matterbridge.toml
+	envContent := "DALCENTER_PORT=11190\n"
+	if err := os.WriteFile(filepath.Join(dir, "team-x.env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := "[mattermost.bot]\nToken = \"fallback-token\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "team-x.matterbridge.toml"), []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Single team — no duplicates, but verify it was scanned
+	dupes := CheckBridgeTokens()
+	if dupes != nil {
+		t.Errorf("expected no duplicates for single team, got %v", dupes)
+	}
+}
+
+// writeTeamConfig creates a team env file and corresponding matterbridge TOML with the given token.
+func writeTeamConfig(t *testing.T, dir, team, token string) {
+	t.Helper()
+
+	tomlPath := filepath.Join(dir, team+".matterbridge.toml")
+	tomlContent := "[mattermost.bot]\nToken = \"" + token + "\"\n"
+	if err := os.WriteFile(tomlPath, []byte(tomlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	envContent := "DALCENTER_PORT=11190\nDALCENTER_BRIDGE_CONF=" + tomlPath + "\n"
+	if err := os.WriteFile(filepath.Join(dir, team+".env"), []byte(envContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- **봇 토큰 공유 시 self-message 무시 버그 해결을 위한 검증 로직 추가** (#578)
- `parseBridgeToken()`: 각 팀의 matterbridge TOML에서 MM 봇 Token 추출
- `CheckBridgeTokens()`: 전체 팀 설정을 스캔하여 중복 토큰 감지
- daemon 시작 시 중복 토큰이 있으면 WARNING 로그 출력 (토큰 마스킹)
- `dalcenter check-tokens` CLI 명령어 추가 — 운영자가 토큰 상태를 즉시 확인 가능

## 배경

모든 팀이 `mb-veilkey-selfhosted` 봇 토큰을 공유하면 matterbridge가 다른 팀의 메시지를 자기 메시지로 오인하여 API stream에 relay하지 않음. 각 팀별 전용 봇 계정+토큰이 필요.

## Test plan

- [ ] `go test ./internal/daemon/ -run TestParseBridgeToken` — TOML 토큰 파싱 테스트
- [ ] `go test ./internal/daemon/ -run TestCheckBridgeTokens` — 중복 감지 테스트  
- [ ] `dalcenter check-tokens` 실행하여 현재 팀별 토큰 상태 확인
- [ ] 각 팀 matterbridge.toml에 전용 토큰 적용 후 matterbridge 재시작
- [ ] 각 팀에서 self-message가 정상 무시되는지 확인

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)