### PR TITLE
fix: tell 메시지에 @dal-leader 멘션 자동 포함

### DIFF
--- a/cmd/dalcenter/cmd_tell.go
+++ b/cmd/dalcenter/cmd_tell.go
@@ -113,6 +113,8 @@ Use --no-ack to skip waiting for ACK (fire-and-forget mode).`,
 // sendViaDalcenter sends a message through the target dalcenter's /api/message endpoint.
 // Returns the message_id assigned by the target dalcenter for ACK tracking.
 func sendViaDalcenter(team, message, wakeNote string) (string, error) {
+	message = "@dal-leader " + message
+
 	targetURL, err := resolveRepoURL(team)
 	if err != nil {
 		return "", fmt.Errorf("resolve repo URL: %w", err)
@@ -221,6 +223,8 @@ func triggerIssueWorkflow(team string, issueNum int, member, task string) error 
 
 // sendViaBridge sends a message directly to a team's matterbridge API.
 func sendViaBridge(team, message, wakeNote string) error {
+	message = "@dal-leader " + message
+
 	bridgeURL, err := resolveBridgeURL(team)
 	if err != nil {
 		return fmt.Errorf("resolve bridge URL: %w", err)

--- a/cmd/dalcenter/cmd_tell_test.go
+++ b/cmd/dalcenter/cmd_tell_test.go
@@ -32,8 +32,8 @@ func TestSendViaDalcenter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sendViaDalcenter: %v", err)
 	}
-	if received.Message != "hello leader" {
-		t.Errorf("message = %q, want %q", received.Message, "hello leader")
+	if received.Message != "@dal-leader hello leader" {
+		t.Errorf("message = %q, want %q", received.Message, "@dal-leader hello leader")
 	}
 	// Server returned no message_id in this test
 	if msgID != "" {
@@ -82,8 +82,8 @@ func TestSendViaBridge(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sendViaBridge: %v", err)
 	}
-	if received.Text != "direct message" {
-		t.Errorf("text = %q, want %q", received.Text, "direct message")
+	if received.Text != "@dal-leader direct message" {
+		t.Errorf("text = %q, want %q", received.Text, "@dal-leader direct message")
 	}
 	if received.Gateway != "dal-team" {
 		t.Errorf("gateway = %q, want %q", received.Gateway, "dal-team")


### PR DESCRIPTION
## Summary
- `sendViaDalcenter`, `sendViaBridge` 함수에서 메시지 본문 구성 전에 `@dal-leader ` 접두어를 자동 추가
- 테스트의 expected 값을 `@dal-leader` 접두어 포함으로 수정

Closes #679

## Test plan
- [ ] `TestSendViaDalcenter` — 수신 메시지가 `@dal-leader hello leader`인지 확인
- [ ] `TestSendViaBridge` — 수신 텍스트가 `@dal-leader direct message`인지 확인
- [ ] 기존 테스트 전체 통과 확인 (`go test ./cmd/dalcenter/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)