### PR TITLE
fix: stub provider resolution in tests to avoid 30s timeout

### DIFF
--- a/cmd/dalcli/circuit_breaker_edge_test.go
+++ b/cmd/dalcli/circuit_breaker_edge_test.go
@@ -6,27 +6,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 )
-
-func installFailingProviders(t *testing.T) {
-	t.Helper()
-
-	dir := t.TempDir()
-	script := []byte("#!/bin/sh\nexit 1\n")
-	for _, name := range []string{"claude", "codex"} {
-		path := filepath.Join(dir, name)
-		if err := os.WriteFile(path, script, 0o755); err != nil {
-			t.Fatalf("write fake %s: %v", name, err)
-		}
-	}
-
-	t.Setenv("PATH", dir)
-}
 
 // ══════════════════════════════════════════════════════════════
 // Circuit Breaker: timing & boundary edge cases
@@ -379,7 +363,10 @@ func TestDetectFallback_AllPlayers(t *testing.T) {
 func TestExecuteTask_AnyErrorRecordsFailure(t *testing.T) {
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
-	installFailingProviders(t)
+	// Use /bin/false for instant failure without subprocess overhead
+	orig := resolveProvider
+	resolveProvider = func(player string) (string, error) { return "/bin/false", nil }
+	t.Cleanup(func() { resolveProvider = orig })
 
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
@@ -412,7 +399,9 @@ func TestExecuteTask_AnyErrorRecordsFailure(t *testing.T) {
 func TestExecuteTask_RepeatedFailuresOpenCircuit(t *testing.T) {
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
-	installFailingProviders(t)
+	orig := resolveProvider
+	resolveProvider = func(player string) (string, error) { return "/bin/false", nil }
+	t.Cleanup(func() { resolveProvider = orig })
 
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")

--- a/cmd/dalcli/cmd_autotask_test.go
+++ b/cmd/dalcli/cmd_autotask_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRunAutoTaskOnly_ExitsWithoutClaude(t *testing.T) {
-	installFailingProviders(t)
+	stubResolveProvider(t)
 	// runAutoTaskOnly calls executeTask which calls claude
 	// Without claude binary, it should still run (fail task but not crash)
 	os.Setenv("DAL_PLAYER", "claude")
@@ -58,7 +58,7 @@ func TestRunAutoTaskOnly_DefaultInterval(t *testing.T) {
 }
 
 func TestAutoTaskOnlyMode_TriggeredWhenMMUnavailable(t *testing.T) {
-	installFailingProviders(t)
+	stubResolveProvider(t)
 	// When MM is not available and DAL_AUTO_TASK is set,
 	// runAgentLoop should enter auto-task-only mode
 	os.Setenv("DAL_PLAYER", "claude")

--- a/cmd/dalcli/cmd_run.go
+++ b/cmd/dalcli/cmd_run.go
@@ -41,6 +41,9 @@ var credentialRefreshCooldown = struct {
 
 var workspaceDir = "/workspace"
 
+// resolveProvider wraps providerexec.Resolve; tests override this to avoid real binary execution.
+var resolveProvider = providerexec.Resolve
+
 func shouldNotifyCredentialRefresh(dalName string) bool {
 	if dalName == "" {
 		return false
@@ -1345,7 +1348,7 @@ func runClaude(player, task string) (string, error) {
 	var cmd *exec.Cmd
 	switch player {
 	case "codex":
-		codexPath, err := providerexec.Resolve("codex")
+		codexPath, err := resolveProvider("codex")
 		if err != nil {
 			return "", err
 		}
@@ -1355,7 +1358,7 @@ func runClaude(player, task string) (string, error) {
 			"-C", workDir,
 			task)
 	default: // claude
-		claudePath, err := providerexec.Resolve("claude")
+		claudePath, err := resolveProvider("claude")
 		if err != nil {
 			return "", err
 		}

--- a/cmd/dalcli/cmd_run_test.go
+++ b/cmd/dalcli/cmd_run_test.go
@@ -727,20 +727,17 @@ func TestFetchAgentConfig_ServerError(t *testing.T) {
 // ── executeTask role branching (verify command construction) ──
 
 func TestExecuteTask_RoleBranching(t *testing.T) {
-	installFailingProviders(t)
-	// We can't actually run claude in tests, but we verify the function
-	// handles missing binary gracefully
+	stubResolveProvider(t)
 	os.Setenv("DAL_ROLE", "member")
 	_, err := executeTask("test")
-	// Should fail (claude not available in test) but not panic
-	if err == nil {
-		t.Log("claude available in test env — unusual but ok")
+	if err != nil {
+		t.Logf("member role: %v", err)
 	}
 
 	os.Setenv("DAL_ROLE", "leader")
 	_, err = executeTask("test")
-	if err == nil {
-		t.Log("claude available in test env — unusual but ok")
+	if err != nil {
+		t.Logf("leader role: %v", err)
 	}
 	os.Unsetenv("DAL_ROLE")
 }
@@ -849,22 +846,26 @@ func TestIsRetryable(t *testing.T) {
 // ── executeTask retry (no claude binary → fails fast, not retryable) ──
 
 func TestExecuteTask_NonRetryable_NoLoop(t *testing.T) {
-	installFailingProviders(t)
+	// Use a provider that fails instantly (exit 1) to verify no retry loop
+	orig := resolveProvider
+	resolveProvider = func(player string) (string, error) {
+		return "/bin/false", nil
+	}
+	t.Cleanup(func() { resolveProvider = orig })
+
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_PLAYER", "claude")
 	defer os.Unsetenv("DAL_ROLE")
 	defer os.Unsetenv("DAL_PLAYER")
 
-	// claude not available → error → NOT retryable → returns after 1 try
 	start := time.Now()
 	_, err := executeTask("test")
 	elapsed := time.Since(start)
 
 	if err == nil {
-		t.Log("claude available — skip")
+		t.Log("/bin/false succeeded — unexpected but ok")
 		return
 	}
-	// Should return fast (< 5s), not wait 30s for retry
 	if elapsed > 10*time.Second {
 		t.Errorf("took %s — seems like retry loop on non-retryable error", elapsed)
 	}
@@ -873,12 +874,12 @@ func TestExecuteTask_NonRetryable_NoLoop(t *testing.T) {
 // ── runProvider player branching ──
 
 func TestRunProvider_Codex(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "codex")
 	os.Setenv("DAL_ROLE", "member")
 	defer os.Unsetenv("DAL_PLAYER")
 	defer os.Unsetenv("DAL_ROLE")
 
-	// codex not available in test → just verify it doesn't panic
 	_, err := runClaude(os.Getenv("DAL_PLAYER"), "test")
 	if err == nil {
 		t.Log("codex available — unusual but ok")
@@ -886,6 +887,7 @@ func TestRunProvider_Codex(t *testing.T) {
 }
 
 func TestRunProvider_Claude_Leader(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "leader")
 	defer os.Unsetenv("DAL_PLAYER")
@@ -898,6 +900,7 @@ func TestRunProvider_Claude_Leader(t *testing.T) {
 }
 
 func TestRunProvider_Claude_Member(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	defer os.Unsetenv("DAL_PLAYER")

--- a/cmd/dalcli/cmd_run_thorough_test.go
+++ b/cmd/dalcli/cmd_run_thorough_test.go
@@ -8,6 +8,17 @@ import (
 	"time"
 )
 
+// stubResolveProvider replaces resolveProvider with one that returns /bin/echo,
+// so tests never launch real claude/codex binaries. Returns a cleanup function.
+func stubResolveProvider(t *testing.T) {
+	t.Helper()
+	orig := resolveProvider
+	resolveProvider = func(player string) (string, error) {
+		return "/bin/echo", nil
+	}
+	t.Cleanup(func() { resolveProvider = orig })
+}
+
 // ══════════════════════════════════════════════════════════════
 // parseInterval: edge cases
 // ══════════════════════════════════════════════════════════════
@@ -169,6 +180,7 @@ func TestExtractTask_UnicodeContent(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestRunClaude_ExtraBashWildcard(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_EXTRA_BASH", "*")
@@ -185,6 +197,7 @@ func TestRunClaude_ExtraBashWildcard(t *testing.T) {
 }
 
 func TestRunClaude_ExtraBashSpecific(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_EXTRA_BASH", "go,npm")
@@ -200,6 +213,7 @@ func TestRunClaude_ExtraBashSpecific(t *testing.T) {
 }
 
 func TestRunClaude_LeaderRole(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "leader")
 	os.Setenv("DAL_EXTRA_BASH", "")
@@ -215,6 +229,7 @@ func TestRunClaude_LeaderRole(t *testing.T) {
 }
 
 func TestRunClaude_MaxDurationEnv(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "500ms")
@@ -234,6 +249,7 @@ func TestRunClaude_MaxDurationEnv(t *testing.T) {
 }
 
 func TestRunClaude_InvalidMaxDuration(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_PLAYER", "claude")
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "not-a-duration")
@@ -252,6 +268,7 @@ func TestRunClaude_InvalidMaxDuration(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestExecuteTask_SuccessKeepsCircuitClosed(t *testing.T) {
+	stubResolveProvider(t)
 	providerCircuit = NewCircuitBreaker(3, 2*time.Minute)
 	defer func() { providerCircuit = NewCircuitBreaker(3, 2*time.Minute) }()
 
@@ -323,6 +340,7 @@ func TestIsActiveThread_EmptyMap(t *testing.T) {
 // ══════════════════════════════════════════════════════════════
 
 func TestRunProvider_DispatchesToRunClaude(t *testing.T) {
+	stubResolveProvider(t)
 	os.Setenv("DAL_ROLE", "member")
 	os.Setenv("DAL_MAX_DURATION", "1s")
 	defer func() {


### PR DESCRIPTION
## Summary
- Fixes #490: `TestRunProvider_DispatchesToRunClaude` 등 provider 관련 테스트가 실제 `claude`/`codex` 바이너리를 실행하여 패키지 전체 테스트 30s 타임아웃 초과
- `var resolveProvider` 함수 변수를 도입하여 테스트에서 `/bin/echo`로 대체 → 테스트 실행 시간 ~5.6s → ~0.04s
- 영향 받는 4개 테스트 파일 모두 수정: `cmd_run_thorough_test.go`, `cmd_run_test.go`, `circuit_breaker_edge_test.go`, `cmd_autotask_test.go`

## Changes
- `cmd_run.go`: `var resolveProvider = providerexec.Resolve` 추가, `runClaude` 내에서 직접 호출 대신 변수 사용
- 테스트 파일: `stubResolveProvider(t)` 헬퍼로 실제 바이너리 실행 방지
- 미사용 `installFailingProviders` 제거

## Test plan
- [x] `go vet ./...` 통과
- [x] `go test ./cmd/dalcli/ -timeout 30s` 통과 (7.0s)
- [x] 이전에 타임아웃되던 테스트들이 0.04s 내에 완료 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)