### PR TITLE
feat: active-standby HA for dalcenter

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -52,6 +52,7 @@ type Daemon struct {
 	messages         *messageStore
 	registry         *Registry
 	pipeline         *DalrootPipeline
+	ha               *haState
 	startTime        time.Time
 }
 
@@ -99,6 +100,7 @@ func New(addr, localdalRoot, serviceRepo, bridgeURL, dalbridgeURL, bridgeConf, g
 		messages:       newMessageStore(filepath.Join(stateDir(serviceRepo), "messages.json")),
 		registry:       newRegistry(serviceRepo),
 		pipeline:       newDalrootPipeline(serviceRepo),
+		ha:            initHA(),
 		credSyncLast: newCredentialSyncMap(),
 		startTime:    time.Now(),
 	}
@@ -132,6 +134,21 @@ func (d *Daemon) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 		token := strings.TrimPrefix(auth, "Bearer ")
 		if auth == "" || token == auth || token != d.apiToken {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}
+
+// requireActive is middleware that rejects container-management requests
+// when this instance is a standby that has not been promoted.
+func (d *Daemon) requireActive(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !d.ha.isActive() {
+			respondJSON(w, http.StatusServiceUnavailable, map[string]any{
+				"error": "standby instance — not managing containers",
+				"role":  d.ha.effectiveRole(),
+			})
 			return
 		}
 		next(w, r)
@@ -227,8 +244,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		log.Printf("[daemon] dalbridge URL: %s (containers)", d.dalbridgeURL)
 	}
 
-	// Reconcile existing containers from a previous daemon run
-	d.reconcile()
+	// Reconcile existing containers from a previous daemon run.
+	// Standby instances skip reconciliation until promoted.
+	if d.ha.isActive() {
+		d.reconcile()
+	} else {
+		log.Printf("[daemon] standby mode — skipping reconcile until promotion")
+	}
 
 	mux := http.NewServeMux()
 
@@ -240,11 +262,12 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("POST /api/validate", d.handleValidate)
 	mux.HandleFunc("GET /api/logs/{name}", d.handleLogs)
 	mux.HandleFunc("GET /runs/{id}", d.handleRunPage)
-	// Write endpoints — require auth when DALCENTER_TOKEN is set
-	mux.HandleFunc("POST /api/wake/{name}", d.requireAuth(d.handleWake))
-	mux.HandleFunc("POST /api/sleep/{name}", d.requireAuth(d.handleSleep))
-	mux.HandleFunc("POST /api/restart/{name}", d.requireAuth(d.handleRestart))
-	mux.HandleFunc("POST /api/replace/{name}", d.requireAuth(d.handleReplace))
+	// Write endpoints — require auth when DALCENTER_TOKEN is set.
+	// Container management endpoints also require active role (not standby).
+	mux.HandleFunc("POST /api/wake/{name}", d.requireAuth(d.requireActive(d.handleWake)))
+	mux.HandleFunc("POST /api/sleep/{name}", d.requireAuth(d.requireActive(d.handleSleep)))
+	mux.HandleFunc("POST /api/restart/{name}", d.requireAuth(d.requireActive(d.handleRestart)))
+	mux.HandleFunc("POST /api/replace/{name}", d.requireAuth(d.requireActive(d.handleReplace)))
 	mux.HandleFunc("POST /api/sync", d.requireAuth(d.handleSync))
 	mux.HandleFunc("POST /api/message", d.requireAuth(d.handleMessage))
 	mux.HandleFunc("POST /api/activity/{name}", d.requireAuth(d.handleActivity))
@@ -346,13 +369,18 @@ func (d *Daemon) handleHealth(w http.ResponseWriter, r *http.Request) {
 
 	dals, _ := localdal.ListDals(d.localdalRoot)
 
-	respondJSON(w, http.StatusOK, map[string]any{
+	resp := map[string]any{
 		"status":        "ok",
 		"uptime":        time.Since(d.startTime).Truncate(time.Second).String(),
 		"dals_running":  dalsRunning,
 		"repo_count":    len(dals),
 		"leader_status": leaderStatus,
-	})
+		"role":          d.ha.effectiveRole(),
+	}
+	if d.ha.role == RoleStandby && d.ha.promoted.Load() {
+		resp["promoted_at"] = d.ha.promotedAt.Format(time.RFC3339)
+	}
+	respondJSON(w, http.StatusOK, resp)
 }
 
 func (d *Daemon) handlePs(w http.ResponseWriter, r *http.Request) {

--- a/internal/daemon/ha.go
+++ b/internal/daemon/ha.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// HA roles for dalcenter instances.
+const (
+	RolePrimary   = "primary"
+	RoleStandby   = "standby"
+	RoleStandalone = "" // default — no HA, backwards compatible
+)
+
+// haState tracks the high-availability state of this dalcenter instance.
+type haState struct {
+	role      string       // configured role: primary, standby, or standalone
+	promoted  atomic.Bool  // true if standby has auto-promoted to active
+	promotedAt time.Time
+}
+
+// initHA reads DALCENTER_ROLE and initialises HA state.
+// Returns the configured role. An invalid value is treated as standalone.
+func initHA() *haState {
+	role := strings.ToLower(strings.TrimSpace(os.Getenv("DALCENTER_ROLE")))
+	switch role {
+	case RolePrimary, RoleStandby:
+		log.Printf("[ha] role=%s", role)
+	default:
+		if role != "" {
+			log.Printf("[ha] unknown DALCENTER_ROLE %q — running as standalone", role)
+		}
+		role = RoleStandalone
+	}
+	return &haState{role: role}
+}
+
+// isStandby returns true when this instance is configured as standby
+// and has NOT been promoted.
+func (h *haState) isStandby() bool {
+	return h.role == RoleStandby && !h.promoted.Load()
+}
+
+// isActive returns true when this instance should manage dal containers.
+// Standalone and primary are always active. Standby is active only after promotion.
+func (h *haState) isActive() bool {
+	switch h.role {
+	case RoleStandalone, RolePrimary:
+		return true
+	case RoleStandby:
+		return h.promoted.Load()
+	default:
+		return true
+	}
+}
+
+// promote transitions a standby instance to active.
+// Returns an error if not in standby role or already promoted.
+func (h *haState) promote() error {
+	if h.role != RoleStandby {
+		return fmt.Errorf("cannot promote: role is %q, not standby", h.role)
+	}
+	if h.promoted.Load() {
+		return fmt.Errorf("already promoted")
+	}
+	h.promoted.Store(true)
+	h.promotedAt = time.Now()
+	log.Printf("[ha] standby promoted to active")
+	return nil
+}
+
+// demote transitions a promoted standby back to passive.
+// Returns an error if not promoted.
+func (h *haState) demote() error {
+	if h.role != RoleStandby {
+		return fmt.Errorf("cannot demote: role is %q, not standby", h.role)
+	}
+	if !h.promoted.Load() {
+		return fmt.Errorf("not promoted")
+	}
+	h.promoted.Store(false)
+	h.promotedAt = time.Time{}
+	log.Printf("[ha] standby demoted back to passive")
+	return nil
+}
+
+// effectiveRole returns the role string for external reporting.
+func (h *haState) effectiveRole() string {
+	if h.role == RoleStandalone {
+		return "standalone"
+	}
+	if h.role == RoleStandby && h.promoted.Load() {
+		return "standby-promoted"
+	}
+	return h.role
+}

--- a/internal/daemon/watcher.go
+++ b/internal/daemon/watcher.go
@@ -18,6 +18,8 @@ const (
 
 // startPeerWatcher periodically checks the peer dalcenter's health endpoint.
 // After peerFailThreshold consecutive failures, it sends a bridge alert.
+// If this instance is a standby, it auto-promotes on peer (primary) failure
+// and auto-demotes when the primary recovers.
 func (d *Daemon) startPeerWatcher(ctx context.Context) {
 	peerURL := os.Getenv("DALCENTER_PEER_URL")
 	if peerURL == "" {
@@ -26,8 +28,8 @@ func (d *Daemon) startPeerWatcher(ctx context.Context) {
 	}
 	peerURL = strings.TrimRight(peerURL, "/")
 
-	log.Printf("[peer-watcher] started (peer=%s, interval=%s, threshold=%d)",
-		peerURL, peerCheckInterval, peerFailThreshold)
+	log.Printf("[peer-watcher] started (peer=%s, interval=%s, threshold=%d, role=%s)",
+		peerURL, peerCheckInterval, peerFailThreshold, d.ha.effectiveRole())
 
 	client := &http.Client{Timeout: peerCheckTimeout}
 	healthURL := peerURL + "/api/health"
@@ -52,17 +54,54 @@ func (d *Daemon) startPeerWatcher(ctx context.Context) {
 				if consecutiveFails >= peerFailThreshold && !alerted {
 					d.notifyPeerDown(peerURL, err)
 					alerted = true
+
+					// Auto-promote standby when primary is confirmed down
+					if d.ha.role == RoleStandby && !d.ha.promoted.Load() {
+						d.promoteStandby(peerURL)
+					}
 				}
 			} else {
 				if alerted {
 					log.Printf("[peer-watcher] peer recovered after alert")
 					d.notifyPeerRecovered(peerURL)
+
+					// Auto-demote if we were a promoted standby
+					if d.ha.role == RoleStandby && d.ha.promoted.Load() {
+						d.demoteStandby(peerURL)
+					}
 				}
 				consecutiveFails = 0
 				alerted = false
 			}
 		}
 	}
+}
+
+// promoteStandby promotes this standby instance to active and starts
+// managing dal containers.
+func (d *Daemon) promoteStandby(peerURL string) {
+	if err := d.ha.promote(); err != nil {
+		log.Printf("[peer-watcher] promotion failed: %v", err)
+		return
+	}
+
+	// Reconcile containers — discover and adopt running dals
+	d.reconcile()
+
+	msg := fmt.Sprintf(":rotating_light: **standby promoted** — primary `%s` is down, this instance is now active", peerURL)
+	d.postAlert(msg)
+}
+
+// demoteStandby demotes this standby instance back to passive mode.
+// Existing containers continue running but new management is deferred to primary.
+func (d *Daemon) demoteStandby(peerURL string) {
+	if err := d.ha.demote(); err != nil {
+		log.Printf("[peer-watcher] demotion failed: %v", err)
+		return
+	}
+
+	msg := fmt.Sprintf(":white_check_mark: **standby demoted** — primary `%s` recovered, yielding control", peerURL)
+	d.postAlert(msg)
 }
 
 // checkPeerHealth sends a GET to the peer's /api/health and expects 200.


### PR DESCRIPTION
## Summary
- **Phase 1 이중화** — `DALCENTER_ROLE=standby` 인스턴스가 primary 장애 감지 시 자동 승격
- `ha.go`: HA 역할 상태 관리 (promote/demote/isActive/effectiveRole)
- `watcher.go`: peer 장애 → auto-promote, 복구 → auto-demote
- `daemon.go`: standby 모드에서 wake/sleep/restart/replace 차단, `/api/health`에 role 노출

## 설계
| 항목 | 내용 |
|------|------|
| 역할 설정 | `DALCENTER_ROLE` 환경변수 (primary/standby/미설정=standalone) |
| 장애 감지 | 기존 peer watcher 확장 (30초 주기, 3회 연속 실패) |
| 승격 | standby → reconcile 실행 → 컨테이너 관리 시작 |
| 양보 | primary 복구 감지 → demote → 관리 중단 |
| split-brain 방지 | standby는 primary 복구 시 즉시 양보 |
| 하위 호환 | `DALCENTER_ROLE` 미설정 시 기존 standalone 동작 유지 |

## Phase 2 (후속)
- LXC 레벨 이중화 (#653 완료 후)
- state 동기화 (tasks, messages, escalations)
- 컨테이너 인수인계 (takeover)

Closes #442

## Test plan
- [x] `go vet ./...` 통과
- [x] `go test ./...` 전체 통과
- [ ] DALCENTER_ROLE 미설정 시 기존 동작 유지 확인
- [ ] standby 인스턴스 시작 → wake 요청 거부 확인
- [ ] primary 중단 → standby 자동 승격 확인
- [ ] primary 복구 → standby 자동 양보 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)