### PR TITLE
fix: runProvider 테스트 바이너리 의존 제거 (#490)

### DIFF
--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -14,8 +14,21 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dalsoop/dalcenter/internal/providerexec"
+
 	"github.com/dalsoop/dalcenter/internal/bridge"
 )
+
+// stubProviderResolve replaces providerexec.ResolveFunc with /bin/echo
+// for the duration of the test, avoiding real binary execution.
+func stubProviderResolve(t *testing.T) {
+	t.Helper()
+	orig := providerexec.ResolveFunc
+	providerexec.ResolveFunc = func(player string) (string, error) {
+		return "/bin/echo", nil
+	}
+	t.Cleanup(func() { providerexec.ResolveFunc = orig })
+}
 
 // ── extractTask ──
 
@@ -873,38 +886,46 @@ func TestExecuteTask_NonRetryable_NoLoop(t *testing.T) {
 // ── runProvider player branching ──
 
 func TestRunProvider_Codex(t *testing.T) {
+	stubProviderResolve(t)
 	os.Setenv("DAL_PLAYER", "codex")
 	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
 	defer os.Unsetenv("DAL_PLAYER")
 	defer os.Unsetenv("DAL_ROLE")
+	defer os.Unsetenv("DAL_MAX_DURATION")
 
-	// codex not available in test → just verify it doesn't panic
 	_, err := runClaude(os.Getenv("DAL_PLAYER"), "test")
-	if err == nil {
-		t.Log("codex available — unusual but ok")
+	if err != nil {
+		t.Logf("expected with stub: %v", err)
 	}
 }
 
 func TestRunProvider_Claude_Leader(t *testing.T) {
+	stubProviderResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "leader")
+	os.Setenv("DAL_MAX_DURATION", "1s")
 	defer os.Unsetenv("DAL_PLAYER")
 	defer os.Unsetenv("DAL_ROLE")
+	defer os.Unsetenv("DAL_MAX_DURATION")
 
 	_, err := runClaude(os.Getenv("DAL_PLAYER"), "test")
-	if err == nil {
-		t.Log("claude available — unusual but ok")
+	if err != nil {
+		t.Logf("expected with stub: %v", err)
 	}
 }
 
 func TestRunProvider_Claude_Member(t *testing.T) {
+	stubProviderResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
+	os.Setenv("DAL_MAX_DURATION", "1s")
 	defer os.Unsetenv("DAL_PLAYER")
 	defer os.Unsetenv("DAL_ROLE")
+	defer os.Unsetenv("DAL_MAX_DURATION")
 
 	_, err := runClaude(os.Getenv("DAL_PLAYER"), "test")
-	if err == nil {
-		t.Log("claude available — unusual but ok")
+	if err != nil {
+		t.Logf("expected with stub: %v", err)
 	}
 }

--- a/cmd/dalcli/cmd_run_thorough_test.go
+++ b/cmd/dalcli/cmd_run_thorough_test.go
@@ -6,7 +6,20 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dalsoop/dalcenter/internal/providerexec"
 )
+
+// stubResolve replaces providerexec.ResolveFunc with /bin/echo for the
+// duration of the test, avoiding real binary execution and timeouts.
+func stubResolve(t *testing.T) {
+	t.Helper()
+	orig := providerexec.ResolveFunc
+	providerexec.ResolveFunc = func(player string) (string, error) {
+		return "/bin/echo", nil
+	}
+	t.Cleanup(func() { providerexec.ResolveFunc = orig })
+}
 
 // ══════════════════════════════════════════════════════════════
 // parseInterval: edge cases
@@ -169,6 +182,7 @@ func TestExtractTask_UnicodeContent(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestRunClaude_ExtraBashWildcard(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_EXTRA_BASH", "*")
@@ -185,6 +199,7 @@ func TestRunClaude_ExtraBashWildcard(t *testing.T) {
 }
 
 func TestRunClaude_ExtraBashSpecific(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_EXTRA_BASH", "go,npm")
@@ -200,6 +215,7 @@ func TestRunClaude_ExtraBashSpecific(t *testing.T) {
 }
 
 func TestRunClaude_LeaderRole(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "leader")
 	os.Setenv("DAL_EXTRA_BASH", "")
@@ -215,6 +231,7 @@ func TestRunClaude_LeaderRole(t *testing.T) {
 }
 
 func TestRunClaude_MaxDurationEnv(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "500ms")
@@ -228,12 +245,12 @@ func TestRunClaude_MaxDurationEnv(t *testing.T) {
 	_, _ = runClaude("claude", "test")
 	elapsed := time.Since(start)
 
-	// If claude exists it might run longer, but with 500ms timeout
-	// it should be capped. Just verify no panic.
+	// With /bin/echo stub, should complete near-instantly.
 	_ = elapsed
 }
 
 func TestRunClaude_InvalidMaxDuration(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "not-a-duration")
@@ -243,7 +260,8 @@ func TestRunClaude_InvalidMaxDuration(t *testing.T) {
 		os.Unsetenv("DAL_MAX_DURATION")
 	}()
 
-	// Invalid duration should fall back to default (5min), not panic
+	// Invalid duration falls back to default (5min), but /bin/echo exits
+	// instantly so no timeout risk. Verifies no panic on parse error.
 	_, _ = runClaude("claude", "test")
 }
 
@@ -252,6 +270,7 @@ func TestRunClaude_InvalidMaxDuration(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestExecuteTask_SuccessKeepsCircuitClosed(t *testing.T) {
+	stubResolve(t)
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
 
@@ -266,12 +285,10 @@ func TestExecuteTask_SuccessKeepsCircuitClosed(t *testing.T) {
 
 	_, err := executeTask("echo hi")
 	if err == nil {
-		// claude 성공 → circuit closed 유지
 		if providerCircuit.State() != "closed" {
 			t.Error("circuit should be closed after success")
 		}
 	}
-	// claude 없으면 에러 → failure 기록됨 (이건 정상)
 }
 
 // ══════════════════════════════════════════════════════════════
@@ -323,6 +340,7 @@ func TestIsActiveThread_EmptyMap(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestRunProvider_DispatchesToRunClaude(t *testing.T) {
+	stubResolve(t)
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "1s")
 	defer func() {

--- a/internal/providerexec/providerexec.go
+++ b/internal/providerexec/providerexec.go
@@ -26,9 +26,17 @@ func binaryCandidates() map[string][]string {
 	}
 }
 
+// ResolveFunc is the function used to resolve provider binaries.
+// Override in tests to avoid real binary execution.
+var ResolveFunc = resolve
+
 // Resolve returns an executable path for the named provider binary.
 // It checks PATH first, then a small set of known install locations.
 func Resolve(player string) (string, error) {
+	return ResolveFunc(player)
+}
+
+func resolve(player string) (string, error) {
 	candidates, ok := binaryCandidates()[player]
 	if !ok {
 		return "", fmt.Errorf("unknown provider %q", player)


### PR DESCRIPTION
## Summary
- `providerexec.ResolveFunc` 함수 변수 도입으로 테스트 시 stub 주입 가능
- `runClaude`/`runProvider`/`executeTask` 호출하는 10개 테스트에 `/bin/echo` stub 적용
- dalcli 패키지 전체 테스트: **30s+ timeout FAIL → 7s PASS**

## 근본 원인
`TestRunProvider_DispatchesToRunClaude` 등이 실제 `claude`/`codex` 바이너리를 실행하여 provider당 ~5초 소비. 전체 패키지 테스트 시간이 30초를 초과하여 CI 불안정.

## 변경 내용
| 파일 | 변경 |
|------|------|
| `internal/providerexec/providerexec.go` | `ResolveFunc` 함수 변수 추가 |
| `cmd/dalcli/cmd_run_thorough_test.go` | `stubResolve(t)` 헬퍼 + 7개 테스트 적용 |
| `cmd/dalcli/cmd_run_test.go` | `stubProviderResolve(t)` 헬퍼 + 3개 테스트 적용 |

## Test plan
- [x] `go vet ./...` PASS
- [x] `go test ./...` 전체 PASS
- [x] `go build ./...` PASS
- [x] dalcli 패키지 30초 timeout 내 통과 확인

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)