### PR TITLE
fix: dalcenter tell 메시지에 @dal-leader 멘션 자동 추가

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -985,10 +985,14 @@ func (d *Daemon) handleMessage(w http.ResponseWriter, r *http.Request) {
 	if dalName == "" {
 		dalName = "dalcenter"
 	}
+
+	// Prepend @dal-leader mention so the leader picks up the message
+	msg := "@dal-leader " + req.Message
+
 	// Post directly to MM (not via matterbridge) to avoid self-skip
-	if err := d.mmPost(req.Message); err != nil {
+	if err := d.mmPost(msg); err != nil {
 		// Fallback to bridge
-		if err2 := d.bridgePost(req.Message, dalName); err2 != nil {
+		if err2 := d.bridgePost(msg, dalName); err2 != nil {
 			http.Error(w, fmt.Sprintf("post failed: mm=%v bridge=%v", err, err2), 500)
 			return
 		}

--- a/internal/daemon/message_test.go
+++ b/internal/daemon/message_test.go
@@ -35,8 +35,8 @@ func TestHandleMessage_PostsViaBridge(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	if !strings.Contains(receivedBody, "test message") {
-		t.Errorf("expected message in bridge post body, got: %s", receivedBody)
+	if !strings.Contains(receivedBody, "@dal-leader test message") {
+		t.Errorf("expected @dal-leader prefix in bridge post body, got: %s", receivedBody)
 	}
 	if !strings.Contains(receivedBody, "leader") {
 		t.Errorf("expected username in bridge post body, got: %s", receivedBody)


### PR DESCRIPTION
## Summary
- `handleMessage`에서 MM post 전에 `@dal-leader` 프리픽스를 자동 추가
- `mmPost`와 `bridgePost` 양쪽 모두 적용
- 기존 테스트 업데이트

Closes #679

## Test plan
- [ ] `go test ./internal/daemon/...` 통과 확인
- [ ] `dalcenter tell` 실행 시 MM 채널에 `@dal-leader` 멘션이 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)