### PR TITLE
feat: DALCENTER_URL 자동 설정 (#558)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -326,6 +326,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /.well-known/agent-card.json", d.handleAgentCard)
 	mux.HandleFunc("POST /rpc", d.requireAuth(d.handleA2ARPC))
 
+	// Auto-set DALCENTER_URL in env file + bashrc so CLI commands work without manual export.
+	ensureDalcenterURL(d.addr, d.serviceRepo)
+
 	srv := &http.Server{Addr: d.addr, Handler: mux}
 	log.Printf("[daemon] listening on %s", d.addr)
 

--- a/internal/daemon/env_url.go
+++ b/internal/daemon/env_url.go
@@ -1,0 +1,127 @@
+package daemon
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/dalsoop/dalcenter/internal/paths"
+)
+
+// ensureDalcenterURL writes DALCENTER_URL to the team env file and /root/.bashrc
+// so that CLI commands (dalcenter wake, task, etc.) can reach the daemon without
+// manual export.
+func ensureDalcenterURL(addr, serviceRepo string) {
+	url := buildURL(addr)
+	if url == "" {
+		return
+	}
+
+	// Set in current process so child containers inherit it
+	os.Setenv("DALCENTER_URL", url)
+
+	envFile := envFileForRepo(serviceRepo)
+	if envFile != "" {
+		if err := ensureEnvLine(envFile, "DALCENTER_URL", url); err != nil {
+			log.Printf("[daemon] env file update failed: %v", err)
+		} else {
+			log.Printf("[daemon] DALCENTER_URL=%s written to %s", url, envFile)
+		}
+	}
+
+	bashrc := os.Getenv("HOME") + "/.bashrc"
+	if err := ensureBashrcExport(bashrc, "DALCENTER_URL", url); err != nil {
+		log.Printf("[daemon] bashrc update failed: %v", err)
+	} else {
+		log.Printf("[daemon] DALCENTER_URL=%s written to %s", url, bashrc)
+	}
+}
+
+// buildURL constructs http://localhost:<port> from an addr like ":11190" or "0.0.0.0:11190".
+func buildURL(addr string) string {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		log.Printf("[daemon] cannot parse addr %q: %v", addr, err)
+		return ""
+	}
+	return "http://localhost:" + port
+}
+
+// envFileForRepo returns the env file path for the given service repo.
+// Uses the repo directory basename as the systemd instance name.
+func envFileForRepo(serviceRepo string) string {
+	if serviceRepo == "" {
+		return ""
+	}
+	name := filepath.Base(serviceRepo)
+	return filepath.Join(paths.ConfigDir(), name+".env")
+}
+
+// ensureEnvLine ensures KEY=VALUE exists in an env file.
+// Updates the value if the key exists with a different value.
+// Appends the line if the key is absent.
+func ensureEnvLine(path, key, value string) error {
+	line := key + "=" + value
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	content := string(data)
+	prefix := key + "="
+
+	for _, l := range strings.Split(content, "\n") {
+		if strings.HasPrefix(l, prefix) {
+			if strings.TrimSpace(l) == line {
+				return nil // already set correctly
+			}
+			// Update existing line
+			updated := strings.Replace(content, l, line, 1)
+			return os.WriteFile(path, []byte(updated), 0644)
+		}
+	}
+
+	// Append
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += line + "\n"
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// ensureBashrcExport ensures export KEY=VALUE exists in bashrc.
+// Updates the value if the key exists with a different value.
+// Appends the line if the key is absent.
+func ensureBashrcExport(path, key, value string) error {
+	line := "export " + key + "=" + value
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	content := string(data)
+	prefix := "export " + key + "="
+
+	for _, l := range strings.Split(content, "\n") {
+		if strings.HasPrefix(l, prefix) {
+			if strings.TrimSpace(l) == line {
+				return nil // already set correctly
+			}
+			// Update existing line
+			updated := strings.Replace(content, l, line, 1)
+			return os.WriteFile(path, []byte(updated), 0644)
+		}
+	}
+
+	// Append
+	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += line + "\n"
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/daemon/env_url_test.go
+++ b/internal/daemon/env_url_test.go
@@ -1,0 +1,131 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildURL(t *testing.T) {
+	tests := []struct {
+		addr string
+		want string
+	}{
+		{":11190", "http://localhost:11190"},
+		{"0.0.0.0:8080", "http://localhost:8080"},
+		{"127.0.0.1:9999", "http://localhost:9999"},
+		{"invalid", ""},
+	}
+	for _, tt := range tests {
+		got := buildURL(tt.addr)
+		if got != tt.want {
+			t.Errorf("buildURL(%q) = %q, want %q", tt.addr, got, tt.want)
+		}
+	}
+}
+
+func TestEnsureEnvLine(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("create new", func(t *testing.T) {
+		f := filepath.Join(dir, "new.env")
+		if err := ensureEnvLine(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		if !strings.Contains(string(data), "DALCENTER_URL=http://localhost:11190") {
+			t.Fatalf("unexpected content: %s", data)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		f := filepath.Join(dir, "idem.env")
+		os.WriteFile(f, []byte("DALCENTER_URL=http://localhost:11190\n"), 0644)
+		if err := ensureEnvLine(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		if strings.Count(string(data), "DALCENTER_URL") != 1 {
+			t.Fatalf("duplicate entries: %s", data)
+		}
+	})
+
+	t.Run("update existing", func(t *testing.T) {
+		f := filepath.Join(dir, "update.env")
+		os.WriteFile(f, []byte("FOO=bar\nDALCENTER_URL=http://localhost:9999\nBAZ=qux\n"), 0644)
+		if err := ensureEnvLine(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		content := string(data)
+		if !strings.Contains(content, "DALCENTER_URL=http://localhost:11190") {
+			t.Fatalf("not updated: %s", content)
+		}
+		if strings.Contains(content, "9999") {
+			t.Fatalf("old value remains: %s", content)
+		}
+		if !strings.Contains(content, "FOO=bar") || !strings.Contains(content, "BAZ=qux") {
+			t.Fatalf("other lines lost: %s", content)
+		}
+	})
+
+	t.Run("append to existing file", func(t *testing.T) {
+		f := filepath.Join(dir, "append.env")
+		os.WriteFile(f, []byte("FOO=bar\n"), 0644)
+		if err := ensureEnvLine(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		content := string(data)
+		if !strings.Contains(content, "FOO=bar") {
+			t.Fatalf("original lost: %s", content)
+		}
+		if !strings.Contains(content, "DALCENTER_URL=http://localhost:11190") {
+			t.Fatalf("not appended: %s", content)
+		}
+	})
+}
+
+func TestEnsureBashrcExport(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("create new", func(t *testing.T) {
+		f := filepath.Join(dir, ".bashrc")
+		if err := ensureBashrcExport(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		if !strings.Contains(string(data), "export DALCENTER_URL=http://localhost:11190") {
+			t.Fatalf("unexpected content: %s", data)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		f := filepath.Join(dir, ".bashrc2")
+		os.WriteFile(f, []byte("export DALCENTER_URL=http://localhost:11190\n"), 0644)
+		if err := ensureBashrcExport(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		if strings.Count(string(data), "DALCENTER_URL") != 1 {
+			t.Fatalf("duplicate entries: %s", data)
+		}
+	})
+
+	t.Run("update existing", func(t *testing.T) {
+		f := filepath.Join(dir, ".bashrc3")
+		os.WriteFile(f, []byte("# my bashrc\nexport DALCENTER_URL=http://localhost:9999\n"), 0644)
+		if err := ensureBashrcExport(f, "DALCENTER_URL", "http://localhost:11190"); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(f)
+		content := string(data)
+		if !strings.Contains(content, "export DALCENTER_URL=http://localhost:11190") {
+			t.Fatalf("not updated: %s", content)
+		}
+		if strings.Contains(content, "9999") {
+			t.Fatalf("old value remains: %s", content)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `dalcenter serve` 시작 시 `DALCENTER_URL=http://localhost:<port>`를 자동 설정
- `/etc/dalcenter/<repo>.env`에 추가/갱신
- `$HOME/.bashrc`에 `export DALCENTER_URL=...` 추가/갱신
- 현재 프로세스 환경변수에도 설정하여 자식 컨테이너가 상속

## Test plan
- [ ] `go test ./internal/daemon/ -run TestBuildURL` — addr 파싱 검증
- [ ] `go test ./internal/daemon/ -run TestEnsureEnvLine` — env 파일 쓰기/갱신/idempotent
- [ ] `go test ./internal/daemon/ -run TestEnsureBashrcExport` — bashrc 쓰기/갱신/idempotent
- [ ] `dalcenter serve` 후 `env | grep DALCENTER_URL` 확인
- [ ] `source ~/.bashrc && echo $DALCENTER_URL` 확인

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)