### PR TITLE
feat: 모든 팀의 bridge를 CT 202 dalbridge로 통일 (#577)

### DIFF
--- a/cmd/dalcenter/dalcenter@.service
+++ b/cmd/dalcenter/dalcenter@.service
@@ -8,10 +8,11 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
+EnvironmentFile=-/etc/dalcenter/common.env
 EnvironmentFile=/etc/dalcenter/%i.env
 Environment=PATH=/usr/local/bin:/usr/local/go/bin:/root/go/bin:/usr/bin:/bin
 Environment=HOME=/root
-ExecStart=/usr/local/bin/dalcenter serve --addr :${DALCENTER_PORT} --repo ${DALCENTER_REPO} --bridge-url ${DALCENTER_BRIDGE_URL}
+ExecStart=/usr/local/bin/dalcenter serve --addr :${DALCENTER_PORT} --repo ${DALCENTER_REPO} --bridge-url ${DALCENTER_BRIDGE_URL} --dalbridge-url ${DALCENTER_DALBRIDGE_URL}
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- systemd 서비스에 `common.env` 환경파일 추가 (`EnvironmentFile=-/etc/dalcenter/common.env`)
- `--dalbridge-url` 플래그를 ExecStart에 추가하여 모든 팀이 CT 202 dalbridge를 공유하도록 통일
- 팀별 `.env`에서 개별 bridge URL을 관리하던 방식에서 공통 dalbridge URL로 전환

## Test plan
- [ ] `systemctl daemon-reload && systemctl restart 'dalcenter@*'` 후 전체 팀 정상 기동 확인
- [ ] `dalcenter ps`로 모든 dal이 dalbridge에 연결되었는지 확인
- [ ] 팀 간 메시지 송수신 정상 동작 확인

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)