### PR TITLE
fix: 중복 PR 생성 방지 — autoGitWorkflow Gate 5 (#691)

### DIFF
--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -877,6 +877,7 @@ func isOnlyArtifacts(porcelainOutput string) bool {
 // Gate 2: artifacts only → skip
 // Gate 3: no real code files (*.go, *.rs, *.md in .dal/) → skip
 // Gate 4: PR 생성 전 diff 재확인 — 빈 PR 방지
+// Gate 5: 동일 브랜치로 기존 PR 존재 시 중복 생성 방지
 func autoGitWorkflow(dalName string) string {
 	run := func(args ...string) (string, error) {
 		cmd := exec.Command(args[0], args[1:]...)
@@ -972,6 +973,14 @@ func autoGitWorkflow(dalName string) string {
 	if _, err := run("git", "push", "-u", "origin", branch); err != nil {
 		run("git", "checkout", "main")
 		return fmt.Sprintf("⚠️ 푸시 실패: %v", err)
+	}
+
+	// Gate 5: 동일 브랜치로 이미 open/merged PR이 있으면 중복 생성 방지
+	existingPR, _ := run("gh", "pr", "list", "--head", branch, "--state", "all", "--json", "number,state", "--jq", ".[0].number")
+	if existingPR != "" {
+		log.Printf("[git] gate5: PR already exists for branch %s (#%s) — skip PR creation", branch, existingPR)
+		run("git", "checkout", "main")
+		return fmt.Sprintf("✅ 커밋+푸시 완료 (`%s`)\n⚠️ 중복 PR 방지: #%s 이미 존재", branch, existingPR)
 	}
 
 	// Create PR


### PR DESCRIPTION
## Summary
- `autoGitWorkflow`에 Gate 5 추가: `gh pr list --head <branch> --state all`로 기존 PR 존재 여부 확인
- 동일 브랜치로 이미 open/merged PR이 있으면 PR 생성을 건너뜀
- PR #687/#688 중복 머지 재발 방지

## 원인 분석
| PR | 생성 | 머지 | 브랜치 |
|----|------|------|--------|
| #687 | 15:38 | 15:43 | `feat/577-dalbridge-unify` |
| #688 | 15:44 | 16:25 | `feat/577-dalbridge-unify` |

dal이 기존 PR 존재 여부를 확인하지 않고 `gh pr create`를 실행하여 중복 발생.
`b4012256`(#688) 머지 커밋은 diff 0 (코드 영향 없음). revert 불필요.

## Test plan
- [ ] `go vet ./cmd/dalcli/...` 통과 확인
- [ ] `go build ./cmd/dalcli/...` 통과 확인
- [ ] Gate 5 로직 확인: 이미 PR이 있는 브랜치에서 중복 PR 생성 시도 시 skip 되는지 확인

Closes #691

🤖 Generated with [Claude Code](https://claude.com/claude-code)