### PR TITLE
feat: 모든 팀의 bridge를 CT 202 dalbridge로 통일 (#577)

### DIFF
--- a/cmd/dalcenter/dalcenter@.service
+++ b/cmd/dalcenter/dalcenter@.service
@@ -8,10 +8,11 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/dalcenter/common.env
 EnvironmentFile=/etc/dalcenter/%i.env
 Environment=PATH=/usr/local/bin:/usr/local/go/bin:/root/go/bin:/usr/bin:/bin
 Environment=HOME=/root
-ExecStart=/usr/local/bin/dalcenter serve --addr :${DALCENTER_PORT} --repo ${DALCENTER_REPO} --bridge-url ${DALCENTER_BRIDGE_URL}
+ExecStart=/usr/local/bin/dalcenter serve --addr :${DALCENTER_PORT} --repo ${DALCENTER_REPO} --bridge-url ${DALCENTER_BRIDGE_URL} --dalbridge-url ${DALCENTER_DALBRIDGE_URL}
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- `dalcenter@.service`에 `common.env` 로딩 추가 (팀 공통 환경변수 지원)
- `--dalbridge-url` 플래그 추가로 CT 202 dalbridge 엔드포인트를 모든 팀에서 사용

Closes #577

## Test plan
- [ ] `systemctl restart 'dalcenter@*'` 후 전체 팀 정상 기동 확인
- [ ] 각 팀에서 dalbridge 통신 정상 동작 확인
- [ ] `common.env` 미존재 시 `-` prefix로 에러 없이 스킵되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)